### PR TITLE
refactor(ingestion): total order for trace/observation same-timestamp merges

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1240,22 +1240,34 @@ export class IngestionService {
   private static toTimeSortedEventList<
     T extends TraceEventType | ObservationEvent,
   >(eventList: T[]): T[] {
-    return eventList.slice().sort((a, b) => {
-      const aTimestamp = new Date(a.timestamp).getTime();
-      const bTimestamp = new Date(b.timestamp).getTime();
+    // The merge folds this list left to right with a last-wins overwrite, so
+    // the winner for any group is whichever event sorts last. Events arrive in
+    // upload order (the queue processor lists files by upload time), captured
+    // here as the arrival index and used as the tie-break so the ordering is a
+    // total order rather than relying on the sort engine's handling of ties.
+    return eventList
+      .map((event, index) => ({ event, index }))
+      .sort((a, b) => {
+        const aTimestamp = new Date(a.event.timestamp).getTime();
+        const bTimestamp = new Date(b.event.timestamp).getTime();
+        if (aTimestamp !== bTimestamp) return aTimestamp - bTimestamp;
 
-      if (aTimestamp === bTimestamp) {
-        // Creates sort before updates. For two tied creates this is not a
-        // total order: V8 places the later-arriving one first, so the
-        // first-arriving create wins the merge. OTel relies on that: a root
-        // span's trace-create and a child span's trace update share the span
-        // start time, and the child's explicit fields must beat the root's
-        // derived ones. Score events use their own stable sort instead.
-        return a.type.includes("create") ? -1 : 1;
-      }
+        const aIsCreate = a.event.type.includes("create");
+        const bIsCreate = b.event.type.includes("create");
+        // Creates sort before updates, so an update at the same timestamp wins.
+        if (aIsCreate !== bIsCreate) return aIsCreate ? -1 : 1;
 
-      return aTimestamp - bTimestamp;
-    });
+        // Tied creates: the first-arriving one wins. OTel emits a root span's
+        // trace-create and a child span's trace-create carrying explicit
+        // update_current_trace() values at the same span start time; the child
+        // arrives first and its explicit fields must beat the root's derived
+        // ones. Placing the earlier arrival last makes it win the merge.
+        if (aIsCreate) return b.index - a.index;
+
+        // Tied updates: the last-arriving one wins.
+        return a.index - b.index;
+      })
+      .map(({ event }) => event);
   }
 
   private async getPrompt(

--- a/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
@@ -506,6 +506,31 @@ describe("IngestionService unit tests", () => {
     ).toEqual([second, first]);
   });
 
+  it("keeps the last-arriving of tied update events last so it wins the merge", () => {
+    const first = { timestamp: 1, type: "trace-update", id: "first" };
+    const second = { timestamp: 1, type: "trace-update", id: "second" };
+
+    expect(
+      (IngestionService as any).toTimeSortedEventList([first, second]),
+    ).toEqual([first, second]);
+  });
+
+  it("orders a mixed run of tied creates and updates deterministically", () => {
+    // Creates sort before updates so the update wins the merge, and among the
+    // tied creates the first-arriving one sorts last.
+    const firstCreate = { timestamp: 1, type: "trace-create", id: "c0" };
+    const update = { timestamp: 1, type: "trace-update", id: "u1" };
+    const secondCreate = { timestamp: 1, type: "trace-create", id: "c2" };
+
+    expect(
+      (IngestionService as any).toTimeSortedEventList([
+        firstCreate,
+        update,
+        secondCreate,
+      ]),
+    ).toEqual([secondCreate, firstCreate, update]);
+  });
+
   it("correctly convert Date to Clickhouse DateTime", async () => {
     const date = new Date("2024-10-12T12:13:14.123Z");
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16979 app preview](https://pr-16979.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Builds on #16925. That PR sorts listed event files by upload time and gives
scores their own stable timestamp sort, but leaves `toTimeSortedEventList`
(traces and observations) resolving same-timestamp ties with a comparator that
never returns `0`:

```ts
if (aTimestamp === bTimestamp) {
  return a.type.includes("create") ? -1 : 1;
}
```

That is not a valid total order. A run of tied creates happens to reverse under
V8 (first arrival wins, which the OTel root-vs-child case relies on), but an
interleaved same-timestamp `create / update / create` run has no defined winner
— the result depends on the sort engine's handling of the invalid comparator,
not on a specified order.

The comparator becomes an explicit total order,
`(timestamp asc, create-before-update, arrival index)`. Arrival index is upload
order (the queue processor now lists files by upload time), so ties are broken
deterministically and engine-independently:

- tied creates → first-arriving wins (preserves the OTel guarantee: a root
  span's `trace-create` and a child span's `trace-create` carrying
  `update_current_trace()` values share the span start time, and the child's
  explicit fields must beat the root's derived ones)
- tied updates → last-arriving wins
- mixed same-timestamp runs → deterministic winner

Observable outcomes are unchanged for every previously-defined case; this makes
the ordering robust and self-documenting rather than reliant on sort-engine
internals.

New unit tests: tied updates keep last-arrival-wins, and a mixed
`create / update / create` run is pinned to a deterministic order.

## Type of change

- [x] Refactor (non-breaking change that preserves observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue): defines ordering for
      previously-undefined mixed same-timestamp runs

## Verification

- `pnpm --filter worker run test IngestionService.unit.test.ts` → `Tests 21 passed (21)`
- `pnpm turbo run lint typecheck --filter=worker` → `Tasks: 5 successful, 5 total`

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces an invalid same-timestamp comparator with an explicit total order while preserving the established merge winners.
- Sorts events by timestamp, create-before-update precedence, and arrival index.
- Preserves first-arriving-wins for tied creates and last-arriving-wins for tied updates.
- Adds unit coverage for tied updates and mixed create/update runs.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The comparator defines deterministic ordering for the previously undefined mixed-event case while retaining the established winners for tied creates and updates.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(ingestion): make trace/observat..."](https://github.com/langfuse/langfuse/commit/0c3b281b32ab043a110ac39e2140767d07a32a7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59631428)</sub>

<!-- /greptile_comment -->