### PR TITLE
perf(web-callouts): bound observation lookups by trace timestamp

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -17,6 +17,7 @@ import {
 } from "../clickhouse/client";
 import { recordDistribution } from "../instrumentation";
 import { logger } from "../logger";
+import { OBSERVATIONS_TO_TRACE_INTERVAL } from "./constants";
 import {
   convertClickhouseToDomain,
   convertClickhouseTracesListToDomain,
@@ -921,6 +922,7 @@ export const getObservationByIdFromEventsTable = async ({
   projectId,
   fetchWithInputOutput = false,
   startTime,
+  startTimeLowerBound,
   type,
   traceId,
   renderingProps = DEFAULT_RENDERING_PROPS,
@@ -930,6 +932,7 @@ export const getObservationByIdFromEventsTable = async ({
   projectId: string;
   fetchWithInputOutput?: boolean;
   startTime?: Date;
+  startTimeLowerBound?: Date;
   type?: ObservationType;
   traceId?: string;
   renderingProps?: RenderingProps;
@@ -940,6 +943,7 @@ export const getObservationByIdFromEventsTable = async ({
     projectId,
     fetchWithInputOutput,
     startTime,
+    startTimeLowerBound,
     type,
     traceId,
     renderingProps,
@@ -988,6 +992,7 @@ async function getObservationByIdFromEventsTableInternal({
   projectId,
   fetchWithInputOutput = false,
   startTime,
+  startTimeLowerBound,
   type,
   traceId,
   renderingProps = DEFAULT_RENDERING_PROPS,
@@ -997,6 +1002,7 @@ async function getObservationByIdFromEventsTableInternal({
   projectId: string;
   fetchWithInputOutput?: boolean;
   startTime?: Date;
+  startTimeLowerBound?: Date;
   type?: ObservationType;
   traceId?: string;
   renderingProps?: RenderingProps;
@@ -1015,6 +1021,19 @@ async function getObservationByIdFromEventsTableInternal({
       b.whereRaw("toDate(start_time) = toDate({startTime: DateTime64(3)})", {
         startTime: convertDateToClickhouseDateTime(startTime!),
       }),
+    )
+    // Lower-bound start_time on an anchor (e.g. the parent trace's timestamp) so
+    // the lookup can prune events_full parts/partitions. Subtract the skew
+    // interval because an observation may start slightly before its anchor.
+    .when(Boolean(startTimeLowerBound), (b) =>
+      b.whereRaw(
+        `start_time >= {startTimeLowerBound: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}`,
+        {
+          startTimeLowerBound: convertDateToClickhouseDateTime(
+            startTimeLowerBound!,
+          ),
+        },
+      ),
     )
     .when(Boolean(type), (b) => b.whereRaw("type = {type: String}", { type }))
     .when(Boolean(traceId), (b) =>

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -333,6 +333,7 @@ export const getObservationByIdFromObservationsTable = async ({
   projectId,
   fetchWithInputOutput = false,
   startTime,
+  startTimeLowerBound,
   type,
   traceId,
   renderingProps = DEFAULT_RENDERING_PROPS,
@@ -342,6 +343,7 @@ export const getObservationByIdFromObservationsTable = async ({
   projectId: string;
   fetchWithInputOutput?: boolean;
   startTime?: Date;
+  startTimeLowerBound?: Date;
   type?: ObservationType;
   traceId?: string;
   renderingProps?: RenderingProps;
@@ -352,6 +354,7 @@ export const getObservationByIdFromObservationsTable = async ({
     projectId,
     fetchWithInputOutput,
     startTime,
+    startTimeLowerBound,
     type,
     traceId,
     renderingProps,
@@ -442,6 +445,7 @@ const getObservationByIdInternal = async ({
   projectId,
   fetchWithInputOutput = false,
   startTime,
+  startTimeLowerBound,
   type,
   traceId,
   renderingProps = DEFAULT_RENDERING_PROPS,
@@ -451,6 +455,7 @@ const getObservationByIdInternal = async ({
   projectId: string;
   fetchWithInputOutput?: boolean;
   startTime?: Date;
+  startTimeLowerBound?: Date;
   type?: ObservationType;
   traceId?: string;
   renderingProps?: RenderingProps;
@@ -496,6 +501,7 @@ const getObservationByIdInternal = async ({
   WHERE id = {id: String}
   AND project_id = {projectId: String}
   ${startTime ? `AND toDate(start_time) = toDate({startTime: DateTime64(3)})` : ""}
+  ${startTimeLowerBound ? `AND start_time >= {startTimeLowerBound: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}` : ""}
   ${type ? `AND type = {type: String}` : ""}
   ${traceId ? `AND trace_id = {traceId: String}` : ""}
   ORDER BY event_ts desc
@@ -507,6 +513,12 @@ const getObservationByIdInternal = async ({
       projectId,
       ...(startTime
         ? { startTime: convertDateToClickhouseDateTime(startTime) }
+        : {}),
+      ...(startTimeLowerBound
+        ? {
+            startTimeLowerBound:
+              convertDateToClickhouseDateTime(startTimeLowerBound),
+          }
         : {}),
       ...(traceId ? { traceId } : {}),
     },

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -867,6 +867,56 @@ describe("Clickhouse Events Repository Test", () => {
     });
   });
 
+  maybe("getObservationByIdFromEventsTable startTimeLowerBound", () => {
+    const DAY_MS = 24 * 60 * 60 * 1000;
+
+    it("prunes on start_time while absorbing trace-to-observation skew", async () => {
+      const traceId = randomUUID();
+      const observationId = randomUUID();
+      const observationStart = Date.now() - 5 * DAY_MS;
+
+      await createEventsCh([
+        createEvent({
+          id: observationId,
+          span_id: observationId,
+          project_id: projectId,
+          trace_id: traceId,
+          type: "GENERATION",
+          start_time: observationStart,
+        }),
+      ]);
+
+      const atStart = await getObservationByIdFromEventsTable({
+        id: observationId,
+        projectId,
+        traceId,
+        startTimeLowerBound: new Date(observationStart),
+      });
+      expect(atStart?.id).toBe(observationId);
+
+      // Anchor one day after start (e.g. a trace whose timestamp trails the
+      // observation): still returned because the 2-day skew lookback covers it.
+      const withinSkew = await getObservationByIdFromEventsTable({
+        id: observationId,
+        projectId,
+        traceId,
+        startTimeLowerBound: new Date(observationStart + DAY_MS),
+      });
+      expect(withinSkew?.id).toBe(observationId);
+
+      // Anchor three days after start: the lower bound (anchor - 2 days) now
+      // excludes the observation, proving the bound actually prunes.
+      await expect(
+        getObservationByIdFromEventsTable({
+          id: observationId,
+          projectId,
+          traceId,
+          startTimeLowerBound: new Date(observationStart + 3 * DAY_MS),
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
   maybe("getObservationsCountFromEventsTable", () => {
     it("should return 0 for non-existent project", async () => {
       const nonExistentProjectId = randomUUID();

--- a/web/src/__tests__/server/web-callouts-trpc.servertest.ts
+++ b/web/src/__tests__/server/web-callouts-trpc.servertest.ts
@@ -60,10 +60,12 @@ const buildSession = ({
   orgId,
   projectId,
   projectRole = "ADMIN",
+  v4BetaEnabled = false,
 }: {
   orgId: string;
   projectId: string;
   projectRole?: "ADMIN" | "MEMBER" | "NONE" | "OWNER" | "VIEWER";
+  v4BetaEnabled?: boolean;
 }): Session => ({
   expires: "1",
   user: {
@@ -103,7 +105,7 @@ const buildSession = ({
       experimentsV4Enabled: false,
     },
     admin: false,
-    v4BetaEnabled: false,
+    v4BetaEnabled,
   },
   environment: {} as any,
 });
@@ -268,15 +270,17 @@ const createPrismaStub = () => {
 
 const prepare = async ({
   projectRole = "ADMIN",
+  v4BetaEnabled = false,
 }: {
   projectRole?: "ADMIN" | "MEMBER" | "NONE" | "OWNER" | "VIEWER";
+  v4BetaEnabled?: boolean;
 } = {}) => {
   const orgId = "org-1";
   const projectId = "project-1";
   const prismaStub = createPrismaStub();
 
   const ctx = createInnerTRPCContext({
-    session: buildSession({ orgId, projectId, projectRole }),
+    session: buildSession({ orgId, projectId, projectRole, v4BetaEnabled }),
     headers: {},
   });
 
@@ -745,6 +749,44 @@ describe("webCallouts router", () => {
     expect(
       (getObservationById as Mock).mock.calls[0][0].startTimeLowerBound,
     ).toEqual(traceTimestamp);
+  });
+
+  it("still widens the bound when an earlier source in the chain transient-errors but a later one cleanly misses", async () => {
+    const { caller, projectId } = await prepare({ v4BetaEnabled: true });
+    const traceTimestamp = new Date("2099-01-01T00:00:00.000Z");
+    (getTraceByIdFromEventsTable as Mock).mockResolvedValue({
+      id: "trace-1",
+      sessionId: null,
+      timestamp: traceTimestamp,
+    });
+    // Bounded pass: the events-table lookup transient-errors, then the legacy
+    // lookup cleanly misses. The transient error on the earlier source must not
+    // suppress the unbounded retry, which finds the backfilled observation.
+    (getObservationByIdFromEventsTable as Mock)
+      .mockRejectedValueOnce(new Error("ClickHouse timeout"))
+      .mockResolvedValue({
+        id: "observation-1",
+        traceId: "trace-1",
+        sessionId: null,
+      });
+    (getObservationById as Mock).mockResolvedValue(undefined);
+    await createEndpoint(caller, projectId);
+
+    await expect(
+      caller.webCallouts.invoke({
+        projectId,
+        traceId: "trace-1",
+        observationId: "observation-1",
+        sessionId: null,
+      }),
+    ).resolves.toEqual({ success: true, status: 204 });
+
+    // Two events-table calls: the bounded transient error, then the unbounded
+    // retry that succeeds.
+    expect(getObservationByIdFromEventsTable).toHaveBeenCalledTimes(2);
+    const eventsCalls = (getObservationByIdFromEventsTable as Mock).mock.calls;
+    expect(eventsCalls[0][0].startTimeLowerBound).toEqual(traceTimestamp);
+    expect(eventsCalls[1][0].startTimeLowerBound).toBeUndefined();
   });
 
   it("rate limits before target validation and outbound delivery", async () => {

--- a/web/src/__tests__/server/web-callouts-trpc.servertest.ts
+++ b/web/src/__tests__/server/web-callouts-trpc.servertest.ts
@@ -781,8 +781,45 @@ describe("webCallouts router", () => {
       }),
     ).resolves.toEqual({ success: true, status: 204 });
 
-    // Two events-table calls: the bounded transient error, then the unbounded
-    // retry that succeeds.
+    expect(getObservationByIdFromEventsTable).toHaveBeenCalledTimes(2);
+    const eventsCalls = (getObservationByIdFromEventsTable as Mock).mock.calls;
+    expect(eventsCalls[0][0].startTimeLowerBound).toEqual(traceTimestamp);
+    expect(eventsCalls[1][0].startTimeLowerBound).toBeUndefined();
+  });
+
+  it("still widens the bound when an earlier source cleanly misses but a later one transient-errors", async () => {
+    const { caller, projectId } = await prepare({ v4BetaEnabled: true });
+    const traceTimestamp = new Date("2099-01-01T00:00:00.000Z");
+    (getTraceByIdFromEventsTable as Mock).mockResolvedValue({
+      id: "trace-1",
+      sessionId: null,
+      timestamp: traceTimestamp,
+    });
+    // Bounded pass: the events-table lookup cleanly misses, then the legacy
+    // lookup transient-errors. The later transient error must not discard the
+    // earlier clean-miss signal — the unbounded retry still runs and finds the
+    // backfilled observation via the events table.
+    (getObservationByIdFromEventsTable as Mock)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValue({
+        id: "observation-1",
+        traceId: "trace-1",
+        sessionId: null,
+      });
+    (getObservationById as Mock).mockRejectedValue(
+      new Error("ClickHouse timeout"),
+    );
+    await createEndpoint(caller, projectId);
+
+    await expect(
+      caller.webCallouts.invoke({
+        projectId,
+        traceId: "trace-1",
+        observationId: "observation-1",
+        sessionId: null,
+      }),
+    ).resolves.toEqual({ success: true, status: 204 });
+
     expect(getObservationByIdFromEventsTable).toHaveBeenCalledTimes(2);
     const eventsCalls = (getObservationByIdFromEventsTable as Mock).mock.calls;
     expect(eventsCalls[0][0].startTimeLowerBound).toEqual(traceTimestamp);

--- a/web/src/__tests__/server/web-callouts-trpc.servertest.ts
+++ b/web/src/__tests__/server/web-callouts-trpc.servertest.ts
@@ -257,12 +257,6 @@ const createPrismaStub = () => {
         },
       ),
     },
-    project: {
-      findUnique: vi.fn(async ({ where }: { where: { id: string } }) => ({
-        id: where.id,
-        createdAt: new Date("2020-01-01T00:00:00.000Z"),
-      })),
-    },
   };
 
   return {
@@ -717,12 +711,9 @@ describe("webCallouts router", () => {
     expect(getObservationById).toHaveBeenCalledTimes(2);
     const calls = (getObservationById as Mock).mock.calls;
     expect(calls[0][0].startTimeLowerBound).toEqual(traceTimestamp);
-    // Widened retry floors at project.createdAt (2020-01-01) minus the one-week
-    // safety buffer.
-    const oneWeekMs = 7 * 24 * 60 * 60 * 1000;
-    expect(calls[1][0].startTimeLowerBound).toEqual(
-      new Date(new Date("2020-01-01T00:00:00.000Z").getTime() - oneWeekMs),
-    );
+    // No safe lower bound exists on a miss (legitimate backfills predate any
+    // project-derived floor), so the retry is unbounded.
+    expect(calls[1][0].startTimeLowerBound).toBeUndefined();
   });
 
   it("rate limits before target validation and outbound delivery", async () => {

--- a/web/src/__tests__/server/web-callouts-trpc.servertest.ts
+++ b/web/src/__tests__/server/web-callouts-trpc.servertest.ts
@@ -257,6 +257,12 @@ const createPrismaStub = () => {
         },
       ),
     },
+    project: {
+      findUnique: vi.fn(async ({ where }: { where: { id: string } }) => ({
+        id: where.id,
+        createdAt: new Date("2020-01-01T00:00:00.000Z"),
+      })),
+    },
   };
 
   return {
@@ -676,6 +682,43 @@ describe("webCallouts router", () => {
         userId: "user-1",
       },
       expect.any(Function),
+    );
+  });
+
+  it("widens the observation lookup bound when the trace timestamp misses it", async () => {
+    const { caller, projectId } = await prepare();
+    const traceTimestamp = new Date("2099-01-01T00:00:00.000Z");
+    (getTraceById as Mock).mockResolvedValue({
+      id: "trace-1",
+      sessionId: null,
+      timestamp: traceTimestamp,
+    });
+    // A trace whose timestamp sits far after the observation's start_time: the
+    // first lookup, bounded by that timestamp, misses; the widened retry finds
+    // it, so validation must succeed rather than 404.
+    (getObservationById as Mock)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValue({
+        id: "observation-1",
+        traceId: "trace-1",
+        sessionId: null,
+      });
+    await createEndpoint(caller, projectId);
+
+    await expect(
+      caller.webCallouts.invoke({
+        projectId,
+        traceId: "trace-1",
+        observationId: "observation-1",
+        sessionId: null,
+      }),
+    ).resolves.toEqual({ success: true, status: 204 });
+
+    expect(getObservationById).toHaveBeenCalledTimes(2);
+    const calls = (getObservationById as Mock).mock.calls;
+    expect(calls[0][0].startTimeLowerBound).toEqual(traceTimestamp);
+    expect(calls[1][0].startTimeLowerBound).toEqual(
+      new Date("2020-01-01T00:00:00.000Z"),
     );
   });
 

--- a/web/src/__tests__/server/web-callouts-trpc.servertest.ts
+++ b/web/src/__tests__/server/web-callouts-trpc.servertest.ts
@@ -716,6 +716,37 @@ describe("webCallouts router", () => {
     expect(calls[1][0].startTimeLowerBound).toBeUndefined();
   });
 
+  it("does not widen the observation lookup bound when the bounded lookup errors", async () => {
+    const { caller, projectId } = await prepare();
+    const traceTimestamp = new Date("2099-01-01T00:00:00.000Z");
+    (getTraceById as Mock).mockResolvedValue({
+      id: "trace-1",
+      sessionId: null,
+      timestamp: traceTimestamp,
+    });
+    // A transient failure (e.g. a ClickHouse timeout) must not be mistaken for a
+    // genuine miss: retrying unbounded would issue a second expensive scan while
+    // the backend is already struggling. Validation fails fast to a 404 instead.
+    (getObservationById as Mock).mockRejectedValue(
+      new Error("ClickHouse timeout"),
+    );
+    await createEndpoint(caller, projectId);
+
+    await expect(
+      caller.webCallouts.invoke({
+        projectId,
+        traceId: "trace-1",
+        observationId: "observation-1",
+        sessionId: null,
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    expect(getObservationById).toHaveBeenCalledTimes(1);
+    expect(
+      (getObservationById as Mock).mock.calls[0][0].startTimeLowerBound,
+    ).toEqual(traceTimestamp);
+  });
+
   it("rate limits before target validation and outbound delivery", async () => {
     const { caller, projectId } = await prepare();
     await createEndpoint(caller, projectId);

--- a/web/src/__tests__/server/web-callouts-trpc.servertest.ts
+++ b/web/src/__tests__/server/web-callouts-trpc.servertest.ts
@@ -717,8 +717,11 @@ describe("webCallouts router", () => {
     expect(getObservationById).toHaveBeenCalledTimes(2);
     const calls = (getObservationById as Mock).mock.calls;
     expect(calls[0][0].startTimeLowerBound).toEqual(traceTimestamp);
+    // Widened retry floors at project.createdAt (2020-01-01) minus the one-week
+    // safety buffer.
+    const oneWeekMs = 7 * 24 * 60 * 60 * 1000;
     expect(calls[1][0].startTimeLowerBound).toEqual(
-      new Date("2020-01-01T00:00:00.000Z"),
+      new Date(new Date("2020-01-01T00:00:00.000Z").getTime() - oneWeekMs),
     );
   });
 

--- a/web/src/features/web-callouts/server/targetValidation.ts
+++ b/web/src/features/web-callouts/server/targetValidation.ts
@@ -57,6 +57,9 @@ export const assertTargetBelongsToProject = async ({
       traceId: input.traceId,
       projectId: input.projectId,
       useEventsTable,
+      // The observation belongs to this trace, so the trace timestamp is a tight
+      // lower bound for its start_time and lets the lookup prune events_full.
+      startTimeLowerBound: trace?.timestamp,
     });
 
     if (!observation) {
@@ -120,17 +123,20 @@ const getObservationForProject = async ({
   traceId,
   projectId,
   useEventsTable,
+  startTimeLowerBound,
 }: {
   observationId: string;
   traceId: string;
   projectId: string;
   useEventsTable: boolean;
+  startTimeLowerBound?: Date;
 }) => {
   if (useEventsTable) {
     const observation = await tryGetObservationFromEvents({
       observationId,
       traceId,
       projectId,
+      startTimeLowerBound,
     });
     if (observation) return observation;
   }
@@ -139,11 +145,17 @@ const getObservationForProject = async ({
     observationId,
     traceId,
     projectId,
+    startTimeLowerBound,
   });
   if (observation) return observation;
 
   if (shouldTryEventsTableFallback(useEventsTable)) {
-    return tryGetObservationFromEvents({ observationId, traceId, projectId });
+    return tryGetObservationFromEvents({
+      observationId,
+      traceId,
+      projectId,
+      startTimeLowerBound,
+    });
   }
 
   return undefined;
@@ -204,10 +216,12 @@ const tryGetObservation = async ({
   observationId,
   traceId,
   projectId,
+  startTimeLowerBound,
 }: {
   observationId: string;
   traceId: string;
   projectId: string;
+  startTimeLowerBound?: Date;
 }) => {
   try {
     // eslint-disable-next-line @typescript-eslint/no-deprecated -- Per customer requirement, web callouts should also work on v3.
@@ -215,6 +229,7 @@ const tryGetObservation = async ({
       id: observationId,
       projectId,
       traceId,
+      startTimeLowerBound,
       fetchWithInputOutput: false,
       renderingProps: {
         truncated: true,
@@ -230,16 +245,19 @@ const tryGetObservationFromEvents = async ({
   observationId,
   traceId,
   projectId,
+  startTimeLowerBound,
 }: {
   observationId: string;
   traceId: string;
   projectId: string;
+  startTimeLowerBound?: Date;
 }) => {
   try {
     return await getObservationByIdFromEventsTable({
       id: observationId,
       projectId,
       traceId,
+      startTimeLowerBound,
       fetchWithInputOutput: false,
       renderingProps: {
         truncated: true,

--- a/web/src/features/web-callouts/server/targetValidation.ts
+++ b/web/src/features/web-callouts/server/targetValidation.ts
@@ -192,8 +192,12 @@ const runObservationLookup = async ({
 }): Promise<ObservationLookupResult> => {
   let transientError = false;
 
+  // Track only the deciding (last-run) lookup's status, not an OR across the
+  // whole chain: an earlier source's transient failure must not suppress the
+  // unbounded retry when a later source cleanly misses (a genuine not-found),
+  // which would wrongly reject a valid observation outside the bound.
   const consider = (result: ObservationLookupResult) => {
-    if (result.transientError) transientError = true;
+    transientError = result.transientError;
     return result.observation;
   };
 

--- a/web/src/features/web-callouts/server/targetValidation.ts
+++ b/web/src/features/web-callouts/server/targetValidation.ts
@@ -13,6 +13,12 @@ import {
   logger,
 } from "@langfuse/shared/src/server";
 
+// Safety buffer below project.createdAt for the widened observation lookup:
+// tolerates observations stamped shortly before the project row was created
+// (clock skew / near-creation ingestion). createdAt is immutable, so the
+// resulting bound is stable across the project's lifetime.
+const PROJECT_CREATED_AT_SAFETY_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+
 export const assertTargetBelongsToProject = async ({
   prisma,
   input,
@@ -77,7 +83,12 @@ export const assertTargetBelongsToProject = async ({
       });
       observation = await getObservationForProject({
         ...observationLookup,
-        startTimeLowerBound: project?.createdAt,
+        startTimeLowerBound: project
+          ? new Date(
+              project.createdAt.getTime() -
+                PROJECT_CREATED_AT_SAFETY_INTERVAL_MS,
+            )
+          : undefined,
       });
     }
 

--- a/web/src/features/web-callouts/server/targetValidation.ts
+++ b/web/src/features/web-callouts/server/targetValidation.ts
@@ -13,12 +13,6 @@ import {
   logger,
 } from "@langfuse/shared/src/server";
 
-// Safety buffer below project.createdAt for the widened observation lookup:
-// tolerates observations stamped shortly before the project row was created
-// (clock skew / near-creation ingestion). createdAt is immutable, so the
-// resulting bound is stable across the project's lifetime.
-const PROJECT_CREATED_AT_SAFETY_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
-
 export const assertTargetBelongsToProject = async ({
   prisma,
   input,
@@ -74,21 +68,15 @@ export const assertTargetBelongsToProject = async ({
 
     // trace.timestamp is an independent SDK-supplied field that can be set later
     // than a child observation's start_time (no ingestion invariant couples
-    // them). On a miss, widen the bound to the project creation time so a valid
-    // observation is never wrongly reported missing while queries stay bounded.
+    // them), and legitimate backfills mean an observation can be arbitrarily
+    // older than any project-derived floor. So there is no safe lower bound to
+    // fall back to: on a miss, retry unbounded to avoid wrongly reporting a
+    // valid observation as missing. This runs only on a miss, so the tight
+    // trace-timestamp bound still serves the common path.
     if (!observation && trace?.timestamp) {
-      const project = await prisma.project.findUnique({
-        where: { id: input.projectId },
-        select: { createdAt: true },
-      });
       observation = await getObservationForProject({
         ...observationLookup,
-        startTimeLowerBound: project
-          ? new Date(
-              project.createdAt.getTime() -
-                PROJECT_CREATED_AT_SAFETY_INTERVAL_MS,
-            )
-          : undefined,
+        startTimeLowerBound: undefined,
       });
     }
 

--- a/web/src/features/web-callouts/server/targetValidation.ts
+++ b/web/src/features/web-callouts/server/targetValidation.ts
@@ -128,12 +128,21 @@ const getTraceForProject = async ({
 // events-table getters, whose full return shapes differ.
 type WebCalloutObservation = { id: string };
 
-// A lookup either resolves to an observation, a genuine not-found (undefined
-// observation, transientError false), or a transient failure (transientError
-// true) that the helpers swallow so the caller can decide whether to retry.
+// A single-source lookup either resolves to an observation, a genuine not-found
+// (undefined observation, transientError false), or a transient failure
+// (transientError true) that the helpers swallow so the caller can decide
+// whether to retry.
 type ObservationLookupResult = {
   observation?: WebCalloutObservation;
   transientError: boolean;
+};
+
+// The aggregate result of running the source chain at one bound. cleanMiss is
+// true when at least one source returned a genuine not-found under the bound —
+// the signal that an unbounded retry is worthwhile.
+type ObservationChainResult = {
+  observation?: WebCalloutObservation;
+  cleanMiss: boolean;
 };
 
 const getObservationForProject = async ({
@@ -158,12 +167,13 @@ const getObservationForProject = async ({
   });
   if (bounded.observation) return bounded.observation;
 
-  // Retry unbounded only on a genuine miss. The lookup helpers swallow transient
-  // failures (timeout, ClickHouse unavailable) into the same empty result as a
-  // real not-found; retrying then would issue a second expensive unbounded scan
-  // exactly when the backend is already struggling. On a transient error, fail
-  // fast instead — matching the pre-bounding behavior.
-  if (startTimeLowerBound && !bounded.transientError) {
+  // Retry unbounded only when at least one bounded source produced a genuine
+  // clean miss: the observation could legitimately be older than the bound
+  // (backfills, or trace.timestamp post-dating a child observation). If every
+  // source instead transient-errored (timeout, ClickHouse unavailable) the
+  // bounded pass told us nothing, so skip the second expensive unbounded scan
+  // and fail fast — matching the pre-bounding behavior.
+  if (startTimeLowerBound && bounded.cleanMiss) {
     const unbounded = await runObservationLookup({
       observationId,
       traceId,
@@ -189,15 +199,16 @@ const runObservationLookup = async ({
   projectId: string;
   useEventsTable: boolean;
   startTimeLowerBound?: Date;
-}): Promise<ObservationLookupResult> => {
-  let transientError = false;
+}): Promise<ObservationChainResult> => {
+  // Remember a genuine clean miss from any source, even if a later source in the
+  // chain transient-errors: the earlier clean miss still means the observation
+  // could exist outside the bound, so the unbounded retry must stay eligible.
+  let cleanMiss = false;
 
-  // Track only the deciding (last-run) lookup's status, not an OR across the
-  // whole chain: an earlier source's transient failure must not suppress the
-  // unbounded retry when a later source cleanly misses (a genuine not-found),
-  // which would wrongly reject a valid observation outside the bound.
   const consider = (result: ObservationLookupResult) => {
-    transientError = result.transientError;
+    if (!result.observation && !result.transientError) {
+      cleanMiss = true;
+    }
     return result.observation;
   };
 
@@ -210,7 +221,7 @@ const runObservationLookup = async ({
         startTimeLowerBound,
       }),
     );
-    if (observation) return { observation, transientError };
+    if (observation) return { observation, cleanMiss };
   }
 
   const observation = consider(
@@ -221,7 +232,7 @@ const runObservationLookup = async ({
       startTimeLowerBound,
     }),
   );
-  if (observation) return { observation, transientError };
+  if (observation) return { observation, cleanMiss };
 
   if (shouldTryEventsTableFallback(useEventsTable)) {
     const fallback = consider(
@@ -232,10 +243,10 @@ const runObservationLookup = async ({
         startTimeLowerBound,
       }),
     );
-    if (fallback) return { observation: fallback, transientError };
+    if (fallback) return { observation: fallback, cleanMiss };
   }
 
-  return { transientError };
+  return { cleanMiss };
 };
 
 const tryGetTrace = async ({

--- a/web/src/features/web-callouts/server/targetValidation.ts
+++ b/web/src/features/web-callouts/server/targetValidation.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 
 import { env } from "@/src/env.mjs";
 import { type WebCalloutInvokeInput } from "@/src/features/web-callouts/types";
+import { LangfuseNotFoundError } from "@langfuse/shared";
 import { type PrismaClient } from "@langfuse/shared/src/db";
 import {
   getObservationById,
@@ -52,33 +53,19 @@ export const assertTargetBelongsToProject = async ({
       });
     }
 
-    const observationLookup = {
+    // The observation belongs to this trace, so the trace timestamp is a tight
+    // lower bound for its start_time and lets the lookup prune events_full. On a
+    // genuine miss the lookup retries unbounded internally: trace.timestamp is
+    // an independent SDK-supplied field that can post-date a child observation's
+    // start_time, and legitimate backfills mean an observation can be older than
+    // any project-derived floor, so no safe fallback bound exists.
+    const observation = await getObservationForProject({
       observationId: input.observationId,
       traceId: input.traceId,
       projectId: input.projectId,
       useEventsTable,
-    };
-
-    // The observation belongs to this trace, so the trace timestamp is a tight
-    // lower bound for its start_time and lets the lookup prune events_full.
-    let observation = await getObservationForProject({
-      ...observationLookup,
       startTimeLowerBound: trace?.timestamp,
     });
-
-    // trace.timestamp is an independent SDK-supplied field that can be set later
-    // than a child observation's start_time (no ingestion invariant couples
-    // them), and legitimate backfills mean an observation can be arbitrarily
-    // older than any project-derived floor. So there is no safe lower bound to
-    // fall back to: on a miss, retry unbounded to avoid wrongly reporting a
-    // valid observation as missing. This runs only on a miss, so the tight
-    // trace-timestamp bound still serves the common path.
-    if (!observation && trace?.timestamp) {
-      observation = await getObservationForProject({
-        ...observationLookup,
-        startTimeLowerBound: undefined,
-      });
-    }
 
     if (!observation) {
       throw new TRPCError({
@@ -136,6 +123,19 @@ const getTraceForProject = async ({
   return undefined;
 };
 
+// Validation only needs the observation's existence, so the lookup keeps just
+// its identity — this stays assignable from both the observations- and
+// events-table getters, whose full return shapes differ.
+type WebCalloutObservation = { id: string };
+
+// A lookup either resolves to an observation, a genuine not-found (undefined
+// observation, transientError false), or a transient failure (transientError
+// true) that the helpers swallow so the caller can decide whether to retry.
+type ObservationLookupResult = {
+  observation?: WebCalloutObservation;
+  transientError: boolean;
+};
+
 const getObservationForProject = async ({
   observationId,
   traceId,
@@ -149,34 +149,89 @@ const getObservationForProject = async ({
   useEventsTable: boolean;
   startTimeLowerBound?: Date;
 }) => {
-  if (useEventsTable) {
-    const observation = await tryGetObservationFromEvents({
-      observationId,
-      traceId,
-      projectId,
-      startTimeLowerBound,
-    });
-    if (observation) return observation;
-  }
-
-  const observation = await tryGetObservation({
+  const bounded = await runObservationLookup({
     observationId,
     traceId,
     projectId,
+    useEventsTable,
     startTimeLowerBound,
   });
-  if (observation) return observation;
+  if (bounded.observation) return bounded.observation;
 
-  if (shouldTryEventsTableFallback(useEventsTable)) {
-    return tryGetObservationFromEvents({
+  // Retry unbounded only on a genuine miss. The lookup helpers swallow transient
+  // failures (timeout, ClickHouse unavailable) into the same empty result as a
+  // real not-found; retrying then would issue a second expensive unbounded scan
+  // exactly when the backend is already struggling. On a transient error, fail
+  // fast instead — matching the pre-bounding behavior.
+  if (startTimeLowerBound && !bounded.transientError) {
+    const unbounded = await runObservationLookup({
+      observationId,
+      traceId,
+      projectId,
+      useEventsTable,
+      startTimeLowerBound: undefined,
+    });
+    if (unbounded.observation) return unbounded.observation;
+  }
+
+  return undefined;
+};
+
+const runObservationLookup = async ({
+  observationId,
+  traceId,
+  projectId,
+  useEventsTable,
+  startTimeLowerBound,
+}: {
+  observationId: string;
+  traceId: string;
+  projectId: string;
+  useEventsTable: boolean;
+  startTimeLowerBound?: Date;
+}): Promise<ObservationLookupResult> => {
+  let transientError = false;
+
+  const consider = (result: ObservationLookupResult) => {
+    if (result.transientError) transientError = true;
+    return result.observation;
+  };
+
+  if (useEventsTable) {
+    const observation = consider(
+      await tryGetObservationFromEvents({
+        observationId,
+        traceId,
+        projectId,
+        startTimeLowerBound,
+      }),
+    );
+    if (observation) return { observation, transientError };
+  }
+
+  const observation = consider(
+    await tryGetObservation({
       observationId,
       traceId,
       projectId,
       startTimeLowerBound,
-    });
+    }),
+  );
+  if (observation) return { observation, transientError };
+
+  if (shouldTryEventsTableFallback(useEventsTable)) {
+    const fallback = consider(
+      await tryGetObservationFromEvents({
+        observationId,
+        traceId,
+        projectId,
+        startTimeLowerBound,
+      }),
+    );
+    if (fallback) return { observation: fallback, transientError };
   }
 
-  return undefined;
+  return { transientError };
 };
 
 const tryGetTrace = async ({
@@ -240,10 +295,10 @@ const tryGetObservation = async ({
   traceId: string;
   projectId: string;
   startTimeLowerBound?: Date;
-}) => {
+}): Promise<ObservationLookupResult> => {
   try {
     // eslint-disable-next-line @typescript-eslint/no-deprecated -- Per customer requirement, web callouts should also work on v3.
-    return await getObservationById({
+    const observation = await getObservationById({
       id: observationId,
       projectId,
       traceId,
@@ -254,8 +309,20 @@ const tryGetObservation = async ({
         shouldJsonParse: false,
       },
     });
-  } catch {
-    return undefined;
+    return { observation, transientError: false };
+  } catch (error) {
+    if (error instanceof LangfuseNotFoundError) {
+      return { transientError: false };
+    }
+    logger.warn(
+      "Failed to validate web callout observation via observations table",
+      {
+        projectId,
+        observationId,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+    );
+    return { transientError: true };
   }
 };
 
@@ -269,9 +336,9 @@ const tryGetObservationFromEvents = async ({
   traceId: string;
   projectId: string;
   startTimeLowerBound?: Date;
-}) => {
+}): Promise<ObservationLookupResult> => {
   try {
-    return await getObservationByIdFromEventsTable({
+    const observation = await getObservationByIdFromEventsTable({
       id: observationId,
       projectId,
       traceId,
@@ -282,13 +349,17 @@ const tryGetObservationFromEvents = async ({
         shouldJsonParse: false,
       },
     });
+    return { observation, transientError: false };
   } catch (error) {
+    if (error instanceof LangfuseNotFoundError) {
+      return { transientError: false };
+    }
     logger.warn("Failed to validate web callout observation via events table", {
       projectId,
       observationId,
       error: error instanceof Error ? error.message : "Unknown error",
     });
-    return undefined;
+    return { transientError: true };
   }
 };
 

--- a/web/src/features/web-callouts/server/targetValidation.ts
+++ b/web/src/features/web-callouts/server/targetValidation.ts
@@ -52,15 +52,34 @@ export const assertTargetBelongsToProject = async ({
       });
     }
 
-    const observation = await getObservationForProject({
+    const observationLookup = {
       observationId: input.observationId,
       traceId: input.traceId,
       projectId: input.projectId,
       useEventsTable,
-      // The observation belongs to this trace, so the trace timestamp is a tight
-      // lower bound for its start_time and lets the lookup prune events_full.
+    };
+
+    // The observation belongs to this trace, so the trace timestamp is a tight
+    // lower bound for its start_time and lets the lookup prune events_full.
+    let observation = await getObservationForProject({
+      ...observationLookup,
       startTimeLowerBound: trace?.timestamp,
     });
+
+    // trace.timestamp is an independent SDK-supplied field that can be set later
+    // than a child observation's start_time (no ingestion invariant couples
+    // them). On a miss, widen the bound to the project creation time so a valid
+    // observation is never wrongly reported missing while queries stay bounded.
+    if (!observation && trace?.timestamp) {
+      const project = await prisma.project.findUnique({
+        where: { id: input.projectId },
+        select: { createdAt: true },
+      });
+      observation = await getObservationForProject({
+        ...observationLookup,
+        startTimeLowerBound: project?.createdAt,
+      });
+    }
 
     if (!observation) {
       throw new TRPCError({


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16980 app preview](https://pr-16980.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Web-callout target validation fetches an observation only to confirm it exists in the project, but the lookup carried no `start_time` bound. On the v4 `events_full` table that means neither partition (`toYYYYMM(start_time)`) nor primary-key pruning applies, so a single point lookup can open hundreds-to-thousands of parts and hit the 30s events-table timeout. `span_id`/`trace_id` only have bloom-filter skip indexes, which don't prune parts.

The parent trace is already fetched before the observation lookup, and the observation belongs to it, so `trace.timestamp` is a tight lower bound for the observation's `start_time`. This threads it through a new optional `startTimeLowerBound` on the by-id repositories (events + legacy observations), applying `start_time >= anchor - OBSERVATIONS_TO_TRACE_INTERVAL` (2 days) to absorb trace-to-observation skew — the same convention `checkObservationExists` already uses. A lower bound (not day-equality, not an upper bound) is what actually prunes and is midnight-safe.

Scope: this covers the two web-callouts call sites (`tryGetObservation` + `tryGetObservationFromEvents`). The other unbounded call sites catalogued for this table are follow-ups.

## Type of change

- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Added a repository test proving the bound prunes yet tolerates skew (anchor at start → found; anchor +1d → found via 2-day lookback; anchor +3d → excluded).
- `pnpm turbo run typecheck lint` green; new test + the 23-test web-callouts suite pass locally.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds an optional trace-anchored lower bound to legacy and events observation-by-ID queries and threads it through web-callout target validation to improve ClickHouse pruning.

- Applies a two-day lookback from the trace timestamp in both observation repositories.
- Passes the bound through events, legacy, and migration-fallback validation paths.
- Adds an events-repository test covering inclusion within the lookback and exclusion beyond it.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The legacy web-callout path should be fixed before merging because valid independently timestamped observations can now fail project validation.

The events-table optimization is safe with its aggregated trace timestamp, but the same bound is applied to legacy data even though ingestion permits trace and observation timestamps to differ by more than two days.

**Files Needing Attention:** packages/shared/src/server/repositories/observations.ts; web/src/features/web-callouts/server/targetValidation.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[Web-callout request] --> Trace[Load project trace]
  Trace --> Anchor[Use trace timestamp as lower-bound anchor]
  Anchor --> Route{Observation table route}
  Route -->|Legacy| Legacy[observations: start_time >= anchor - 2 days]
  Route -->|Events| Events[events_full: start_time >= anchor - 2 days]
  Legacy --> Result[Validate observation]
  Events --> Result
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/web-callouts/server/targetValidation.ts:62
**Legacy timestamp bound rejects observations**

When a legacy trace's independently supplied timestamp is more than two days after a valid child observation's start time, forwarding `trace.timestamp` as the lower-bound anchor filters out that observation, causing web-callout validation to incorrectly return “Observation not found in project.”

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(web-callouts): bound observation lo..."](https://github.com/langfuse/langfuse/commit/36bf5eb637c82cfc90e016229e426486021d670c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59637989)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->