### PR TITLE
test(web): regression tests for dialogs opened from dashboard row actions

### DIFF
--- a/web/src/features/dashboard/components/DashboardTable.edit-dialog.clienttest.tsx
+++ b/web/src/features/dashboard/components/DashboardTable.edit-dialog.clienttest.tsx
@@ -1,0 +1,162 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { LAYER_ORDER } from "@/src/components/ui/layer";
+
+const projectDashboardRow = {
+  id: "dashboard-1",
+  name: "My dashboard",
+  description: "A dashboard",
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-02T00:00:00Z"),
+  owner: "PROJECT" as const,
+};
+
+const langfuseDashboardRow = {
+  ...projectDashboardRow,
+  id: "dashboard-locked",
+  name: "Locked dashboard",
+  owner: "LANGFUSE" as const,
+};
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    dashboard: {
+      allDashboards: {
+        useQuery: () => ({
+          data: {
+            dashboards: [projectDashboardRow, langfuseDashboardRow],
+            totalCount: 2,
+          },
+          isError: false,
+          isPending: false,
+        }),
+      },
+      updateDashboardMetadata: {
+        useMutation: () => ({
+          isPending: false,
+          mutate: vi.fn(),
+          mutateAsync: vi.fn(async () => ({})),
+        }),
+      },
+      cloneDashboard: {
+        useMutation: () => ({
+          isPending: false,
+          mutate: vi.fn(),
+          mutateAsync: vi.fn(async () => ({})),
+        }),
+      },
+      delete: {
+        useMutation: () => ({
+          isPending: false,
+          mutate: vi.fn(),
+          mutateAsync: vi.fn(async () => ({})),
+        }),
+      },
+    },
+    useUtils: () => ({
+      dashboard: { invalidate: vi.fn() },
+    }),
+  },
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn(), query: { projectId: "project-1" } }),
+}));
+
+vi.mock("@/src/features/orderBy/hooks/useOrderByState", () => ({
+  useOrderByState: (initial: { column: string; order: string }) => [
+    initial,
+    vi.fn(),
+  ],
+}));
+
+vi.mock("use-query-params", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useQueryParams: () => [{ pageIndex: 0, pageSize: 50 }, vi.fn()],
+}));
+
+vi.mock("@/src/features/navigate-detail-pages/context", () => ({
+  useDetailPageLists: () => ({ setDetailPageList: vi.fn() }),
+}));
+
+vi.mock("@/src/features/posthog-analytics", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+vi.mock("@/src/features/rbac/utils/checkProjectAccess", () => ({
+  useHasProjectAccess: () => true,
+}));
+
+import { DashboardTable } from "./DashboardTable";
+
+const installOverlayLayers = () => {
+  const overlayRoot = document.createElement("div");
+  overlayRoot.setAttribute("data-overlay-root", "");
+  for (const layer of LAYER_ORDER) {
+    const layerNode = document.createElement("div");
+    layerNode.setAttribute("data-layer", layer);
+    overlayRoot.appendChild(layerNode);
+  }
+  document.body.appendChild(overlayRoot);
+};
+
+const openRowActionsMenu = async (rowIndex = 0) => {
+  const triggers = screen
+    .getAllByRole("button")
+    .filter((button) => button.getAttribute("aria-haspopup")?.includes("menu"));
+  expect(triggers.length).toBeGreaterThan(rowIndex);
+  const menuTrigger = triggers[rowIndex];
+  menuTrigger!.focus();
+  fireEvent.keyDown(menuTrigger!, { key: "Enter" });
+  await screen.findByRole("menu");
+};
+
+const assertMenuClosedAndDialogOpen = async (dialogName: RegExp) => {
+  // The menu closed, so its content unmounted. The dialog, rendered as a
+  // sibling of the menu, must still be up.
+  await waitFor(() => {
+    expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
+  });
+  expect(await screen.findByRole("dialog")).toHaveAccessibleName(dialogName);
+};
+
+describe("DashboardTable dialogs opened from row actions", () => {
+  beforeEach(() => {
+    installOverlayLayers();
+  });
+
+  afterEach(() => {
+    document.querySelector("[data-overlay-root]")?.remove();
+  });
+
+  it("keeps the edit dialog open after the row actions menu closes", async () => {
+    render(<DashboardTable />);
+
+    await openRowActionsMenu(0);
+    fireEvent.click(await screen.findByRole("menuitem", { name: /edit/i }));
+
+    await assertMenuClosedAndDialogOpen(/edit dashboard/i);
+
+    // The dialog is not just visible, it is editable.
+    const nameInput = await screen.findByRole("textbox", { name: /name/i });
+    expect(nameInput).toBeEnabled();
+  });
+
+  it("keeps the clone-first dialog open after the row actions menu closes", async () => {
+    render(<DashboardTable />);
+
+    // The Langfuse-owned (locked) row is second in the table.
+    await openRowActionsMenu(1);
+    fireEvent.click(await screen.findByRole("menuitem", { name: /edit/i }));
+
+    await assertMenuClosedAndDialogOpen(/create your editable copy/i);
+  });
+
+  it("keeps the delete dialog open after the row actions menu closes", async () => {
+    render(<DashboardTable />);
+
+    await openRowActionsMenu(0);
+    fireEvent.click(await screen.findByRole("menuitem", { name: /delete/i }));
+
+    await assertMenuClosedAndDialogOpen(/delete dashboard/i);
+  });
+});


### PR DESCRIPTION
TL;DR: adds client tests locking the "dialogs opened from a row actions menu stay open after the menu closes" behavior across the edit, clone-first and delete flows.

## Context

#16969 moved the dashboard table's edit, clone-first and delete dialogs out of the dropdown content so that closing the menu can no longer unmount a freshly opened dialog. #16970 (closed as a duplicate) had reported the same unmount bug with the same diagnosis; the maintainer's feedback confirmed the approach. #16969 merged without a regression test, so the invariant the fix established is currently unguarded.

## What the tests cover

`DashboardTable.edit-dialog.clienttest.tsx` renders the real `DashboardTable` (mocked tRPC + router), opens a row actions menu, picks an item, and asserts after the menu content unmounts that:

1. the **edit** dialog is still up with a usable name input (project-owned row),
2. the **clone-first** dialog is still up (Langfuse-owned row, Edit attempt),
3. the **delete** dialog is still up.

All three assert via accessible names (`toHaveAccessibleName`), so they survive cosmetic refactors and would fail if a dialog were ever re-rendered inside the menu content again.

## Evidence

```
RUN  v4.1.10 web
✓ |client| src/features/dashboard/components/DashboardTable.edit-dialog.clienttest.tsx (3 tests) 1026ms
Test Files  1 passed (1)
     Tests  3 passed (3)
```

Run with: `pnpm --filter web run test-client src/features/dashboard/components/DashboardTable.edit-dialog.clienttest.tsx`

ESLint clean on the file. Note: `pnpm --filter web run typecheck` currently reports pre-existing TS7006 errors in `src/utils/chatml/jumptoplayground.clienttest.ts` on main; this PR touches no file outside the new test.

CLA is signed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds focused client regression coverage ensuring dashboard edit, managed-dashboard clone-first, and delete dialogs remain mounted after their originating row-actions menu closes.

- Renders the real `DashboardTable` with mocked query, mutation, routing, and access dependencies.
- Exercises project-owned and Langfuse-managed dashboard action flows.
- Verifies the menu unmounts while each selected dialog remains accessible and usable.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking import-organization issue to address.

The new tests correctly exercise all three dashboard row-action dialog paths, and the only accepted concern is that the component import is placed below top-level declarations.

**Files Needing Attention:** web/src/features/dashboard/components/DashboardTable.edit-dialog.clienttest.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/dashboard/components/DashboardTable.edit-dialog.clienttest.tsx:74
**Component import breaks grouping**

The `DashboardTable` import appears after the fixtures and mock declarations instead of in the module's top import block, obscuring the file's dependencies and violating the repository's required import organization.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(web): lock dialog open behavior aft..."](https://github.com/langfuse/langfuse/commit/a88c792260fad375cf8104676b853a977328ff4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59628216)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->