### PR TITLE
feat(web): expand timeline rows to show labels without shrinking time

### DIFF
--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
@@ -1869,6 +1869,71 @@ export const ShowLabelsKeepsTheWholeClock = meta.story({
   },
 });
 
+/**
+ * A box that only slices time must not hide Fit behind Show labels. Growing
+ * the rows would keep that narrow clock; Fit is the way back to the overview.
+ */
+export const FitStaysAfterATimeOnlyBox = meta.story({
+  name: "(Test) Fit Stays After A Time Only Box",
+  args: {
+    roots: manySpans(150),
+    box: DESKTOP,
+    gutter: "auto",
+    pointer: "fine",
+    barColor: "type",
+    compress: false,
+    showReadout: true,
+    selectedId: null,
+    onSelect: fn(),
+    onHover: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const surface = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="timeline-dense-surface"]',
+    );
+    if (!surface) throw new Error("dense surface not found");
+    surface.setPointerCapture = () => undefined;
+    surface.releasePointerCapture = () => undefined;
+    const readout = () =>
+      canvasElement.querySelector<HTMLElement>(
+        '[data-testid="timeline-dense-readout"]',
+      )?.textContent ?? "";
+
+    await expect(
+      canvasElement.querySelector('button[aria-label="Show labels"]'),
+    ).not.toBeNull();
+
+    const rect = surface.getBoundingClientRect();
+    const drag = (type: string, x: number, y: number) =>
+      surface.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          pointerId: 1,
+          pointerType: "mouse",
+          buttons: type === "pointerup" ? 0 : 1,
+          clientX: x,
+          clientY: y,
+        }),
+      );
+    // Full height, half the clock: rows stay hairline, time narrows.
+    drag("pointerdown", rect.left + rect.width * 0.25, rect.top + 2);
+    drag("pointermove", rect.left + rect.width * 0.75, rect.bottom - 2);
+    drag("pointerup", rect.left + rect.width * 0.75, rect.bottom - 2);
+    await waitFor(() => expect(readout()).toContain("zoomed"));
+    await expect(readout()).toMatch(/[1-4]\.\dpx rows/);
+
+    await expect(
+      canvasElement.querySelector('button[aria-label="Show labels"]'),
+    ).toBeNull();
+    const fit = canvasElement.querySelector<HTMLButtonElement>(
+      'button[aria-label="Fit whole trace"]',
+    );
+    if (!fit) throw new Error("Fit disappeared after a time-only box");
+    await expect(fit.disabled).toBe(false);
+  },
+});
+
 /** Collapse in the tree means collapse here: the same set, honoured. */
 export const CollapsedRowsAreNotDrawn = meta.story({
   name: "(Test) Collapsed Rows Are Not Drawn",

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
@@ -1849,8 +1849,13 @@ export const ShowLabelsKeepsTheWholeClock = meta.story({
     );
     if (!show) throw new Error("no show-labels button");
     await expect(show.disabled).toBe(false);
-    await expect(toolbar()?.innerText.toLowerCase()).toContain("show labels");
-    await userEvent.click(show);
+    await expect(show.innerText.toLowerCase()).toContain("show labels");
+    const caption = [...(toolbar()?.querySelectorAll("span") ?? [])].find(
+      (el) => el.textContent?.trim().toLowerCase() === "show labels",
+    );
+    if (!caption) throw new Error("Show labels text is not on the button");
+    await expect(show.contains(caption)).toBe(true);
+    await userEvent.click(caption);
 
     await waitFor(() => expect(readout()).toContain("26.0px rows (labelled)"));
     await expect(readout()).toContain("zoomed");

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
@@ -1934,6 +1934,66 @@ export const FitStaysAfterATimeOnlyBox = meta.story({
   },
 });
 
+/**
+ * Panning a hairline overview is not a time zoom. Show labels must stay, or
+ * Fit would snap the window back to the top of the tree instead of naming
+ * the rows you just scrolled to.
+ */
+export const ShowLabelsSurvivesAVerticalPan = meta.story({
+  name: "(Test) Show Labels Survives A Vertical Pan",
+  args: {
+    roots: manySpans(800),
+    box: DESKTOP,
+    gutter: "auto",
+    pointer: "fine",
+    barColor: "type",
+    compress: false,
+    showReadout: true,
+    selectedId: null,
+    onSelect: fn(),
+    onHover: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const surface = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="timeline-dense-surface"]',
+    );
+    if (!surface) throw new Error("dense surface not found");
+    const readout = () =>
+      canvasElement.querySelector<HTMLElement>(
+        '[data-testid="timeline-dense-readout"]',
+      )?.textContent ?? "";
+    const show = () =>
+      canvasElement.querySelector<HTMLButtonElement>(
+        'button[aria-label="Show labels"]',
+      );
+
+    await expect(readout()).toContain("fitted");
+    await expect(show()).not.toBeNull();
+
+    const rect = surface.getBoundingClientRect();
+    surface.dispatchEvent(
+      new WheelEvent("wheel", {
+        bubbles: true,
+        cancelable: true,
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.top + rect.height / 2,
+        deltaY: 240,
+      }),
+    );
+    await waitFor(() => expect(readout()).toContain("zoomed"));
+    await expect(readout()).toMatch(/1\.0px rows/);
+    await expect(show()).not.toBeNull();
+    await expect(
+      canvasElement.querySelector('button[aria-label="Fit whole trace"]'),
+    ).toBeNull();
+
+    if (!show()) throw new Error("Show labels vanished after a vertical pan");
+    await userEvent.click(show()!);
+    await waitFor(() => expect(readout()).toContain("26.0px rows (labelled)"));
+    await expect(readout()).toContain("zoomed");
+  },
+});
+
 /** Collapse in the tree means collapse here: the same set, honoured. */
 export const CollapsedRowsAreNotDrawn = meta.story({
   name: "(Test) Collapsed Rows Are Not Drawn",

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
@@ -1787,7 +1787,7 @@ export const HoverDoesNotRecolourTheBar = meta.story({
 /** A control that can do nothing should say so rather than look broken. */
 export const FitIsDisabledWhenItWouldDoNothing = meta.story({
   name: "(Test) Fit Is Disabled When It Would Do Nothing",
-  args: { ...READABLE, roots: manySpans(40), onSelect: fn(), onHover: fn() },
+  args: { ...READABLE, roots: manySpans(12), onSelect: fn(), onHover: fn() },
   play: async ({ canvasElement }) => {
     const fit = () =>
       canvasElement.querySelector<HTMLButtonElement>(
@@ -1804,6 +1804,68 @@ export const FitIsDisabledWhenItWouldDoNothing = meta.story({
     if (!zoomIn) throw new Error("no zoom button");
     await userEvent.click(zoomIn);
     await waitFor(() => expect(fit()?.disabled).toBe(false));
+  },
+});
+
+/**
+ * A long trace fits as 1px rows — the whole clock, no names. The spent fit
+ * control used to sit there disabled, so there was no obvious way to get the
+ * labels back without also shrinking the duration. "Show labels" grows only
+ * the rows; Fit then takes you back to the overview.
+ */
+export const ShowLabelsKeepsTheWholeClock = meta.story({
+  name: "(Test) Show Labels Keeps The Whole Clock",
+  args: {
+    roots: manySpans(150),
+    box: DESKTOP,
+    gutter: "auto",
+    pointer: "fine",
+    barColor: "type",
+    compress: false,
+    showReadout: true,
+    selectedId: null,
+    onSelect: fn(),
+    onHover: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const readout = () =>
+      canvasElement.querySelector<HTMLElement>(
+        '[data-testid="timeline-dense-readout"]',
+      )?.textContent ?? "";
+    const toolbar = () =>
+      canvasElement.querySelector<HTMLElement>(
+        '[data-testid="timeline-dense-toolbar"]',
+      );
+    const labels = () =>
+      canvasElement.querySelectorAll('[data-testid="timeline-dense-metrics"]')
+        .length;
+
+    await expect(readout()).toContain("fitted");
+    await expect(readout()).toContain("4.0px rows");
+    await expect(labels()).toBe(0);
+
+    const show = canvasElement.querySelector<HTMLButtonElement>(
+      'button[aria-label="Show labels"]',
+    );
+    if (!show) throw new Error("no show-labels button");
+    await expect(show.disabled).toBe(false);
+    await expect(toolbar()?.innerText.toLowerCase()).toContain("show labels");
+    await userEvent.click(show);
+
+    await waitFor(() => expect(readout()).toContain("26.0px rows (labelled)"));
+    await expect(readout()).toContain("zoomed");
+    await expect(labels()).toBeGreaterThan(0);
+
+    const fit = canvasElement.querySelector<HTMLButtonElement>(
+      'button[aria-label="Fit whole trace"]',
+    );
+    if (!fit) throw new Error("no fit button after expanding");
+    await expect(fit.disabled).toBe(false);
+    await userEvent.click(fit);
+
+    await waitFor(() => expect(readout()).toContain("fitted"));
+    await expect(readout()).toContain("4.0px rows");
+    await expect(labels()).toBe(0);
   },
 });
 
@@ -2017,7 +2079,7 @@ export const TheCursorMatchesTheGesture = meta.story({
  */
 export const TheToolbarDoesNotExplainItself = meta.story({
   name: "(Test) The Toolbar Does Not Explain Itself",
-  args: { ...READABLE, roots: manySpans(40), onSelect: fn(), onHover: fn() },
+  args: { ...READABLE, roots: manySpans(12), onSelect: fn(), onHover: fn() },
   play: async ({ canvasElement }) => {
     const toolbar = canvasElement.querySelector<HTMLElement>(
       '[data-testid="timeline-dense-toolbar"]',

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
@@ -1940,6 +1940,55 @@ export const FitStaysAfterATimeOnlyBox = meta.story({
 });
 
 /**
+ * A short trace on a narrow pane already has readable rows, but auto will not
+ * spend the lane on names. Show labels is still the ask: take the gutter,
+ * even if the bars get thinner.
+ */
+export const ShowLabelsOpensTheGutterOnANarrowPane = meta.story({
+  name: "(Test) Show Labels Opens The Gutter On A Narrow Pane",
+  args: {
+    roots: manySpans(12),
+    box: PHONE,
+    gutter: "auto",
+    pointer: "fine",
+    barColor: "type",
+    compress: false,
+    showReadout: true,
+    selectedId: null,
+    onSelect: fn(),
+    onHover: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const names = () =>
+      canvasElement.querySelectorAll(
+        '[data-testid="timeline-dense-peek"] span[title], [data-testid="timeline-dense-content"] > div span[title]',
+      ).length;
+    const barLeft = () => {
+      const bar = canvasElement.querySelector<HTMLElement>(
+        '[data-testid="timeline-dense-bar"]',
+      );
+      return bar?.getBoundingClientRect().left ?? 0;
+    };
+
+    await expect(names()).toBe(0);
+    const show = canvasElement.querySelector<HTMLButtonElement>(
+      'button[aria-label="Show labels"]',
+    );
+    if (!show) throw new Error("no show-labels button on a squeezed pane");
+    await expect(show.innerText.toLowerCase()).toContain("show labels");
+    const caption = [...show.querySelectorAll("span")].find(
+      (el) => el.textContent?.trim().toLowerCase() === "show labels",
+    );
+    if (!caption) throw new Error("Show labels text is not on the button");
+    const leftBefore = barLeft();
+
+    await userEvent.click(caption);
+    await waitFor(() => expect(names()).toBeGreaterThan(0));
+    await expect(barLeft()).toBeGreaterThan(leftBefore + 40);
+  },
+});
+
+/**
  * Panning a hairline overview is not a time zoom. Show labels must stay, or
  * Fit would snap the window back to the top of the tree instead of naming
  * the rows you just scrolled to.

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
@@ -1989,6 +1989,148 @@ export const ShowLabelsOpensTheGutterOnANarrowPane = meta.story({
 });
 
 /**
+ * A pane too narrow to ever commit the gutter still offers Show labels, but
+ * names float as a peek overlay. A second rail tap must be able to dismiss
+ * that peek: committedOpen never becomes true, so the toggle has to look at
+ * the held-open pin, not the committed lane.
+ */
+const TOO_NARROW_TO_COMMIT = { width: 220, height: 400 };
+
+export const ShowLabelsPeekTogglesOffOnATooNarrowPane = meta.story({
+  name: "(Test) Show Labels Peek Toggles Off On A Too Narrow Pane",
+  args: {
+    roots: manySpans(12),
+    box: TOO_NARROW_TO_COMMIT,
+    gutter: "auto",
+    pointer: "coarse",
+    barColor: "type",
+    compress: false,
+    showReadout: true,
+    selectedId: null,
+    onSelect: fn(),
+    onHover: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const surface = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="timeline-dense-surface"]',
+    );
+    if (!surface) throw new Error("dense surface not found");
+    surface.setPointerCapture = () => undefined;
+    surface.releasePointerCapture = () => undefined;
+    const peekNames = () =>
+      canvasElement.querySelectorAll(
+        '[data-testid="timeline-dense-peek"] span[title]',
+      ).length;
+    const gutterNames = () =>
+      canvasElement.querySelectorAll(
+        '[data-testid="timeline-dense-content"] > div span[title]',
+      ).length;
+    const barLeft = () => {
+      const bar = canvasElement.querySelector<HTMLElement>(
+        '[data-testid="timeline-dense-bar"]',
+      );
+      return bar?.getBoundingClientRect().left ?? 0;
+    };
+    const tapRail = () => {
+      const rect = surface.getBoundingClientRect();
+      touch(surface, "pointerdown", 1, rect.left + 2, rect.top + 80);
+      touch(surface, "pointerup", 1, rect.left + 2, rect.top + 80);
+    };
+
+    const show = canvasElement.querySelector<HTMLButtonElement>(
+      'button[aria-label="Show labels"]',
+    );
+    if (!show) throw new Error("no show-labels button on a peek-only pane");
+    const leftBefore = barLeft();
+
+    await userEvent.click(show);
+    await waitFor(() => expect(peekNames()).toBeGreaterThan(0));
+    await expect(gutterNames()).toBe(0);
+    await expect(Math.abs(barLeft() - leftBefore)).toBeLessThan(20);
+
+    tapRail();
+    await waitFor(() => expect(peekNames()).toBe(0));
+    await expect(gutterNames()).toBe(0);
+
+    tapRail();
+    await waitFor(() => expect(peekNames()).toBeGreaterThan(0));
+    await expect(gutterNames()).toBe(0);
+  },
+});
+
+/**
+ * After a coarse rail tap collapses a committed gutter, Show labels must
+ * clear that leftover override and take the lane again. A stale
+ * override==="collapsed" used to leave names as a peek overlay.
+ */
+export const ShowLabelsRecommitsAfterARailCollapse = meta.story({
+  name: "(Test) Show Labels Recommits After A Rail Collapse",
+  args: {
+    roots: manySpans(12),
+    box: PHONE,
+    gutter: "auto",
+    pointer: "coarse",
+    barColor: "type",
+    compress: false,
+    showReadout: true,
+    selectedId: null,
+    onSelect: fn(),
+    onHover: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const surface = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="timeline-dense-surface"]',
+    );
+    if (!surface) throw new Error("dense surface not found");
+    surface.setPointerCapture = () => undefined;
+    surface.releasePointerCapture = () => undefined;
+    const peekNames = () =>
+      canvasElement.querySelectorAll(
+        '[data-testid="timeline-dense-peek"] span[title]',
+      ).length;
+    const gutterNames = () =>
+      canvasElement.querySelectorAll(
+        '[data-testid="timeline-dense-content"] > div span[title]',
+      ).length;
+    const barLeft = () => {
+      const bar = canvasElement.querySelector<HTMLElement>(
+        '[data-testid="timeline-dense-bar"]',
+      );
+      return bar?.getBoundingClientRect().left ?? 0;
+    };
+    const tapRail = () => {
+      const rect = surface.getBoundingClientRect();
+      touch(surface, "pointerdown", 1, rect.left + 2, rect.top + 80);
+      touch(surface, "pointerup", 1, rect.left + 2, rect.top + 80);
+    };
+    const clickShowLabels = async () => {
+      const show = canvasElement.querySelector<HTMLButtonElement>(
+        'button[aria-label="Show labels"]',
+      );
+      if (!show) throw new Error("no show-labels button");
+      await userEvent.click(show);
+    };
+
+    const leftClosed = barLeft();
+    await expect(gutterNames()).toBe(0);
+
+    await clickShowLabels();
+    await waitFor(() => expect(gutterNames()).toBeGreaterThan(0));
+    await expect(peekNames()).toBe(0);
+    await expect(barLeft()).toBeGreaterThan(leftClosed + 40);
+
+    tapRail();
+    await waitFor(() => expect(gutterNames()).toBe(0));
+    await expect(peekNames()).toBe(0);
+
+    await clickShowLabels();
+    await waitFor(() => expect(gutterNames()).toBeGreaterThan(0));
+    await expect(peekNames()).toBe(0);
+    await expect(barLeft()).toBeGreaterThan(leftClosed + 40);
+  },
+});
+
+/**
  * Panning a hairline overview is not a time zoom. Show labels must stay, or
  * Fit would snap the window back to the top of the tree instead of naming
  * the rows you just scrolled to.

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
@@ -495,9 +495,12 @@ export function TimelineDense({
   const presentation = presentationForRowHeight(rowHeight);
   const fitted = isViewportFitted(current, limits);
   const canShowLabels = canExpandRowsToReadable(current, limits);
-  // Only replace Fit at rest. A time-zoomed hairline still needs one click
-  // back to the whole trace; Show labels would keep that narrow clock.
-  const offerShowLabels = canShowLabels && fitted;
+  // Replace Fit only while the whole clock is still on screen. A time-zoomed
+  // hairline needs one click back to the overview; Show labels would keep
+  // that narrow clock. A vertical pan of the overview is not a time zoom —
+  // Show labels should still grow the rows from where you are.
+  const clockFits = current.time.duration >= limits.traceSpace.duration - 0.5;
+  const offerShowLabels = canShowLabels && clockFits;
   const barHeight = Math.max(Math.min(rowHeight - 1, MAX_BAR_HEIGHT), 1);
 
   /**

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
@@ -1340,6 +1340,9 @@ export function TimelineDense({
         {offerShowLabels ? (
           <ToolbarButton label="Show labels" onClick={showLabels}>
             <UnfoldVertical className="h-3 w-3" />
+            <span className="pr-0.5" style={{ fontSize: "10px" }}>
+              Show labels
+            </span>
           </ToolbarButton>
         ) : (
           <ToolbarButton
@@ -1354,18 +1357,16 @@ export function TimelineDense({
           </ToolbarButton>
         )}
         {/* Where you are, when you are somewhere — and nothing at all when the
-            whole trace is in view. When labels are hidden at rest, the spent
-            fit control becomes "Show labels" and this caption says so: zoom is
-            how you get the names back, and that is not obvious from 1px rows. */}
-        <span
-          className="text-muted-foreground truncate"
-          style={{ fontSize: "10px" }}
-          title={
-            offerShowLabels ? "Show labels" : fitted ? undefined : windowHint
-          }
-        >
-          {offerShowLabels ? "Show labels" : fitted ? null : windowHint}
-        </span>
+            whole trace is in view. */}
+        {!offerShowLabels && !fitted ? (
+          <span
+            className="text-muted-foreground truncate"
+            style={{ fontSize: "10px" }}
+            title={windowHint}
+          >
+            {windowHint}
+          </span>
+        ) : null}
       </div>
 
       {/* The axis doubles as the scrub track: press to place the playhead, drag
@@ -1945,7 +1946,7 @@ function ToolbarButton({
       title={label}
       onClick={onClick}
       disabled={disabled}
-      className="hover:bg-muted flex h-4 w-4 shrink-0 items-center justify-center rounded disabled:pointer-events-none disabled:opacity-40"
+      className="hover:bg-muted flex h-4 min-w-4 shrink-0 items-center justify-center gap-0.5 rounded px-0.5 disabled:pointer-events-none disabled:opacity-40"
     >
       {children}
     </button>

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
@@ -391,6 +391,10 @@ export function TimelineDense({
   // A manual override lives until you touch the chart again, which is what
   // "expand to look, then get out of my way" means in practice.
   const [override, setOverride] = useState<GutterMode | null>(null);
+  // An explicit "Show labels" is the other ask: keep the names on screen even
+  // when a gesture would have handed the gutter back, and even when auto would
+  // rather keep the lane. Fit or a rail collapse lets go.
+  const [labelsPinned, setLabelsPinned] = useState(false);
   // Desktop peek: hovering the left edge opens it, moving into the chart closes
   // it again. No click to look, no click to get out of the way.
   const [peeking, setPeeking] = useState(false);
@@ -440,7 +444,8 @@ export function TimelineDense({
    */
   const canShowNames = liveRowHeight >= NAME_MIN_ROW_HEIGHT;
   const wantedGutter = Math.min(Math.max(contentWidth * 0.38, 96), 168);
-  const asked = override === "expanded" || gutterMode === "expanded";
+  const asked =
+    labelsPinned || override === "expanded" || gutterMode === "expanded";
   const wantsOpen =
     override === "collapsed" ? false : asked || gutterMode === "auto";
   const gutterFits =
@@ -489,18 +494,22 @@ export function TimelineDense({
   // an explicit ask still gets the names where they could not fit beside the
   // chart.
   const peekWidth =
-    canShowNames && !committedOpen && (peeking || override === "expanded")
+    canShowNames &&
+    !committedOpen &&
+    (peeking || labelsPinned || override === "expanded")
       ? wantedGutter
       : 0;
   const presentation = presentationForRowHeight(rowHeight);
   const fitted = isViewportFitted(current, limits);
   const canShowLabels = canExpandRowsToReadable(current, limits);
-  // Replace Fit only while the whole clock is still on screen. A time-zoomed
-  // hairline needs one click back to the overview; Show labels would keep
-  // that narrow clock. A vertical pan of the overview is not a time zoom —
-  // Show labels should still grow the rows from where you are.
+  const labelsShowing = committedOpen || (labelsPinned && peekWidth > 0);
+  // Replace Fit only while the whole clock is still on screen AND names are
+  // missing. Rows can be too short, or the pane too narrow to volunteer a
+  // gutter — both are the same ask. A time-zoomed hairline keeps Fit.
   const clockFits = current.time.duration >= limits.traceSpace.duration - 0.5;
-  const offerShowLabels = canShowLabels && clockFits;
+  const offerShowLabels =
+    clockFits && !labelsShowing && (canShowLabels || canShowNames);
+  const fitSpent = fitted && !labelsPinned;
   const barHeight = Math.max(Math.min(rowHeight - 1, MAX_BAR_HEIGHT), 1);
 
   /**
@@ -828,6 +837,7 @@ export function TimelineDense({
 
   const showLabels = () => {
     const { limits: live, extentOf } = layoutRef.current;
+    setLabelsPinned(true);
     flyTo(
       anchorTimeToRows(
         expandRowsToReadable(viewportRef.current, live),
@@ -945,6 +955,7 @@ export function TimelineDense({
       canShowNames &&
       offsetX <= Math.max(railWidth, peekWidth) + PEEK_MARGIN_PX
     ) {
+      setLabelsPinned(!isOpen);
       setOverride(isOpen ? "collapsed" : "expanded");
       // This tap is spent on the toggle, so it is not half of a double-tap:
       // opening and closing the names inside the double-tap window otherwise read
@@ -1330,7 +1341,7 @@ export function TimelineDense({
         <ToolbarButton
           label="Zoom in"
           onClick={() =>
-            canShowLabels
+            offerShowLabels
               ? showLabels()
               : zoomBy(2 ** BUTTON_ZOOM_LEVELS, 0.5, 0.5)
           }
@@ -1346,9 +1357,13 @@ export function TimelineDense({
           </ToolbarButton>
         ) : (
           <ToolbarButton
-            label={fitted ? "Whole trace already fits" : "Fit whole trace"}
-            onClick={() => flyTo(fitViewport(limits))}
-            disabled={fitted}
+            label={fitSpent ? "Whole trace already fits" : "Fit whole trace"}
+            onClick={() => {
+              setLabelsPinned(false);
+              setOverride(null);
+              flyTo(fitViewport(limits));
+            }}
+            disabled={fitSpent}
           >
             {/* A viewfinder, not the diagonal arrows this used to wear: those
                 read as "fullscreen", so a control that was merely spent looked

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
@@ -20,9 +20,11 @@
  *    phone or a peek panel, where there is not, the colour rail becomes the
  *    affordance and a hover or a tap floats the names over the chart.
  *  - Any wheel or two-finger scroll pans both axes; pinch and ⌘/ctrl + wheel zoom
- *    BOTH axes about the cursor, so the time window narrows and the rows grow
- *    together. Zoom is exponential in a zoom level and deltas accumulate per
- *    frame, as in mapping libraries — see the rate constants below.
+ *    about the cursor. While rows are still too short to hold a label, that zoom
+ *    grows only the rows — the whole duration stays on screen until the names
+ *    come back — and after that both axes move together. Zoom is exponential in
+ *    a zoom level and deltas accumulate per frame, as in mapping libraries — see
+ *    the rate constants below.
  *  - Drag pans both axes too, and drag draws a box to zoom into — the one
  *    gesture where the user has stated the window on both axes, so it goes
  *    straight there. There are no scrollbars by design: a map has none, and the
@@ -55,7 +57,7 @@ import {
   type ReactNode,
 } from "react";
 import { useTheme } from "next-themes";
-import { Scan, Minus, Plus } from "lucide-react";
+import { Scan, Minus, Plus, UnfoldVertical } from "lucide-react";
 import { ItemBadge, type LangfuseItemType } from "@/src/components/ItemBadge";
 import {
   tooltipPlacement,
@@ -80,6 +82,8 @@ import { traceSpaceOf, type Box } from "../../fns/timeline/viewTransform";
 import {
   HUMAN_ROW_HEIGHT,
   anchorTimeToRows,
+  canExpandRowsToReadable,
+  expandRowsToReadable,
   interpolateViewport,
   rowCountBounds,
   viewportsEqual,
@@ -94,7 +98,7 @@ import {
   rowIndexAtOffset,
   visibleRowRange,
   zoomToBox,
-  zoomViewport,
+  zoomViewportRevealLabels,
   type RowExtent,
   type Viewport,
 } from "../../fns/timeline/viewport";
@@ -490,6 +494,7 @@ export function TimelineDense({
       : 0;
   const presentation = presentationForRowHeight(rowHeight);
   const fitted = isViewportFitted(current, limits);
+  const canShowLabels = canExpandRowsToReadable(current, limits);
   const barHeight = Math.max(Math.min(rowHeight - 1, MAX_BAR_HEIGHT), 1);
 
   /**
@@ -665,7 +670,7 @@ export function TimelineDense({
     options: { factor: number; xRatio: number; yRatio: number },
   ) => {
     const { limits: live, extentOf: extent } = layoutRef.current;
-    const zoomed = zoomViewport(
+    const zoomed = zoomViewportRevealLabels(
       from ? clampViewport(from, live) : fitViewport(live),
       live,
       options,
@@ -815,6 +820,10 @@ export function TimelineDense({
     [cancelTween],
   );
 
+  const showLabels = () => {
+    flyTo(expandRowsToReadable(viewportRef.current, layoutRef.current.limits));
+  };
+
   const scheduleGesture = useCallback(() => {
     // Any gesture on the chart hands the space back: an expanded gutter is for
     // looking, and the moment you work in the chart it gets out of the way. It
@@ -827,8 +836,9 @@ export function TimelineDense({
 
   /**
    * Wheel and trackpad pinch on a non-passive listener, so the page never takes
-   * the gesture. Both zoom, like a map: a Mac pinch arrives as wheel + ctrlKey
-   * and needs no special case; shift or a horizontal wheel pans instead.
+   * the gesture. A Mac pinch arrives as wheel + ctrlKey and needs no special
+   * case; shift or a horizontal wheel pans instead. Pinch-zoom grows only the
+   * rows while labels are hidden, then both axes once they fit.
    */
   const attachSurface = useCallback(
     (element: HTMLDivElement | null) => {
@@ -1306,30 +1316,42 @@ export function TimelineDense({
         </ToolbarButton>
         <ToolbarButton
           label="Zoom in"
-          onClick={() => zoomBy(2 ** BUTTON_ZOOM_LEVELS, 0.5, 0.5)}
+          onClick={() =>
+            canShowLabels
+              ? showLabels()
+              : zoomBy(2 ** BUTTON_ZOOM_LEVELS, 0.5, 0.5)
+          }
         >
           <Plus className="h-3 w-3" />
         </ToolbarButton>
-        <ToolbarButton
-          label={fitted ? "Whole trace already fits" : "Fit whole trace"}
-          onClick={() => flyTo(fitViewport(limits))}
-          disabled={fitted}
-        >
-          {/* A viewfinder, not the diagonal arrows this used to wear: those read
-              as "fullscreen", so a control that was merely spent looked broken. */}
-          <Scan className="h-3 w-3" />
-        </ToolbarButton>
+        {canShowLabels ? (
+          <ToolbarButton label="Show labels" onClick={showLabels}>
+            <UnfoldVertical className="h-3 w-3" />
+          </ToolbarButton>
+        ) : (
+          <ToolbarButton
+            label={fitted ? "Whole trace already fits" : "Fit whole trace"}
+            onClick={() => flyTo(fitViewport(limits))}
+            disabled={fitted}
+          >
+            {/* A viewfinder, not the diagonal arrows this used to wear: those
+                read as "fullscreen", so a control that was merely spent looked
+                broken. */}
+            <Scan className="h-3 w-3" />
+          </ToolbarButton>
+        )}
         {/* Where you are, when you are somewhere — and nothing at all when the
-            whole trace is in view. This carried a list of gestures once. Every
-            way of interacting with this surface is one you would have tried:
-            drag, scroll, pinch, double-click, click. A caption explaining them
-            is a caption nobody reads, taking the room a state readout earns. */}
+            whole trace is in view. When labels are hidden at rest, the spent
+            fit control becomes "Show labels" and this caption says so: zoom is
+            how you get the names back, and that is not obvious from 1px rows. */}
         <span
           className="text-muted-foreground truncate"
           style={{ fontSize: "10px" }}
-          title={fitted ? undefined : windowHint}
+          title={
+            canShowLabels ? "Show labels" : fitted ? undefined : windowHint
+          }
         >
-          {fitted ? null : windowHint}
+          {canShowLabels ? "Show labels" : fitted ? null : windowHint}
         </span>
       </div>
 

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
@@ -495,6 +495,9 @@ export function TimelineDense({
   const presentation = presentationForRowHeight(rowHeight);
   const fitted = isViewportFitted(current, limits);
   const canShowLabels = canExpandRowsToReadable(current, limits);
+  // Only replace Fit at rest. A time-zoomed hairline still needs one click
+  // back to the whole trace; Show labels would keep that narrow clock.
+  const offerShowLabels = canShowLabels && fitted;
   const barHeight = Math.max(Math.min(rowHeight - 1, MAX_BAR_HEIGHT), 1);
 
   /**
@@ -821,7 +824,14 @@ export function TimelineDense({
   );
 
   const showLabels = () => {
-    flyTo(expandRowsToReadable(viewportRef.current, layoutRef.current.limits));
+    const { limits: live, extentOf } = layoutRef.current;
+    flyTo(
+      anchorTimeToRows(
+        expandRowsToReadable(viewportRef.current, live),
+        live,
+        extentOf,
+      ),
+    );
   };
 
   const scheduleGesture = useCallback(() => {
@@ -1324,7 +1334,7 @@ export function TimelineDense({
         >
           <Plus className="h-3 w-3" />
         </ToolbarButton>
-        {canShowLabels ? (
+        {offerShowLabels ? (
           <ToolbarButton label="Show labels" onClick={showLabels}>
             <UnfoldVertical className="h-3 w-3" />
           </ToolbarButton>
@@ -1348,10 +1358,10 @@ export function TimelineDense({
           className="text-muted-foreground truncate"
           style={{ fontSize: "10px" }}
           title={
-            canShowLabels ? "Show labels" : fitted ? undefined : windowHint
+            offerShowLabels ? "Show labels" : fitted ? undefined : windowHint
           }
         >
-          {canShowLabels ? "Show labels" : fitted ? null : windowHint}
+          {offerShowLabels ? "Show labels" : fitted ? null : windowHint}
         </span>
       </div>
 

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
@@ -446,8 +446,14 @@ export function TimelineDense({
   const wantedGutter = Math.min(Math.max(contentWidth * 0.38, 96), 168);
   const asked =
     labelsPinned || override === "expanded" || gutterMode === "expanded";
-  const wantsOpen =
-    override === "collapsed" ? false : asked || gutterMode === "auto";
+  // An explicit "Show labels" pin wins over a leftover rail-collapse
+  // override; otherwise the names stay a peek overlay and never take
+  // the gutter the user just asked for.
+  const wantsOpen = labelsPinned
+    ? true
+    : override === "collapsed"
+      ? false
+      : asked || gutterMode === "auto";
   const gutterFits =
     contentWidth - wantedGutter >=
     (asked ? MIN_LANE_WIDTH : AUTO_OPEN_MIN_LANE_WIDTH);
@@ -838,6 +844,7 @@ export function TimelineDense({
   const showLabels = () => {
     const { limits: live, extentOf } = layoutRef.current;
     setLabelsPinned(true);
+    setOverride(null);
     flyTo(
       anchorTimeToRows(
         expandRowsToReadable(viewportRef.current, live),
@@ -955,8 +962,14 @@ export function TimelineDense({
       canShowNames &&
       offsetX <= Math.max(railWidth, peekWidth) + PEEK_MARGIN_PX
     ) {
-      setLabelsPinned(!isOpen);
-      setOverride(isOpen ? "collapsed" : "expanded");
+      // Peek overlays never become committedOpen (the pane is too narrow
+      // to give the gutter a lane). Toggle on the held-open state so a
+      // second tap can dismiss a peek the first tap — or Show labels —
+      // just opened.
+      const namesHeldOpen =
+        committedOpen || labelsPinned || override === "expanded";
+      setLabelsPinned(!namesHeldOpen);
+      setOverride(namesHeldOpen ? "collapsed" : "expanded");
       // This tap is spent on the toggle, so it is not half of a double-tap:
       // opening and closing the names inside the double-tap window otherwise read
       // as one, and flew the viewport to whatever row the second tap landed on.

--- a/web/src/features/traces/fns/timeline/viewport.clienttest.ts
+++ b/web/src/features/traces/fns/timeline/viewport.clienttest.ts
@@ -99,6 +99,21 @@ describe("viewport", () => {
     expect(fromThere.rows.start).toBeCloseTo(800, 6);
     expect(fromThere.time).toEqual(panned.time);
 
+    // A clock that has already been sliced stays sliced; only the rows grow.
+    const narrowed = zoomViewport(fitted, limits, {
+      factor: 2,
+      xRatio: 0.5,
+      yRatio: 0.5,
+      axes: "x",
+    });
+    expect(canExpandRowsToReadable(narrowed, limits)).toBe(true);
+    const expandedClock = expandRowsToReadable(narrowed, limits);
+    expect(expandedClock.time).toEqual(narrowed.time);
+    expect(rowHeightOf(expandedClock, limits.boxHeight)).toBeCloseTo(
+      HUMAN_ROW_HEIGHT,
+      6,
+    );
+
     // A short trace already sits at the human height — nothing to grow.
     const short = { ...limits, rowCount: 12 };
     const shortFit = fitViewport(short);
@@ -126,6 +141,18 @@ describe("viewport", () => {
     });
     expect(reveal.time).toEqual(fitted.time);
     expect(rowHeightOf(reveal, limits.boxHeight)).toBeCloseTo(2, 6);
+
+    // A factor large enough to cross the labelled threshold spends the rest
+    // on both axes — otherwise a batched pinch would leave the clock full.
+    const crossing = zoomViewportRevealLabels(fitted, limits, {
+      factor: LABELLED_ROW_HEIGHT * 1.2,
+      xRatio: 0.5,
+      yRatio: 0.5,
+    });
+    expect(rowHeightOf(crossing, limits.boxHeight)).toBeGreaterThanOrEqual(
+      LABELLED_ROW_HEIGHT,
+    );
+    expect(crossing.time.duration).toBeCloseTo(fitted.time.duration / 1.2, 6);
 
     const labelled = expandRowsToReadable(fitted, limits);
     const both = zoomViewportRevealLabels(labelled, limits, {

--- a/web/src/features/traces/fns/timeline/viewport.clienttest.ts
+++ b/web/src/features/traces/fns/timeline/viewport.clienttest.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import { traceSpaceOf } from "./viewTransform";
 import {
   HUMAN_ROW_HEIGHT,
+  LABELLED_ROW_HEIGHT,
   anchorTimeToRows,
+  canExpandRowsToReadable,
+  expandRowsToReadable,
   MAX_ROW_HEIGHT,
   MIN_ROW_HEIGHT,
   clampViewport,
@@ -10,6 +13,7 @@ import {
   focusViewport,
   isViewportFitted,
   panViewport,
+  presentationForRowHeight,
   revealViewport,
   rowHeightOf,
   viewportsEqual,
@@ -17,6 +21,7 @@ import {
   visibleRowRange,
   zoomToBox,
   zoomViewport,
+  zoomViewportRevealLabels,
   type Viewport,
 } from "./viewport";
 
@@ -64,6 +69,83 @@ describe("viewport", () => {
       yRatio: 0.5,
     });
     expect(rowHeightOf(zoomedIn, 600)).toBeCloseTo(MAX_ROW_HEIGHT, 6);
+  });
+
+  it("expands rows to a readable height without narrowing the clock", () => {
+    const fitted = fitViewport(limits);
+    expect(rowHeightOf(fitted, limits.boxHeight)).toBe(MIN_ROW_HEIGHT);
+    expect(canExpandRowsToReadable(fitted, limits)).toBe(true);
+    expect(presentationForRowHeight(MIN_ROW_HEIGHT)).toBe("hairline");
+
+    const expanded = expandRowsToReadable(fitted, limits);
+    expect(rowHeightOf(expanded, limits.boxHeight)).toBeCloseTo(
+      HUMAN_ROW_HEIGHT,
+      6,
+    );
+    expect(expanded.time).toEqual(limits.traceSpace);
+    expect(expanded.rows.start).toBe(0);
+    expect(isViewportFitted(expanded, limits)).toBe(false);
+    expect(canExpandRowsToReadable(expanded, limits)).toBe(false);
+    expect(
+      presentationForRowHeight(rowHeightOf(expanded, limits.boxHeight)),
+    ).toBe("labelled");
+
+    // A window that has been panned keeps that slice at the top.
+    const panned = {
+      ...fitted,
+      rows: { start: 800, count: fitted.rows.count },
+    };
+    const fromThere = expandRowsToReadable(panned, limits);
+    expect(fromThere.rows.start).toBeCloseTo(800, 6);
+    expect(fromThere.time).toEqual(panned.time);
+
+    // A short trace already sits at the human height — nothing to grow.
+    const short = { ...limits, rowCount: 12 };
+    const shortFit = fitViewport(short);
+    expect(canExpandRowsToReadable(shortFit, short)).toBe(false);
+    expect(expandRowsToReadable(shortFit, short)).toEqual(shortFit);
+  });
+
+  it("zooms only the rows when labels are still hidden", () => {
+    const fitted = fitViewport(limits);
+    const yOnly = zoomViewport(fitted, limits, {
+      factor: 2,
+      xRatio: 0.5,
+      yRatio: 0.5,
+      axes: "y",
+    });
+    expect(yOnly.time).toEqual(fitted.time);
+    expect(yOnly.rows.count).toBeCloseTo(300, 6);
+    expect(rowHeightOf(yOnly, limits.boxHeight)).toBeCloseTo(2, 6);
+
+    // Incremental zoom-in stays on Y until a label would fit.
+    const reveal = zoomViewportRevealLabels(fitted, limits, {
+      factor: 2,
+      xRatio: 0.5,
+      yRatio: 0.5,
+    });
+    expect(reveal.time).toEqual(fitted.time);
+    expect(rowHeightOf(reveal, limits.boxHeight)).toBeCloseTo(2, 6);
+
+    const labelled = expandRowsToReadable(fitted, limits);
+    const both = zoomViewportRevealLabels(labelled, limits, {
+      factor: 2,
+      xRatio: 0.5,
+      yRatio: 0.5,
+    });
+    expect(both.time.duration).toBeCloseTo(labelled.time.duration / 2, 6);
+    expect(both.rows.count).toBeCloseTo(labelled.rows.count / 2, 6);
+
+    // Zooming out from the hairline is a no-op on time (already full) and
+    // cannot shrink the rows below the floor.
+    const out = zoomViewportRevealLabels(fitted, limits, {
+      factor: 0.5,
+      xRatio: 0.5,
+      yRatio: 0.5,
+    });
+    expect(out.time).toEqual(fitted.time);
+    expect(rowHeightOf(out, limits.boxHeight)).toBeCloseTo(MIN_ROW_HEIGHT, 6);
+    expect(LABELLED_ROW_HEIGHT).toBe(20);
   });
 
   it("zooms both axes about the anchor and holds the content under it", () => {

--- a/web/src/features/traces/fns/timeline/viewport.clienttest.ts
+++ b/web/src/features/traces/fns/timeline/viewport.clienttest.ts
@@ -129,12 +129,12 @@ describe("viewport", () => {
 
     const labelled = expandRowsToReadable(fitted, limits);
     const both = zoomViewportRevealLabels(labelled, limits, {
-      factor: 2,
+      factor: 1.2,
       xRatio: 0.5,
       yRatio: 0.5,
     });
-    expect(both.time.duration).toBeCloseTo(labelled.time.duration / 2, 6);
-    expect(both.rows.count).toBeCloseTo(labelled.rows.count / 2, 6);
+    expect(both.time.duration).toBeCloseTo(labelled.time.duration / 1.2, 6);
+    expect(both.rows.count).toBeCloseTo(labelled.rows.count / 1.2, 6);
 
     // Zooming out from the hairline is a no-op on time (already full) and
     // cannot shrink the rows below the floor.

--- a/web/src/features/traces/fns/timeline/viewport.ts
+++ b/web/src/features/traces/fns/timeline/viewport.ts
@@ -13,8 +13,11 @@
  *    `boxHeight / rows.count` — vertical zoom IS the visible row count, which is
  *    what makes "zoom until the rows are readable" a single number.
  *
- * Both axes clamp to content, so the viewport can never leave the trace, and a
- * single `factor` drives both — a map does not zoom one axis at a time.
+ * Both axes clamp to content, so the viewport can never leave the trace.
+ * Gesture zoom is usually one `factor` on both axes — a map does not zoom one
+ * axis at a time — except while rows are still too short to hold a label: then
+ * zooming in grows only the rows, so the whole duration stays on screen until
+ * the names come back.
  */
 
 import { clampView, type TimeSpan } from "./viewTransform";
@@ -33,6 +36,8 @@ export const MIN_ROW_HEIGHT = 1;
 export const MAX_ROW_HEIGHT = 40;
 /** The row height a human reads comfortably — what double-click aims for. */
 export const HUMAN_ROW_HEIGHT = 26;
+/** Shortest row that can hold a duration label and a name. */
+export const LABELLED_ROW_HEIGHT = 20;
 
 export type RowPresentation =
   /** Bar, duration label and name. */
@@ -45,7 +50,7 @@ export type RowPresentation =
 /** What a row can show follows from how tall it is, never the other way round. */
 export function presentationForRowHeight(rowHeight: number): RowPresentation {
   const height = Number.isFinite(rowHeight) ? rowHeight : 0;
-  if (height >= 20) return "labelled";
+  if (height >= LABELLED_ROW_HEIGHT) return "labelled";
   if (height >= 10) return "compact";
   return "hairline";
 }
@@ -143,37 +148,121 @@ export function clampViewport(
   };
 }
 
+export type ZoomAxes = "both" | "x" | "y";
+
 /**
- * Zoom both axes about a point in the box, given as ratios of its width and
- * height. `factor > 1` zooms in. The content under the anchor stays under it.
+ * Zoom about a point in the box, given as ratios of its width and height.
+ * `factor > 1` zooms in. The content under the anchor stays under it.
+ *
+ * `axes` defaults to both. `"y"` grows or shrinks only the rows, which is how
+ * a long trace can keep its full duration on screen while the labels return.
  */
 export function zoomViewport(
+  viewport: Viewport,
+  limits: ViewportLimits,
+  options: {
+    factor: number;
+    xRatio: number;
+    yRatio: number;
+    axes?: ZoomAxes;
+  },
+): Viewport {
+  const factor = finite(options.factor, 1);
+  if (factor <= 0) return clampViewport(viewport, limits);
+
+  const axes = options.axes ?? "both";
+  const zoomX = axes !== "y";
+  const zoomY = axes !== "x";
+  const xRatio = clamp(finite(options.xRatio, 0.5), 0, 1);
+  const yRatio = clamp(finite(options.yRatio, 0.5), 0, 1);
+
+  const anchorMs = viewport.time.start + viewport.time.duration * xRatio;
+  const timeDuration = zoomX
+    ? viewport.time.duration / factor
+    : viewport.time.duration;
+
+  const anchorRow = viewport.rows.start + viewport.rows.count * yRatio;
+  const rowsCount = zoomY ? viewport.rows.count / factor : viewport.rows.count;
+
+  return clampViewport(
+    {
+      time: {
+        start: zoomX ? anchorMs - timeDuration * xRatio : viewport.time.start,
+        duration: timeDuration,
+      },
+      rows: {
+        start: zoomY ? anchorRow - rowsCount * yRatio : viewport.rows.start,
+        count: rowsCount,
+      },
+    },
+    limits,
+  );
+}
+
+/**
+ * Grow rows until they can hold labels, without narrowing the time window.
+ *
+ * The resting fit of a long trace is 1px rows — the whole shape, no text. This
+ * is the other rest: the same clock, rows tall enough to name themselves, the
+ * rest of the tree panned to.
+ */
+export function expandRowsToReadable(
+  viewport: Viewport,
+  limits: ViewportLimits,
+  options: { yRatio?: number; targetRowHeight?: number } = {},
+): Viewport {
+  const from = clampViewport(viewport, limits);
+  const target = Math.max(
+    finite(options.targetRowHeight, HUMAN_ROW_HEIGHT),
+    LABELLED_ROW_HEIGHT,
+  );
+  const yRatio = clamp(finite(options.yRatio, 0), 0, 1);
+  const bounds = rowCountBounds(limits);
+  const boxHeight = Math.max(finite(limits.boxHeight, 0), 0);
+  const count = clamp(
+    boxHeight > 0 ? boxHeight / target : bounds.min,
+    bounds.min,
+    bounds.max,
+  );
+  const anchorRow = from.rows.start + from.rows.count * yRatio;
+  return clampViewport(
+    {
+      time: from.time,
+      rows: { start: anchorRow - count * yRatio, count },
+    },
+    limits,
+  );
+}
+
+/** Whether growing the rows (and keeping the clock) would reveal labels. */
+export function canExpandRowsToReadable(
+  viewport: Viewport,
+  limits: ViewportLimits,
+): boolean {
+  const height = rowHeightOf(viewport, limits.boxHeight);
+  if (height >= LABELLED_ROW_HEIGHT) return false;
+  const expanded = expandRowsToReadable(viewport, limits);
+  return rowHeightOf(expanded, limits.boxHeight) > height + 0.05;
+}
+
+/**
+ * Zoom in: grow rows first until labels fit, then zoom both axes.
+ * Zoom out: both axes (a full-width window only shrinks the rows).
+ */
+export function zoomViewportRevealLabels(
   viewport: Viewport,
   limits: ViewportLimits,
   options: { factor: number; xRatio: number; yRatio: number },
 ): Viewport {
   const factor = finite(options.factor, 1);
-  if (factor <= 0) return clampViewport(viewport, limits);
-
-  const xRatio = clamp(finite(options.xRatio, 0.5), 0, 1);
-  const yRatio = clamp(finite(options.yRatio, 0.5), 0, 1);
-
-  const anchorMs = viewport.time.start + viewport.time.duration * xRatio;
-  const timeDuration = viewport.time.duration / factor;
-
-  const anchorRow = viewport.rows.start + viewport.rows.count * yRatio;
-  const rowsCount = viewport.rows.count / factor;
-
-  return clampViewport(
-    {
-      time: {
-        start: anchorMs - timeDuration * xRatio,
-        duration: timeDuration,
-      },
-      rows: { start: anchorRow - rowsCount * yRatio, count: rowsCount },
-    },
-    limits,
-  );
+  if (factor <= 1) {
+    return zoomViewport(viewport, limits, options);
+  }
+  const height = rowHeightOf(viewport, limits.boxHeight);
+  if (height >= LABELLED_ROW_HEIGHT) {
+    return zoomViewport(viewport, limits, options);
+  }
+  return zoomViewport(viewport, limits, { ...options, axes: "y" });
 }
 
 /**

--- a/web/src/features/traces/fns/timeline/viewport.ts
+++ b/web/src/features/traces/fns/timeline/viewport.ts
@@ -70,8 +70,8 @@ export type ViewportLimits = {
   boxHeight: number;
 };
 
-const finite = (value: number, fallback: number) =>
-  Number.isFinite(value) ? value : fallback;
+const finite = (value: number | undefined, fallback: number) =>
+  typeof value === "number" && Number.isFinite(value) ? value : fallback;
 
 const clamp = (value: number, min: number, max: number) =>
   Math.min(Math.max(value, min), max);
@@ -246,8 +246,9 @@ export function canExpandRowsToReadable(
 }
 
 /**
- * Zoom in: grow rows first until labels fit, then zoom both axes.
- * Zoom out: both axes (a full-width window only shrinks the rows).
+ * Zoom in: grow rows first until labels fit, then apply whatever factor is
+ * left to both axes. Zoom out: both axes (a full-width window only shrinks
+ * the rows).
  */
 export function zoomViewportRevealLabels(
   viewport: Viewport,
@@ -259,10 +260,22 @@ export function zoomViewportRevealLabels(
     return zoomViewport(viewport, limits, options);
   }
   const height = rowHeightOf(viewport, limits.boxHeight);
-  if (height >= LABELLED_ROW_HEIGHT) {
+  if (!(height > 0) || height >= LABELLED_ROW_HEIGHT) {
     return zoomViewport(viewport, limits, options);
   }
-  return zoomViewport(viewport, limits, { ...options, axes: "y" });
+  const yFactorNeeded = LABELLED_ROW_HEIGHT / height;
+  if (factor <= yFactorNeeded) {
+    return zoomViewport(viewport, limits, { ...options, axes: "y" });
+  }
+  const labelled = zoomViewport(viewport, limits, {
+    ...options,
+    factor: yFactorNeeded,
+    axes: "y",
+  });
+  return zoomViewport(labelled, limits, {
+    ...options,
+    factor: factor / yFactorNeeded,
+  });
 }
 
 /**


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16977 app preview](https://pr-16977.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

On a long trace the timeline fits as 1px rows so the whole duration is visible — and the names disappear. The fit control was already spent in that state, so there was no obvious way to get a readable row height without also shrinking the clock.

This adds a **Show labels** control (icon + words in one button) that reveals names. It grows rows when they are too short, and it also opens the name gutter when a narrow pane would otherwise keep the lane. Taking space from the timeline is the intended trade. Fit returns to the overview and lets the gutter go.

After a time-only box zoom, Fit stays available. After a vertical pan of the overview, Show labels stays so Fit does not snap you back to the top of the tree.

On a pane too narrow to ever commit a gutter, names float as a peek overlay; a rail tap dismisses that peek. After a rail collapse, Show labels clears the leftover override and takes the lane again instead of leaving names as a floating peek.

Pinch / ⌘-wheel zoom does the same first step: while rows are still too short for a label, zoom-in grows only Y. Once a gesture crosses the labelled height, leftover factor applies to both axes. After labels fit, both axes move together as before.

Toolbar **+** from a hairline view jumps to that labelled height instead of taking eight incremental clicks to get there. Expanding rows also re-anchors the clock so a narrow time window cannot land on empty air.

Not persisted in localStorage: the birds-eye fit remains the default rest state. One click reveals labels on any dense trace.

No PostHog event: `TimelineDense` is a presentational Storybook surface without view/v4 context.

![Too-narrow pane: Show labels peeks names as an overlay; play test passes](https://cursor.com/artifacts/c/art-c6d2ab15-416a-4005-aed7-03348e2d0453)
![After collapse then Show labels: names take a committed gutter and bars shift right](https://cursor.com/artifacts/c/art-59486744-d111-4f47-9746-0df95274eabf)
<a href="https://cursor.com/agents/bc-5b069762-2da1-4d38-ba00-cb32ad6c15be/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftimeline-peek-toggle-and-gutter-recommit.mp4"><img src="https://cursor.com/artifacts/c/art-e586743c-3bce-4db4-ad26-bff2c0de04f3" alt="timeline-peek-toggle-and-gutter-recommit.mp4" /></a>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Comments document behavior for future readers
- [x] Tests prove the labelled expand keeps the clock
- [x] No new lint warnings

## Impacted packages

- `web` — timeline viewport math and `TimelineDense` toolbar

## Verification

- `pnpm run lint` (pre-commit): `Tasks: 7 successful, 7 total`
- `pnpm --filter web run test-storybook src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx`: `Tests 57 passed (57)`
- Viewport client tests skipped this pass: no `viewport.ts` change
- Full app / seed path not re-checked: Docker is down in this environment; Storybook is the verification surface

## Test this

Preview: `https://pr-16977.preview.langfuse.com`

1. Open a long trace → Timeline.
2. Confirm **Show labels** is one button (icon + words). Click the words: names appear, clock stays full.
3. On a **narrow** pane with only a handful of rows (type squares, no names): click Show labels — names take a gutter even if the bars get thinner.
4. After a rail double-tap collapse, click Show labels again — names take the gutter, not a floating peek.
5. On a pane too narrow to commit a gutter, Show labels peeks names; a rail tap dismisses the peek.
6. Click **Fit whole trace** to return to the overview (and give the lane back).

Data: `pnpm run seed -- agent-timeline --turns 120 --turn-gap-ms 60000 --v4` or `pnpm run seed -- trace-tree --observations 500 --v4`
Sandbox: same path on `http://localhost:3000`. Storybook: `(Test) Show Labels Keeps The Whole Clock` / `(Test) Show Labels Opens The Gutter On A Narrow Pane` / `(Test) Show Labels Peek Toggles Off On A Too Narrow Pane` / `(Test) Show Labels Recommits After A Rail Collapse`.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15931](https://linear.app/clickhouse/issue/LFE-15931/timeline-when-no-legend-is-shown-not-clear-that-you-need-to-zoom-to)

<div><a href="https://cursor.com/agents/bc-5b069762-2da1-4d38-ba00-cb32ad6c15be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b069762-2da1-4d38-ba00-cb32ad6c15be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a labels-first vertical expansion mode to the dense trace timeline while retaining the full time range.
- Adds a Show labels toolbar state and makes toolbar zoom jump directly to readable rows.
- Changes pinch and modifier-wheel zoom to grow rows before zooming both dimensions.
- Adds viewport and Storybook coverage for label expansion and returning to the fitted overview.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until threshold-crossing gestures preserve their remaining time zoom and Fit remains available in non-fitted short-row states.

Batched zoom factors can cross the label threshold while remaining entirely Y-only, and the toolbar condition removes the one-click whole-trace action from some partially zoomed viewports.

**Files Needing Attention:** web/src/features/traces/fns/timeline/viewport.ts; web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Zoom input] --> B{Rows at least 20px?}
  B -- No --> C[Zoom rows only]
  C --> D{Threshold crossed within factor?}
  D -- No --> A
  D -- Yes --> E[Remaining horizontal zoom is currently dropped]
  B -- Yes --> F[Zoom time and rows]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/traces/fns/timeline/viewport.ts:261-265
**Threshold crossing drops time zoom**

When an accumulated pinch or modifier-wheel factor takes rows from below 20px to above 20px, this starting-height check applies the entire factor only to Y. The zoom remaining after labels become readable is never applied to time, so equivalent gestures produce different horizontal zoom depending on frame batching and a fast gesture can leave the full clock visible.

### Issue 2
web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx:1327-1342
**Short rows hide Fit**

When a non-fitted viewport has rows shorter than the label threshold, `canShowLabels` replaces Fit even though the time window still covers only part of the trace. This removes the dedicated one-click route back to the whole-trace overview from that zoomed state.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): expand timeline rows to show ..."](https://github.com/langfuse/langfuse/commit/f5b4186a51ddada6cb666c41cea695c61d66806a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59620534)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->