### PR TITLE
fix(pricing): ignore formatting-only audit diffs

### DIFF
--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -503,6 +503,38 @@ jobs:
             cat "$RUNNER_TEMP/claude-model-price-audit.txt"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Discard pricing-only formatting changes
+        run: |
+          set -euo pipefail
+
+          base_pricing_file="$RUNNER_TEMP/default-model-prices-before-audit.json"
+          git show "HEAD:worker/src/constants/default-model-prices.json" > "$base_pricing_file"
+
+          BASE_PRICING_FILE="$base_pricing_file" node <<'NODE'
+          const fs = require("node:fs");
+
+          const base = JSON.parse(fs.readFileSync(process.env.BASE_PRICING_FILE, "utf8"));
+          const currentPath = "worker/src/constants/default-model-prices.json";
+          const current = JSON.parse(fs.readFileSync(currentPath, "utf8"));
+          const byModel = (entries) =>
+            new Map(entries.map((entry) => [entry.modelName.trim().toLowerCase(), JSON.stringify(entry)]));
+
+          const baseByModel = byModel(base);
+          const currentByModel = byModel(current);
+          const sameEntries =
+            baseByModel.size === currentByModel.size &&
+            [...baseByModel].every(
+              ([modelName, entry]) => currentByModel.get(modelName) === entry,
+            );
+
+          if (sameEntries && JSON.stringify(base) !== JSON.stringify(current)) {
+            fs.copyFileSync(process.env.BASE_PRICING_FILE, currentPath);
+            console.log(
+              "Discarded pricing JSON formatting or ordering changes without model-entry changes.",
+            );
+          }
+          NODE
+
       - name: Validate audit diff
         run: |
           set -euo pipefail

--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -509,31 +509,9 @@ jobs:
 
           base_pricing_file="$RUNNER_TEMP/default-model-prices-before-audit.json"
           git show "HEAD:worker/src/constants/default-model-prices.json" > "$base_pricing_file"
-
-          BASE_PRICING_FILE="$base_pricing_file" node <<'NODE'
-          const fs = require("node:fs");
-
-          const base = JSON.parse(fs.readFileSync(process.env.BASE_PRICING_FILE, "utf8"));
-          const currentPath = "worker/src/constants/default-model-prices.json";
-          const current = JSON.parse(fs.readFileSync(currentPath, "utf8"));
-          const byModel = (entries) =>
-            new Map(entries.map((entry) => [entry.modelName.trim().toLowerCase(), JSON.stringify(entry)]));
-
-          const baseByModel = byModel(base);
-          const currentByModel = byModel(current);
-          const sameEntries =
-            baseByModel.size === currentByModel.size &&
-            [...baseByModel].every(
-              ([modelName, entry]) => currentByModel.get(modelName) === entry,
-            );
-
-          if (sameEntries && JSON.stringify(base) !== JSON.stringify(current)) {
-            fs.copyFileSync(process.env.BASE_PRICING_FILE, currentPath);
-            console.log(
-              "Discarded pricing JSON formatting or ordering changes without model-entry changes.",
-            );
-          }
-          NODE
+          node scripts/model-price-audit/discard-formatting-only-pricing-diff.mjs \
+            --base "$base_pricing_file" \
+            --current worker/src/constants/default-model-prices.json
 
       - name: Validate audit diff
         run: |

--- a/scripts/model-price-audit/discard-formatting-only-pricing-diff.mjs
+++ b/scripts/model-price-audit/discard-formatting-only-pricing-diff.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+const args = process.argv.slice(2);
+const readArgument = (name) => {
+  const index = args.indexOf(name);
+  if (index === -1 || !args[index + 1]) {
+    throw new Error(`Missing required argument: ${name}`);
+  }
+  return args[index + 1];
+};
+
+const basePath = readArgument("--base");
+const currentPath = readArgument("--current");
+const base = JSON.parse(fs.readFileSync(basePath, "utf8"));
+const current = JSON.parse(fs.readFileSync(currentPath, "utf8"));
+
+const canonicalize = (value) => {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalize(value[key])]),
+    );
+  }
+  return value;
+};
+
+const entriesByModel = (entries) => {
+  const result = new Map();
+  for (const entry of entries) {
+    const modelName = entry.modelName.trim().toLowerCase();
+    if (result.has(modelName)) return null;
+    result.set(modelName, JSON.stringify(canonicalize(entry)));
+  }
+  return result;
+};
+
+const baseByModel = entriesByModel(base);
+const currentByModel = entriesByModel(current);
+const sameEntries =
+  baseByModel !== null &&
+  currentByModel !== null &&
+  baseByModel.size === currentByModel.size &&
+  [...baseByModel].every(
+    ([modelName, entry]) => currentByModel.get(modelName) === entry,
+  );
+
+if (
+  sameEntries &&
+  fs.readFileSync(basePath, "utf8") !== fs.readFileSync(currentPath, "utf8")
+) {
+  fs.copyFileSync(basePath, currentPath);
+  console.log(
+    "Discarded pricing JSON formatting or ordering changes without model-entry changes.",
+  );
+}

--- a/scripts/model-price-audit/discard-formatting-only-pricing-diff.test.mjs
+++ b/scripts/model-price-audit/discard-formatting-only-pricing-diff.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const scriptPath = path.join(
+  import.meta.dirname,
+  "discard-formatting-only-pricing-diff.mjs",
+);
+
+function runCleanup(basePrices, currentPrices) {
+  const fixtureDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "model-price-audit-formatting-"),
+  );
+  const basePath = path.join(fixtureDirectory, "base.json");
+  const currentPath = path.join(fixtureDirectory, "current.json");
+  const baseText = JSON.stringify(basePrices, null, 2) + "\n";
+  const currentText = JSON.stringify(currentPrices, null, 4) + "\n";
+  fs.writeFileSync(basePath, baseText);
+  fs.writeFileSync(currentPath, currentText);
+
+  const result = spawnSync(
+    process.execPath,
+    [scriptPath, "--base", basePath, "--current", currentPath],
+    { encoding: "utf8" },
+  );
+  const finalText = fs.readFileSync(currentPath, "utf8");
+  fs.rmSync(fixtureDirectory, { force: true, recursive: true });
+  return { baseText, currentText, finalText, result };
+}
+
+const alpha = {
+  modelName: "alpha",
+  pricingTiers: [{ prices: { input: 1, output: 2 }, priority: 0 }],
+};
+const beta = {
+  modelName: "beta",
+  pricingTiers: [{ prices: { input: 3, output: 4 }, priority: 0 }],
+};
+
+test("restores the checked-in file after entry and object-key reordering", () => {
+  const reorderedAlpha = {
+    pricingTiers: [{ priority: 0, prices: { output: 2, input: 1 } }],
+    modelName: "alpha",
+  };
+  const { baseText, finalText, result } = runCleanup(
+    [alpha, beta],
+    [beta, reorderedAlpha],
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(finalText, baseText);
+  assert.match(
+    result.stdout,
+    /Discarded pricing JSON formatting or ordering changes/,
+  );
+});
+
+test("preserves a real pricing value change", () => {
+  const updatedAlpha = {
+    ...alpha,
+    pricingTiers: [{ prices: { input: 10, output: 2 }, priority: 0 }],
+  };
+  const { currentText, finalText, result } = runCleanup(
+    [alpha, beta],
+    [updatedAlpha, beta],
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(finalText, currentText);
+  assert.equal(result.stdout, "");
+});
+
+test("preserves nested array reordering as a potentially meaningful change", () => {
+  const base = [{ ...alpha, inputPriceKeys: ["input", "input_tokens"] }];
+  const current = [{ ...alpha, inputPriceKeys: ["input_tokens", "input"] }];
+  const { currentText, finalText, result } = runCleanup(base, current);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(finalText, currentText);
+});


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16971 app preview](https://pr-16971.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Context

The latest scheduled and manually dispatched model-price audit runs completed the Claude audit and passed pricing validation, but failed while preparing the pull request artifact.

## Problem

Claude can rewrite the pricing catalog without changing a model entry. The metadata guard correctly rejects that no-op diff with `Pricing JSON changed without a concrete model-entry change`, but the workflow previously had no deterministic way to discard recoverable formatting or top-level ordering changes. Comparing entries with plain `JSON.stringify` also remained sensitive to object-key order.

## Solution

Add a tested normalization step before diff validation. It compares entries by normalized model name, recursively canonicalizes object keys, and restores the checked-in pricing file when only formatting or top-level entry order changed. Nested array order and real values remain exact, so meaningful changes continue through all existing pricing, metadata, staged-blob, and publish gates.

The audit job remains read-only and the write-capable publisher remains separate.

## Validation

- `node --test scripts/model-price-audit/discard-formatting-only-pricing-diff.test.mjs scripts/model-price-audit/prepare-metadata.test.mjs` — `tests 7`, `pass 7`, `fail 0`
- `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs` — `Validated 167 pricing entries in worker/src/constants/default-model-prices.json.`
- Prettier check for the workflow, helper, and regression test — `All matched files use Prettier code style!`
- `git diff --check`

The regression suite covers top-level entry reordering, nested object-key reordering, real price changes, and conservative handling of nested array reordering.

Latest failure evidence: scheduled run [33584665807](https://github.com/langfuse/langfuse/actions/runs/33584665807) and manual run [33639533588](https://github.com/langfuse/langfuse/actions/runs/33639533588).

Skipped a live end-to-end workflow dispatch because it requires the protected Claude and publisher secrets; GitHub CI exercises the published branch.
