### PR TITLE
fix(pricing): notify engineering when model price audit fails

### DIFF
--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -826,3 +826,24 @@ jobs:
           echo "Created or updated model price audit PR: $pr_url"
           echo "## Pull request" >> "$GITHUB_STEP_SUMMARY"
           echo "$pr_url" >> "$GITHUB_STEP_SUMMARY"
+
+  notify-slack-on-failure:
+    needs:
+      - audit
+      - publish
+    if: failure()
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Notify Slack
+        uses: ./.github/actions/notify-slack-failure
+        with:
+          title: "❌ Model Price Audit Failed"
+          message: "❌ Model price audit failed on ${{ github.ref_name }}"
+          webhook-url: ${{ secrets.SLACK_CI_FAILURE_WORKFLOW_WEBHOOK_URL }}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16976 app preview](https://pr-16976.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Context

The scheduled model price audit can fail during either its read-only audit phase or its separate publishing phase. Those failures were only visible in GitHub Actions, so a failed recurring run could go unnoticed.

## Change

- add a downstream job that watches both audit phases and runs only when one fails
- reuse the repository's existing Slack failure action and CI failure webhook, which routes to the engineering channel
- grant the notification job only `contents: read` and `actions: read`
- keep the webhook secret isolated from the LLM audit job

The shared action includes the failed job/step context and a direct link to the workflow run. Successful, skipped-publish, and no-change runs remain silent.

## Validation

- `ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/model-price-audit.yml")'`
- `pnpm --dir /Users/hassieb/Langfuse/langfuse exec prettier --check /Users/hassieb/.codex/worktrees/4467/langfuse/.github/workflows/model-price-audit.yml`
- `git diff --check`

## Risk

Low. This follows the same failure-notification pattern used by the release, deploy, and SDK API-spec workflows and does not alter audit or publishing permissions.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a downstream Slack notification job to the model-price audit workflow so failures in either the audit or publishing phase are reported to engineering.
- Watches both audit and publish jobs with a failure-only condition
- Reuses the repository’s shared Slack failure action and webhook
- Grants only read access to repository contents and workflow actions
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the notification condition, action inputs, permissions, checkout, and runner configuration match established repository patterns.

Failed audit and publish jobs both reach the new notifier, while successful and intentionally skipped paths remain silent as intended.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pricing): notify engineering when mo..."](https://github.com/langfuse/langfuse/commit/33ce981921882aa3fbe8c9bc45bc66f711299aac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59582092)</sub>

<!-- /greptile_comment -->