### PR TITLE
fix(dashboard): keep edit dialog open after the row actions menu closes

### DIFF
--- a/web/src/features/dashboard/components/DashboardTable.edit-dialog.clienttest.tsx
+++ b/web/src/features/dashboard/components/DashboardTable.edit-dialog.clienttest.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { LAYER_ORDER } from "@/src/components/ui/layer";
+
+const projectDashboardRow = {
+  id: "dashboard-1",
+  name: "My dashboard",
+  description: "A dashboard",
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-02T00:00:00Z"),
+  owner: "PROJECT" as const,
+};
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    dashboard: {
+      allDashboards: {
+        useQuery: () => ({
+          data: {
+            dashboards: [projectDashboardRow],
+            totalCount: 1,
+          },
+          isError: false,
+          isPending: false,
+        }),
+      },
+      updateDashboardMetadata: {
+        useMutation: () => ({
+          isPending: false,
+          mutate: vi.fn(),
+          mutateAsync: vi.fn(async () => ({})),
+        }),
+      },
+      cloneDashboard: {
+        useMutation: () => ({
+          isPending: false,
+          mutate: vi.fn(),
+          mutateAsync: vi.fn(async () => ({})),
+        }),
+      },
+      delete: {
+        useMutation: () => ({
+          isPending: false,
+          mutate: vi.fn(),
+          mutateAsync: vi.fn(async () => ({})),
+        }),
+      },
+    },
+    useUtils: () => ({
+      dashboard: { invalidate: vi.fn() },
+    }),
+  },
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn(), query: { projectId: "project-1" } }),
+}));
+
+vi.mock("@/src/features/orderBy/hooks/useOrderByState", () => ({
+  useOrderByState: (initial: { column: string; order: string }) => [
+    initial,
+    vi.fn(),
+  ],
+}));
+
+vi.mock("use-query-params", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useQueryParams: () => [{ pageIndex: 0, pageSize: 50 }, vi.fn()],
+}));
+
+vi.mock("@/src/features/navigate-detail-pages/context", () => ({
+  useDetailPageLists: () => ({ setDetailPageList: vi.fn() }),
+}));
+
+vi.mock("@/src/features/posthog-analytics", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+vi.mock("@/src/features/rbac/utils/checkProjectAccess", () => ({
+  useHasProjectAccess: () => true,
+}));
+
+import { DashboardTable } from "./DashboardTable";
+
+const installOverlayLayers = () => {
+  const overlayRoot = document.createElement("div");
+  overlayRoot.setAttribute("data-overlay-root", "");
+  for (const layer of LAYER_ORDER) {
+    const layerNode = document.createElement("div");
+    layerNode.setAttribute("data-layer", layer);
+    overlayRoot.appendChild(layerNode);
+  }
+  document.body.appendChild(overlayRoot);
+};
+
+describe("DashboardTable edit dialog", () => {
+  beforeEach(() => {
+    installOverlayLayers();
+  });
+
+  afterEach(() => {
+    document.querySelector("[data-overlay-root]")?.remove();
+  });
+
+  it("keeps the edit dialog open after the row actions menu closes", async () => {
+    render(<DashboardTable />);
+
+    // Open the row actions menu (one trigger per row, labelled by the column).
+    const triggers = screen.getAllByRole("button");
+    const menuTrigger = triggers.find((button) =>
+      button.getAttribute("aria-haspopup")?.includes("menu"),
+    );
+    expect(menuTrigger).toBeDefined();
+    menuTrigger!.focus();
+    fireEvent.keyDown(menuTrigger!, { key: "Enter" });
+
+    const editItem = await screen.findByRole("menuitem", { name: /edit/i });
+    fireEvent.click(editItem);
+
+    // The menu closed, so its content unmounted. The dialog, rendered as a
+    // sibling of the menu, must still be up and editable.
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
+    });
+
+    const nameInput = await screen.findByRole("textbox", { name: /name/i });
+    expect(nameInput).toBeVisible();
+  });
+});

--- a/web/src/features/dashboard/components/DashboardTable.tsx
+++ b/web/src/features/dashboard/components/DashboardTable.tsx
@@ -95,93 +95,34 @@ function CloneDashboardButton({
   );
 }
 
-function EditDashboardButton({
-  dashboardId,
-  projectId,
-  dashboardName,
-  dashboardDescription,
-}: {
+type EditDashboardTarget = {
   dashboardId: string;
-  projectId: string;
   dashboardName: string;
   dashboardDescription: string;
-}) {
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const hasAccess = useHasProjectAccess({ projectId, scope: "dashboards:CUD" });
+};
 
-  return (
-    <div className={dashboardMenuButtonWrapperClassName}>
-      <Button
-        variant="ghost"
-        size="default"
-        className={dashboardMenuButtonClassName}
-        disabled={!hasAccess}
-        onClick={() => setIsDialogOpen(true)}
-      >
-        <Edit className="mr-2 h-4 w-4" />
-        Edit
-      </Button>
-
-      <EditDashboardDialog
-        open={isDialogOpen}
-        onOpenChange={setIsDialogOpen}
-        projectId={projectId}
-        dashboardId={dashboardId}
-        initialName={dashboardName}
-        initialDescription={dashboardDescription}
-      />
-    </div>
-  );
-}
-
-function LockedEditDashboardButton({
-  dashboardId,
-  projectId,
-  dashboardName,
-}: {
+type CloneFirstDashboardTarget = {
   dashboardId: string;
-  projectId: string;
   dashboardName: string;
-}) {
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const hasAccess = useHasProjectAccess({ projectId, scope: "dashboards:CUD" });
-  const capture = usePostHogClientCapture();
-
-  return (
-    <div className={dashboardMenuButtonWrapperClassName}>
-      <Button
-        variant="ghost"
-        size="default"
-        className={dashboardMenuButtonClassName}
-        disabled={!hasAccess}
-        onClick={() => {
-          capture("dashboard:locked_edit_attempt", {
-            dashboard_id: dashboardId,
-            attempt: "list_edit",
-            surface: "list",
-          });
-          setIsDialogOpen(true);
-        }}
-      >
-        <Edit className="mr-2 h-4 w-4" />
-        Edit
-      </Button>
-
-      <CloneFirstDialog
-        open={isDialogOpen}
-        onOpenChange={setIsDialogOpen}
-        projectId={projectId}
-        dashboardId={dashboardId}
-        dashboardName={dashboardName}
-      />
-    </div>
-  );
-}
+};
 
 export function DashboardTable() {
   const projectId = useProjectIdFromURL() as string;
   const { setDetailPageList } = useDetailPageLists();
   const router = useRouter();
+  const capture = usePostHogClientCapture();
+  const hasEditAccess = useHasProjectAccess({
+    projectId,
+    scope: "dashboards:CUD",
+  });
+
+  // The edit dialogs live OUTSIDE the row actions menu: the menu unmounts its
+  // content when it closes, which used to take the freshly opened dialog with
+  // it (the dialog flashed and vanished as soon as the menu closed).
+  const [editDashboard, setEditDashboard] =
+    useState<EditDashboardTarget | null>(null);
+  const [cloneFirstDashboard, setCloneFirstDashboard] =
+    useState<CloneFirstDashboardTarget | null>(null);
 
   const [orderByState, setOrderByState] = useOrderByState({
     column: "updatedAt",
@@ -287,21 +228,38 @@ export function DashboardTable() {
         return (
           <>
             {owner === "PROJECT" ? (
-              <DropdownMenuItem className="w-full p-0">
-                <EditDashboardButton
-                  dashboardId={id}
-                  projectId={projectId}
-                  dashboardName={name}
-                  dashboardDescription={description}
-                />
+              <DropdownMenuItem
+                className="w-full"
+                disabled={!hasEditAccess}
+                onSelect={() =>
+                  setEditDashboard({
+                    dashboardId: id,
+                    dashboardName: name,
+                    dashboardDescription: description,
+                  })
+                }
+              >
+                <Edit className="mr-2 h-4 w-4" />
+                Edit
               </DropdownMenuItem>
             ) : (
-              <DropdownMenuItem className="w-full p-0">
-                <LockedEditDashboardButton
-                  dashboardId={id}
-                  projectId={projectId}
-                  dashboardName={name}
-                />
+              <DropdownMenuItem
+                className="w-full"
+                disabled={!hasEditAccess}
+                onSelect={() => {
+                  capture("dashboard:locked_edit_attempt", {
+                    dashboard_id: id,
+                    attempt: "list_edit",
+                    surface: "list",
+                  });
+                  setCloneFirstDashboard({
+                    dashboardId: id,
+                    dashboardName: name,
+                  });
+                }}
+              >
+                <Edit className="mr-2 h-4 w-4" />
+                Edit
               </DropdownMenuItem>
             )}
             <DropdownMenuItem className="w-full p-0">
@@ -335,37 +293,62 @@ export function DashboardTable() {
   ] as LangfuseColumnDef<DashboardTableRow>[];
 
   return (
-    <DataTable
-      tableName="dashboards"
-      columns={dashboardColumns}
-      data={
-        dashboards.isPending
-          ? { isLoading: true, isError: false }
-          : dashboards.isError
-            ? {
-                isLoading: false,
-                isError: true,
-                error: dashboards.error.message,
-              }
-            : {
-                isLoading: false,
-                isError: false,
-                data: safeExtract(dashboards.data, "dashboards", []),
-              }
-      }
-      orderBy={orderByState}
-      setOrderBy={setOrderByState}
-      pagination={{
-        totalCount: dashboards.data?.totalCount ?? null,
-        onChange: setPaginationState,
-        state: paginationState,
-      }}
-      onRowClick={(row) => {
-        router.push(
-          `/project/${projectId}/dashboards/${encodeURIComponent(row.id)}`,
-        );
-      }}
-      cellPadding="comfortable"
-    />
+    <>
+      <DataTable
+        tableName="dashboards"
+        columns={dashboardColumns}
+        data={
+          dashboards.isPending
+            ? { isLoading: true, isError: false }
+            : dashboards.isError
+              ? {
+                  isLoading: false,
+                  isError: true,
+                  error: dashboards.error.message,
+                }
+              : {
+                  isLoading: false,
+                  isError: false,
+                  data: safeExtract(dashboards.data, "dashboards", []),
+                }
+        }
+        orderBy={orderByState}
+        setOrderBy={setOrderByState}
+        pagination={{
+          totalCount: dashboards.data?.totalCount ?? null,
+          onChange: setPaginationState,
+          state: paginationState,
+        }}
+        onRowClick={(row) => {
+          router.push(
+            `/project/${projectId}/dashboards/${encodeURIComponent(row.id)}`,
+          );
+        }}
+        cellPadding="comfortable"
+      />
+      {editDashboard ? (
+        <EditDashboardDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setEditDashboard(null);
+          }}
+          projectId={projectId}
+          dashboardId={editDashboard.dashboardId}
+          initialName={editDashboard.dashboardName}
+          initialDescription={editDashboard.dashboardDescription}
+        />
+      ) : null}
+      {cloneFirstDashboard ? (
+        <CloneFirstDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setCloneFirstDashboard(null);
+          }}
+          projectId={projectId}
+          dashboardId={cloneFirstDashboard.dashboardId}
+          dashboardName={cloneFirstDashboard.dashboardName}
+        />
+      ) : null}
+    </>
   );
 }


### PR DESCRIPTION
## Problem

On the dashboards list, clicking Edit in the row actions menu opens the edit dialog for a second and then it closes instantly (#16937).

## Cause

`EditDashboardDialog` was rendered inside the row actions menu content (`DropdownMenuItem` → `DropdownMenuController`). Selecting the menu item closes the menu, and Radix unmounts the menu content, taking the freshly opened dialog with it.

## Fix

Hoist the dialog state to the table and render the dialogs as siblings of the table instead of inside the menu content, so closing the menu no longer unmounts them:

- Edit on project dashboards now opens `EditDashboardDialog` from state lifted to `DashboardTable`.
- The same treatment for the locked-edit path on Langfuse-owned dashboards: its `CloneFirstDialog` had the identical bug. The `dashboard:locked_edit_attempt` capture is preserved.
- The menu items keep the `dashboards:CUD` access gating (now `disabled` on the items).

## Testing

Added `DashboardTable.edit-dialog.clienttest.tsx` against the real Radix primitives: it opens the row actions menu, clicks Edit, waits for the menu content to unmount, and asserts the dialog is still up and editable. It fails against the old code (the dialog unmounts with the menu) and passes with this change.

- `pnpm --filter web run test-client src/features/dashboard/components/DashboardTable.edit-dialog.clienttest.tsx`: `Tests  1 passed (1)`
- ESLint on the touched files: clean with `--max-warnings 0`
- Repo-wide web typecheck error list is byte-identical before/after this change (pre-existing unrelated errors, none added)

## Preview verification steps

The PR preview should let you reproduce the report directly: Project → Dashboards → row actions menu → Edit. The dialog should now stay open and save normally. The locked-edit path (Langfuse-owned dashboard row) should open the clone-first dialog the same way.

Fixes #16937


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR hoists project-edit and managed-dashboard clone-first dialogs outside the row actions menu so closing the Radix menu no longer unmounts them. It preserves dashboard write-access gating and locked-edit analytics, and adds a client regression test using the real menu primitives.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking import-organization issue in the new test.

The dialog lifecycle, ownership-specific paths, and access gating remain coherent, while the sole accepted concern is the placement of a test import after mock declarations.

**Files Needing Attention:** web/src/features/dashboard/components/DashboardTable.edit-dialog.clienttest.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/dashboard/components/DashboardTable.edit-dialog.clienttest.tsx:80
**Import declared below mocks**

The `DashboardTable` import appears after executable mock declarations instead of with the imports at the top of the module, making the test's dependencies less discoverable and violating the repository's import organization rule.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): keep edit dialog open af..."](https://github.com/langfuse/langfuse/commit/8ad1817cc13f529dacc0f1fc684b31f1975885c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59538416)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)
- Knowledge Base — [Dashboards, metrics, and monitors](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/dashboards-metrics-and-monitors.md)

<!-- /greptile_comment -->