### PR TITLE
fix(shared): propagate GCS source-stream errors through pipeline()

### DIFF
--- a/packages/shared/src/server/services/StorageService.test.ts
+++ b/packages/shared/src/server/services/StorageService.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto";
-import { Readable } from "stream";
+import { PassThrough, Readable } from "stream";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -322,6 +322,79 @@ describe("GoogleCloudStorageService signed-URL retry", () => {
       "https://signed-read-url",
     );
     expect(getSignedUrl).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * Source-stream errors on GCS uploads must reject the awaited upload instead
+ * of escaping as an uncaught 'error' event. `.pipe().on("error")` only
+ * listens on the destination; `pipeline()` forwards source errors too.
+ */
+describe("GoogleCloudStorageService.uploadFile source stream errors", () => {
+  it("rejects when the source stream fails without leaking process events", async () => {
+    const service = StorageServiceFactory.getInstance({
+      accessKeyId: undefined,
+      secretAccessKey: undefined,
+      bucketName: "test-bucket",
+      endpoint: undefined,
+      region: undefined,
+      forcePathStyle: false,
+      useGoogleCloudStorage: true,
+      awsSse: undefined,
+      awsSseKmsKeyId: undefined,
+    });
+
+    (
+      service as unknown as { bucket: { file: (name: string) => unknown } }
+    ).bucket = {
+      file: () => ({
+        createWriteStream: () => new PassThrough(),
+      }),
+    };
+
+    const unhandled: unknown[] = [];
+    const uncaught: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    const onUncaught = (err: unknown) => {
+      uncaught.push(err);
+    };
+    process.on("unhandledRejection", onUnhandled);
+    process.on("uncaughtException", onUncaught);
+
+    try {
+      const source = new Readable({
+        read() {
+          this.destroy(new Error("source stream failed"));
+        },
+      });
+
+      await expect(
+        (
+          service as unknown as {
+            uploadFile(params: {
+              fileName: string;
+              fileType: string;
+              data: Readable;
+            }): Promise<void>;
+          }
+        ).uploadFile({
+          fileName: "export.json",
+          fileType: "application/json",
+          data: source,
+        }),
+      ).rejects.toThrow();
+
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(unhandled).toHaveLength(0);
+      expect(uncaught).toHaveLength(0);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      process.off("uncaughtException", onUncaught);
+    }
   });
 });
 

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -1,4 +1,5 @@
 import { Readable } from "stream";
+import { pipeline } from "stream/promises";
 import {
   DeleteObjectsCommand,
   GetObjectCommand,
@@ -1136,19 +1137,8 @@ class GoogleCloudStorageService implements StorageService {
         await file.save(data, options);
         return;
       } else if (data instanceof Readable) {
-        return new Promise((resolve, reject) => {
-          const writeStream = file.createWriteStream(options);
-
-          data
-            .pipe(writeStream)
-            .on("error", (err: unknown) => {
-              reject(err);
-            })
-            .on("finish", () => {
-              resolve();
-            });
-          return;
-        });
+        await pipeline(data, file.createWriteStream(options));
+        return;
       }
 
       throw new Error("Unsupported data type. Must be Readable or string.");


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16995 app preview](https://pr-16995.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

GCS `uploadFile` piped the source stream into the write stream and only
listened for errors on the destination (`.pipe(writeStream).on("error", …)`).
A failing **source** stream therefore escaped as an uncaught `'error'` event
instead of rejecting the awaited upload. This switches to
`stream/promises` `pipeline()`, which forwards source-stream errors into
the returned promise so the upload rejects cleanly.

Split out of #16929 (this is the change that PR's author was comfortable
shipping independently).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `@langfuse/shared`

## Verification

```bash
pnpm --filter @langfuse/shared run test src/server/services/StorageService.test.ts
```

`Tests 19 passed (19)` (includes a new source-stream-error case asserting
the upload rejects without leaking `unhandledRejection`/`uncaughtException`).

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes GCS stream uploads to use promise-based `pipeline()`, ensuring source-stream failures reject the awaited upload rather than escaping as uncaught events.
- Replaces destination-only stream event handling with `stream/promises` `pipeline()`.
- Adds regression coverage for source errors and leaked process-level error events.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The supported runtime provides promise-based stream pipelines, and the changed upload path now rejects on source errors while retaining destination completion and error handling.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): propagate GCS source-stream..."](https://github.com/langfuse/langfuse/commit/c2deb895fdc41a767df62c36e6eb235f65c00149) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59887868)</sub>

<!-- /greptile_comment -->