### PR TITLE
feat(public-api): add ?fromTimestamp / ?toTimestamp filters to GET /a…

### DIFF
--- a/fern/apis/server/definition/datasets.yml
+++ b/fern/apis/server/definition/datasets.yml
@@ -19,6 +19,18 @@ service:
           limit:
             type: optional<integer>
             docs: limit of items per page
+          fromTimestamp:
+            type: optional<datetime>
+            docs: |
+              Optional ISO-8601 lower bound on the dataset row's `createdAt`.
+              Omit for an open-ended start. Pattern matches
+              `GET /api/public/models`.
+          toTimestamp:
+            type: optional<datetime>
+            docs: |
+              Optional ISO-8601 upper bound on the dataset row's `createdAt`.
+              Omit for an open-ended end. Pattern matches
+              `GET /api/public/models`.
       response: PaginatedDatasets
     get:
       method: GET

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -1284,6 +1284,28 @@ paths:
           schema:
             type: integer
             nullable: true
+        - name: fromTimestamp
+          in: query
+          description: |-
+            Optional ISO-8601 lower bound on the dataset row's `createdAt`.
+            Omit for an open-ended start. Pattern matches
+            `GET /api/public/models`.
+          required: false
+          schema:
+            type: string
+            format: date-time
+            nullable: true
+        - name: toTimestamp
+          in: query
+          description: |-
+            Optional ISO-8601 upper bound on the dataset row's `createdAt`.
+            Omit for an open-ended end. Pattern matches
+            `GET /api/public/models`.
+          required: false
+          schema:
+            type: string
+            format: date-time
+            nullable: true
       responses:
         '200':
           description: ''

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -2201,3 +2201,255 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     expect(runAfterSecond?.createdAt).toEqual(customCreatedAt); // Still original timestamp
   });
 });
+
+describe("GET /api/public/datasets timestamp window", () => {
+  it("returns only datasets with createdAt >= fromTimestamp", async () => {
+    const { auth, projectId } = await createOrgProjectAndApiKey();
+
+    const early = await makeZodVerifiedAPICall(
+      PostDatasetsV1Response,
+      "POST",
+      "/api/public/datasets",
+      {
+        name: `early-${v4()}`,
+      },
+      auth,
+    );
+    expect(early.status).toBe(200);
+
+    const late = await makeZodVerifiedAPICall(
+      PostDatasetsV1Response,
+      "POST",
+      "/api/public/datasets",
+      {
+        name: `late-${v4()}`,
+      },
+      auth,
+    );
+    expect(late.status).toBe(200);
+
+    const future = new Date("2027-06-15T12:00:00Z");
+    await prisma.dataset.update({
+      where: { id_projectId: { id: late.body.id, projectId } },
+      data: { createdAt: future },
+    });
+    const past = new Date("2026-06-15T12:00:00Z");
+    await prisma.dataset.update({
+      where: { id_projectId: { id: early.body.id, projectId } },
+      data: { createdAt: past },
+    });
+
+    const res = await makeZodVerifiedAPICall(
+      GetDatasetsV1Response,
+      "GET",
+      `/api/public/datasets?fromTimestamp=${encodeURIComponent("2027-01-01T00:00:00Z")}`,
+      undefined,
+      auth,
+    );
+    expect(res.status).toBe(200);
+    const ids = res.body.data.map((d) => d.id);
+    expect(ids).toContain(late.body.id);
+    expect(ids).not.toContain(early.body.id);
+
+    // Cleanup
+    await prisma.dataset.deleteMany({
+      where: { projectId, id: { in: [early.body.id, late.body.id] } },
+    });
+  });
+
+  it("returns only datasets with createdAt <= toTimestamp", async () => {
+    const { auth, projectId } = await createOrgProjectAndApiKey();
+
+    const early = await makeZodVerifiedAPICall(
+      PostDatasetsV1Response,
+      "POST",
+      "/api/public/datasets",
+      {
+        name: `early-${v4()}`,
+      },
+      auth,
+    );
+    expect(early.status).toBe(200);
+
+    const late = await makeZodVerifiedAPICall(
+      PostDatasetsV1Response,
+      "POST",
+      "/api/public/datasets",
+      {
+        name: `late-${v4()}`,
+      },
+      auth,
+    );
+    expect(late.status).toBe(200);
+
+    await prisma.dataset.update({
+      where: { id_projectId: { id: early.body.id, projectId } },
+      data: { createdAt: new Date("2026-06-15T12:00:00Z") },
+    });
+    await prisma.dataset.update({
+      where: { id_projectId: { id: late.body.id, projectId } },
+      data: { createdAt: new Date("2027-06-15T12:00:00Z") },
+    });
+
+    const res = await makeZodVerifiedAPICall(
+      GetDatasetsV1Response,
+      "GET",
+      `/api/public/datasets?toTimestamp=${encodeURIComponent("2026-12-31T23:59:59Z")}`,
+      undefined,
+      auth,
+    );
+    expect(res.status).toBe(200);
+    const ids = res.body.data.map((d) => d.id);
+    expect(ids).toContain(early.body.id);
+    expect(ids).not.toContain(late.body.id);
+
+    await prisma.dataset.deleteMany({
+      where: { projectId, id: { in: [early.body.id, late.body.id] } },
+    });
+  });
+
+  it("rejects an invalid timestamp with 400", async () => {
+    const { auth } = await createOrgProjectAndApiKey();
+
+    const res = await makeAPICall(
+      "GET",
+      "/api/public/datasets?fromTimestamp=not-a-date",
+      undefined,
+      auth,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("omitting both params preserves the existing unfiltered behavior", async () => {
+    const { auth } = await createOrgProjectAndApiKey();
+
+    const res = await makeZodVerifiedAPICall(
+      GetDatasetsV1Response,
+      "GET",
+      "/api/public/datasets",
+      undefined,
+      auth,
+    );
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+});
+
+describe("GET /api/public/v2/datasets timestamp window", () => {
+  it("returns only datasets with createdAt >= fromTimestamp", async () => {
+    const { auth, projectId } = await createOrgProjectAndApiKey();
+
+    const early = await makeZodVerifiedAPICall(
+      PostDatasetsV2Response,
+      "POST",
+      "/api/public/v2/datasets",
+      {
+        name: `early-v2-${v4()}`,
+      },
+      auth,
+    );
+    expect(early.status).toBe(200);
+
+    const late = await makeZodVerifiedAPICall(
+      PostDatasetsV2Response,
+      "POST",
+      "/api/public/v2/datasets",
+      {
+        name: `late-v2-${v4()}`,
+      },
+      auth,
+    );
+    expect(late.status).toBe(200);
+
+    const future = new Date("2027-06-15T12:00:00Z");
+    await prisma.dataset.update({
+      where: { id_projectId: { id: late.body.id, projectId } },
+      data: { createdAt: future },
+    });
+    const past = new Date("2026-06-15T12:00:00Z");
+    await prisma.dataset.update({
+      where: { id_projectId: { id: early.body.id, projectId } },
+      data: { createdAt: past },
+    });
+
+    const res = await makeZodVerifiedAPICall(
+      GetDatasetsV2Response,
+      "GET",
+      `/api/public/v2/datasets?fromTimestamp=${encodeURIComponent("2027-01-01T00:00:00Z")}`,
+      undefined,
+      auth,
+    );
+    expect(res.status).toBe(200);
+    const ids = res.body.data.map((d) => d.id);
+    expect(ids).toContain(late.body.id);
+    expect(ids).not.toContain(early.body.id);
+
+    // Cleanup
+    await prisma.dataset.deleteMany({
+      where: { projectId, id: { in: [early.body.id, late.body.id] } },
+    });
+  });
+
+  it("returns only datasets with createdAt <= toTimestamp", async () => {
+    const { auth, projectId } = await createOrgProjectAndApiKey();
+
+    const early = await makeZodVerifiedAPICall(
+      PostDatasetsV2Response,
+      "POST",
+      "/api/public/v2/datasets",
+      {
+        name: `early-v2-${v4()}`,
+      },
+      auth,
+    );
+    expect(early.status).toBe(200);
+
+    const late = await makeZodVerifiedAPICall(
+      PostDatasetsV2Response,
+      "POST",
+      "/api/public/v2/datasets",
+      {
+        name: `late-v2-${v4()}`,
+      },
+      auth,
+    );
+    expect(late.status).toBe(200);
+
+    await prisma.dataset.update({
+      where: { id_projectId: { id: early.body.id, projectId } },
+      data: { createdAt: new Date("2026-06-15T12:00:00Z") },
+    });
+    await prisma.dataset.update({
+      where: { id_projectId: { id: late.body.id, projectId } },
+      data: { createdAt: new Date("2027-06-15T12:00:00Z") },
+    });
+
+    const res = await makeZodVerifiedAPICall(
+      GetDatasetsV2Response,
+      "GET",
+      `/api/public/v2/datasets?toTimestamp=${encodeURIComponent("2026-12-31T23:59:59Z")}`,
+      undefined,
+      auth,
+    );
+    expect(res.status).toBe(200);
+    const ids = res.body.data.map((d) => d.id);
+    expect(ids).toContain(early.body.id);
+    expect(ids).not.toContain(late.body.id);
+
+    await prisma.dataset.deleteMany({
+      where: { projectId, id: { in: [early.body.id, late.body.id] } },
+    });
+  });
+
+  it("rejects an invalid timestamp with 400 on v2", async () => {
+    const { auth } = await createOrgProjectAndApiKey();
+
+    const res = await makeAPICall(
+      "GET",
+      "/api/public/v2/datasets?fromTimestamp=not-a-date",
+      undefined,
+      auth,
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -382,9 +382,22 @@ export const listDatasetsByProjectForApi = async ({
   projectId,
   page,
   limit,
+  fromTimestamp,
+  toTimestamp,
 }: ListDatasetsV1Input) => {
   const shouldReadLegacyDatasetRuns =
     env.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "events_only";
+  const where = {
+    projectId,
+    ...(fromTimestamp || toTimestamp
+      ? {
+          createdAt: {
+            ...(fromTimestamp ? { gte: new Date(fromTimestamp) } : {}),
+            ...(toTimestamp ? { lte: new Date(toTimestamp) } : {}),
+          },
+        }
+      : {}),
+  };
   const datasets = await prisma.dataset.findMany({
     select: {
       name: true,
@@ -407,7 +420,7 @@ export const listDatasetsByProjectForApi = async ({
           }
         : {}),
     },
-    where: { projectId },
+    where,
     orderBy: [{ createdAt: "desc" }, { id: "asc" }],
     take: limit,
     skip: (page - 1) * limit,
@@ -432,7 +445,7 @@ export const listDatasetsByProjectForApi = async ({
   }
 
   const totalItems = await prisma.dataset.count({
-    where: { projectId },
+    where,
   });
 
   return {

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -164,6 +164,8 @@ export const PostDatasetsV2Response = APIDataset.strict();
 // GET /v2/datasets
 export const GetDatasetsV2Query = z.object({
   ...publicApiPaginationZod,
+  fromTimestamp: stringDateTime,
+  toTimestamp: stringDateTime,
 });
 export const GetDatasetsV2Response = z
   .object({
@@ -317,6 +319,8 @@ export const PostDatasetsV1Response = APIDataset.extend({
 // GET /datasets
 export const GetDatasetsV1Query = z.object({
   ...paginationZod,
+  fromTimestamp: stringDateTime,
+  toTimestamp: stringDateTime,
 });
 export const GetDatasetsV1Response = z
   .object({

--- a/web/src/pages/api/public/datasets/index.ts
+++ b/web/src/pages/api/public/datasets/index.ts
@@ -41,6 +41,8 @@ export default withMiddlewares({
         projectId: auth.scope.projectId,
         page: query.page,
         limit: query.limit,
+        fromTimestamp: query.fromTimestamp,
+        toTimestamp: query.toTimestamp,
       }),
   }),
 });

--- a/web/src/pages/api/public/v2/datasets/index.ts
+++ b/web/src/pages/api/public/v2/datasets/index.ts
@@ -31,6 +31,22 @@ export default withMiddlewares({
     responseSchema: GetDatasetsV2Response,
     rateLimitResource: "datasets",
     fn: async ({ query, auth }) => {
+      const where = {
+        projectId: auth.scope.projectId,
+        ...(query.fromTimestamp || query.toTimestamp
+          ? {
+              createdAt: {
+                ...(query.fromTimestamp
+                  ? { gte: new Date(query.fromTimestamp) }
+                  : {}),
+                ...(query.toTimestamp
+                  ? { lte: new Date(query.toTimestamp) }
+                  : {}),
+              },
+            }
+          : {}),
+      };
+
       const datasets = await prisma.dataset.findMany({
         select: {
           name: true,
@@ -43,18 +59,14 @@ export default withMiddlewares({
           updatedAt: true,
           id: true,
         },
-        where: {
-          projectId: auth.scope.projectId,
-        },
+        where,
         orderBy: [{ createdAt: "desc" }, { id: "asc" }],
         take: query.limit,
         skip: (query.page - 1) * query.limit,
       });
 
       const totalItems = await prisma.dataset.count({
-        where: {
-          projectId: auth.scope.projectId,
-        },
+        where,
       });
 
       return {


### PR DESCRIPTION
…pi/public/datasets

## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds optional creation-time bounds to the public dataset list APIs and keeps pagination totals scoped to the same filtered window.
- Extends the v1 and v2 query schemas and Prisma dataset queries with inclusive `fromTimestamp` and `toTimestamp` filters.
- Updates the Fern/OpenAPI contract for the documented v2 endpoint.
- Adds server tests for lower bounds, upper bounds, invalid values, and omitted filters.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking request-validation mismatch that should be tightened to match the published date-time contract.

Dataset filtering and totals remain consistently project-scoped, but the new query schemas accept date strings outside the documented offset-bearing date-time format and can interpret offset-less timestamps according to server timezone.

**Files Needing Attention:** web/src/features/public-api/types/datasets.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/public-api/types/datasets.ts:167-168
**Coercive timestamp validation**

The new fields use `z.coerce.date()`, so offset-less or non-date-time inputs can be accepted and interpreted using JavaScript date coercion even though the Fern and OpenAPI contracts specify date-time values. This can produce server-timezone-dependent dataset windows instead of returning a validation error consistent with sibling timestamp-filter APIs.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add ?fromTimestamp / ?..."](https://github.com/langfuse/langfuse/commit/549baffc79dd84b73a56c61914f6affa030ffd1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59863641)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)
- Knowledge Base — [Datasets and experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-and-experiments.md)

<!-- /greptile_comment -->