### PR TITLE
chore(model-price-bot): bump claude code version

### DIFF
--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Run Claude price audit
         id: claude-audit
         if: steps.validate-inputs.outputs.dry_run_mode == 'disabled'
-        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        uses: anthropics/claude-code-action@fa2b2666b747000bf42767d1f332065b375e3c8f # v1.0.214
         env:
           API_TIMEOUT_MS: "900000"
           BASH_DEFAULT_TIMEOUT_MS: "120000"


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the pinned `anthropics/claude-code-action` revision used by the model price audit from v1.0.183 to v1.0.214.

- Retains the existing workflow inputs, permissions, Claude arguments, and structured-output processing.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no concrete incompatibility or workflow regression was identified.

The updated action revision preserves the workflow’s configured inputs and structured-output contract, and the change introduces no demonstrated failure.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(model-price-bot): bump claude code..."](https://github.com/langfuse/langfuse/commit/de5ae3392a340476219860b76f1dc77507e4d435) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59879414)</sub>

<!-- /greptile_comment -->