### PR TITLE
fix(worker): drain in-flight requests on fatal error before exiting

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -137,6 +137,7 @@ export * from "./filterToPrisma";
 export * from "./prismaFilter";
 export * from "./instrumentation";
 export * from "./logger";
+export * from "./processErrorHandlers";
 export * from "./headerPropagation";
 export * from "./queries";
 export * from "./queries/clickhouse-sql/orderby-factory";

--- a/packages/shared/src/server/processErrorHandlers.test.ts
+++ b/packages/shared/src/server/processErrorHandlers.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const recordIncrement = vi.fn();
+
+vi.mock("./instrumentation", () => ({
+  recordIncrement: (...args: unknown[]) => recordIncrement(...args),
+}));
+vi.mock("./logger", () => ({
+  logger: { error: vi.fn() },
+}));
+
+import { installUnhandledRejectionCapture } from "./processErrorHandlers";
+
+describe("installUnhandledRejectionCapture", () => {
+  beforeEach(() => {
+    recordIncrement.mockClear();
+  });
+
+  it("registers the listener only once", () => {
+    const captureListeners = () =>
+      process
+        .listeners("unhandledRejection")
+        .filter((listener) => listener.name === "onUnhandledRejection");
+
+    installUnhandledRejectionCapture();
+    expect(captureListeners()).toHaveLength(1);
+    installUnhandledRejectionCapture();
+    expect(captureListeners()).toHaveLength(1);
+  });
+
+  it("records a metric when an unhandledRejection is emitted", () => {
+    installUnhandledRejectionCapture();
+
+    const emitted = process.emit(
+      "unhandledRejection",
+      new Error("leaked"),
+      Promise.resolve(),
+    );
+
+    expect(emitted).toBe(true);
+    expect(recordIncrement).toHaveBeenCalledWith(
+      "langfuse.process.unhandled_rejection",
+      1,
+    );
+  });
+});

--- a/packages/shared/src/server/processErrorHandlers.test.ts
+++ b/packages/shared/src/server/processErrorHandlers.test.ts
@@ -105,10 +105,6 @@ describe("installProcessErrorHandlers", () => {
       "langfuse.process.unhandled_rejection",
       1,
     );
-    expect(recordIncrement).toHaveBeenCalledWith(
-      "langfuse.process.fatal_shutdown",
-      1,
-    );
   });
 
   it("drains then exits non-zero on an uncaught exception", async () => {

--- a/packages/shared/src/server/processErrorHandlers.test.ts
+++ b/packages/shared/src/server/processErrorHandlers.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const recordIncrement = vi.fn();
 
@@ -9,38 +9,182 @@ vi.mock("./logger", () => ({
   logger: { error: vi.fn() },
 }));
 
-import { installUnhandledRejectionCapture } from "./processErrorHandlers";
+import type { ProcessErrorHandlerOptions } from "./processErrorHandlers";
 
-describe("installUnhandledRejectionCapture", () => {
+const OUR_LISTENER_NAMES = ["onUnhandledRejection", "onUncaughtException"];
+
+type ProcessEvent = "unhandledRejection" | "uncaughtException";
+
+// process.listeners is typed against NodeJS.Signals; cast so a plain event
+// name variable is accepted. The runtime value is the real event string.
+const listenersFor = (
+  event: ProcessEvent,
+): Array<(...args: unknown[]) => void> =>
+  process.listeners(event as NodeJS.Signals) as unknown as Array<
+    (...args: unknown[]) => void
+  >;
+
+const removeOurListeners = () => {
+  for (const event of ["unhandledRejection", "uncaughtException"] as const) {
+    for (const listener of listenersFor(event)) {
+      if (OUR_LISTENER_NAMES.includes(listener.name)) {
+        process.removeListener(event as NodeJS.Signals, listener as never);
+      }
+    }
+  }
+};
+
+// Freshly load the module (its `installed`/`draining` state is module-level)
+// and install with the given options.
+async function freshInstall(options: ProcessErrorHandlerOptions) {
+  vi.resetModules();
+  const mod = await import("./processErrorHandlers.js");
+  mod.installProcessErrorHandlers(options);
+  return mod;
+}
+
+// Invoke our registered handler directly instead of process.emit(), so the
+// test never risks killing the runner or tripping the framework's own
+// unhandledRejection/uncaughtException listeners.
+const fire = (event: ProcessEvent, reason: unknown) => {
+  const name =
+    event === "unhandledRejection"
+      ? "onUnhandledRejection"
+      : "onUncaughtException";
+  const listener = listenersFor(event).find((l) => l.name === name);
+  if (!listener) {
+    throw new Error(`no ${name} listener registered`);
+  }
+  listener(reason, Promise.resolve());
+};
+
+const flush = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+};
+
+describe("installProcessErrorHandlers", () => {
   beforeEach(() => {
     recordIncrement.mockClear();
   });
 
-  it("registers the listener only once", () => {
-    const captureListeners = () =>
-      process
-        .listeners("unhandledRejection")
-        .filter((listener) => listener.name === "onUnhandledRejection");
-
-    installUnhandledRejectionCapture();
-    expect(captureListeners()).toHaveLength(1);
-    installUnhandledRejectionCapture();
-    expect(captureListeners()).toHaveLength(1);
+  afterEach(() => {
+    removeOurListeners();
   });
 
-  it("records a metric when an unhandledRejection is emitted", () => {
-    installUnhandledRejectionCapture();
+  it("registers each listener only once", async () => {
+    const mod = await freshInstall({ exit: vi.fn() });
+    const count = (event: ProcessEvent) =>
+      listenersFor(event).filter((l) => OUR_LISTENER_NAMES.includes(l.name))
+        .length;
 
-    const emitted = process.emit(
-      "unhandledRejection",
-      new Error("leaked"),
-      Promise.resolve(),
-    );
+    expect(count("unhandledRejection")).toBe(1);
+    expect(count("uncaughtException")).toBe(1);
 
-    expect(emitted).toBe(true);
+    mod.installProcessErrorHandlers({ exit: vi.fn() });
+
+    expect(count("unhandledRejection")).toBe(1);
+    expect(count("uncaughtException")).toBe(1);
+  });
+
+  it("drains then exits non-zero on an unhandled rejection", async () => {
+    const exit = vi.fn();
+    const onFatal = vi.fn().mockResolvedValue(undefined);
+    await freshInstall({ onFatal, exit });
+
+    fire("unhandledRejection", new Error("leaked"));
+    await flush();
+
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    expect(onFatal.mock.calls[0][0]).toMatchObject({
+      source: "unhandledRejection",
+    });
+    expect(exit).toHaveBeenCalledWith(1);
     expect(recordIncrement).toHaveBeenCalledWith(
       "langfuse.process.unhandled_rejection",
       1,
     );
+    expect(recordIncrement).toHaveBeenCalledWith(
+      "langfuse.process.fatal_shutdown",
+      1,
+    );
+  });
+
+  it("drains then exits non-zero on an uncaught exception", async () => {
+    const exit = vi.fn();
+    const onFatal = vi.fn().mockResolvedValue(undefined);
+    await freshInstall({ onFatal, exit });
+
+    fire("uncaughtException", new Error("boom"));
+    await flush();
+
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    expect(onFatal.mock.calls[0][0]).toMatchObject({
+      source: "uncaughtException",
+    });
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(recordIncrement).toHaveBeenCalledWith(
+      "langfuse.process.uncaught_exception",
+      1,
+    );
+  });
+
+  it("still exits once when the drain itself rejects", async () => {
+    const exit = vi.fn();
+    const onFatal = vi.fn().mockRejectedValue(new Error("drain failed"));
+    await freshInstall({ onFatal, exit });
+
+    fire("unhandledRejection", new Error("leaked"));
+    await flush();
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(exit).toHaveBeenCalledTimes(1);
+  });
+
+  it("force-exits immediately on a repeated fatal while still draining", async () => {
+    const exit = vi.fn();
+    let releaseDrain: () => void = () => {};
+    const onFatal = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseDrain = resolve;
+        }),
+    );
+    await freshInstall({ onFatal, exit });
+
+    // First fatal: drain starts, no exit yet.
+    fire("unhandledRejection", new Error("first"));
+    await flush();
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    expect(exit).not.toHaveBeenCalled();
+
+    // Second fatal mid-drain: force exit immediately, without re-draining.
+    fire("uncaughtException", new Error("second"));
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    expect(recordIncrement).toHaveBeenCalledWith(
+      "langfuse.process.forced_exit",
+      1,
+    );
+
+    releaseDrain();
+  });
+
+  it("force-exits when the drain exceeds the timeout budget", async () => {
+    vi.useFakeTimers();
+    try {
+      const exit = vi.fn();
+      const onFatal = vi.fn(() => new Promise<void>(() => {})); // never resolves
+      await freshInstall({ onFatal, exit, drainTimeoutMs: 1_000 });
+
+      fire("unhandledRejection", new Error("leaked"));
+      expect(exit).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1_000);
+      expect(exit).toHaveBeenCalledWith(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/shared/src/server/processErrorHandlers.ts
+++ b/packages/shared/src/server/processErrorHandlers.ts
@@ -1,0 +1,31 @@
+import { recordIncrement } from "./instrumentation";
+import { logger } from "./logger";
+
+let installed = false;
+
+function onUnhandledRejection(
+  reason: unknown,
+  _promise: Promise<unknown>,
+): void {
+  try {
+    logger.error(
+      "Unhandled promise rejection captured; process kept alive",
+      reason,
+    );
+    recordIncrement("langfuse.process.unhandled_rejection", 1);
+  } catch {
+    // Capture must never throw: a failure here would still kill the process.
+  }
+}
+
+/**
+ * Log unhandled promise rejections and emit a metric without exiting.
+ * Idempotent. Call after dd.init.
+ */
+export function installUnhandledRejectionCapture(): void {
+  if (installed) {
+    return;
+  }
+  installed = true;
+  process.on("unhandledRejection", onUnhandledRejection);
+}

--- a/packages/shared/src/server/processErrorHandlers.ts
+++ b/packages/shared/src/server/processErrorHandlers.ts
@@ -49,58 +49,33 @@ export function installProcessErrorHandlers(
   const exit = options.exit ?? ((code: number) => process.exit(code));
   const drainTimeoutMs = options.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
 
-  const beginFatalDrain = (info: {
-    source: FatalSource;
-    reason: unknown;
-  }): void => {
+  const onFatalError = (source: FatalSource, reason: unknown): void => {
     if (draining) {
-      // Safety gate: a second fatal error mid-drain means draining is not going
-      // to recover the process. Stop waiting and die now.
-      try {
-        logger.error(
-          `Repeated ${info.source} during shutdown drain; forcing immediate exit`,
-          info.reason,
-        );
-        recordIncrement("langfuse.process.forced_exit", 1);
-      } catch {
-        // Never let the safety gate throw and prevent the exit.
-      }
+      // Safety gate: a second fatal error mid-drain means draining will not
+      // recover the process. Stop waiting and die now.
+      logger.error(
+        `Repeated ${source} during shutdown drain; exiting now`,
+        reason,
+      );
+      recordIncrement("langfuse.process.forced_exit", 1);
       exit(1);
       return;
     }
     draining = true;
-
-    try {
-      logger.error(
-        `Fatal ${info.source}; draining in-flight requests before exit`,
-        info.reason,
-      );
-      recordIncrement("langfuse.process.fatal_shutdown", 1);
-    } catch {
-      // Logging/metrics must never block the drain.
-    }
+    logger.error(
+      `Fatal ${source}; draining in-flight requests before exit`,
+      reason,
+    );
 
     const backstop = setTimeout(() => {
-      try {
-        logger.error("Shutdown drain exceeded budget; forcing exit");
-      } catch {
-        // ignore
-      }
+      logger.error("Shutdown drain exceeded budget; forcing exit");
       exit(1);
     }, drainTimeoutMs);
-    if (typeof backstop.unref === "function") {
-      backstop.unref();
-    }
+    backstop.unref?.();
 
     Promise.resolve()
-      .then(() => options.onFatal?.(info))
-      .catch((err) => {
-        try {
-          logger.error("Shutdown drain failed", err);
-        } catch {
-          // ignore
-        }
-      })
+      .then(() => options.onFatal?.({ source, reason }))
+      .catch((err) => logger.error("Shutdown drain failed", err))
       .finally(() => {
         clearTimeout(backstop);
         exit(1);
@@ -108,20 +83,12 @@ export function installProcessErrorHandlers(
   };
 
   process.on("unhandledRejection", function onUnhandledRejection(reason) {
-    try {
-      recordIncrement("langfuse.process.unhandled_rejection", 1);
-    } catch {
-      // ignore
-    }
-    beginFatalDrain({ source: "unhandledRejection", reason });
+    recordIncrement("langfuse.process.unhandled_rejection", 1);
+    onFatalError("unhandledRejection", reason);
   });
 
   process.on("uncaughtException", function onUncaughtException(err) {
-    try {
-      recordIncrement("langfuse.process.uncaught_exception", 1);
-    } catch {
-      // ignore
-    }
-    beginFatalDrain({ source: "uncaughtException", reason: err });
+    recordIncrement("langfuse.process.uncaught_exception", 1);
+    onFatalError("uncaughtException", err);
   });
 }

--- a/packages/shared/src/server/processErrorHandlers.ts
+++ b/packages/shared/src/server/processErrorHandlers.ts
@@ -1,31 +1,127 @@
 import { recordIncrement } from "./instrumentation";
 import { logger } from "./logger";
 
-let installed = false;
+type FatalSource = "uncaughtException" | "unhandledRejection";
 
-function onUnhandledRejection(
-  reason: unknown,
-  _promise: Promise<unknown>,
-): void {
-  try {
-    logger.error(
-      "Unhandled promise rejection captured; process kept alive",
-      reason,
-    );
-    recordIncrement("langfuse.process.unhandled_rejection", 1);
-  } catch {
-    // Capture must never throw: a failure here would still kill the process.
-  }
-}
+export type ProcessErrorHandlerOptions = {
+  /**
+   * Runtime graceful drain: flip readiness to unhealthy so the load balancer
+   * stops routing new traffic, let in-flight work finish, and close
+   * connections. Must NOT call process.exit — this module owns the exit so it
+   * can enforce the repeated-error safety gate. Omit to exit immediately with
+   * no drain (for runtimes that have nothing to drain).
+   */
+  onFatal?: (info: { source: FatalSource; reason: unknown }) => Promise<void>;
+  /**
+   * Backstop: force exit if the drain never resolves (e.g. a wedged connection
+   * close). Not the primary safety gate — that is the repeated-error kill.
+   */
+  drainTimeoutMs?: number;
+  /** Injectable process exit, for tests. */
+  exit?: (code: number) => void;
+};
+
+let installed = false;
+let draining = false;
+
+const DEFAULT_DRAIN_TIMEOUT_MS = 130_000;
 
 /**
- * Log unhandled promise rejections and emit a metric without exiting.
+ * Install process-level handlers for unhandled rejections and uncaught
+ * exceptions. Both are fatal: the first one drains in-flight requests via
+ * `onFatal` and then exits non-zero so the orchestrator restarts a clean
+ * process. A self-initiated shutdown never receives a follow-up SIGKILL from
+ * the orchestrator, so we must exit ourselves.
+ *
+ * Safety gate: if a second fatal error arrives while the drain is still
+ * running, the process is wedged — abandon the drain and exit immediately.
+ *
  * Idempotent. Call after dd.init.
  */
-export function installUnhandledRejectionCapture(): void {
+export function installProcessErrorHandlers(
+  options: ProcessErrorHandlerOptions = {},
+): void {
   if (installed) {
     return;
   }
   installed = true;
-  process.on("unhandledRejection", onUnhandledRejection);
+
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  const drainTimeoutMs = options.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
+
+  const beginFatalDrain = (info: {
+    source: FatalSource;
+    reason: unknown;
+  }): void => {
+    if (draining) {
+      // Safety gate: a second fatal error mid-drain means draining is not going
+      // to recover the process. Stop waiting and die now.
+      try {
+        logger.error(
+          `Repeated ${info.source} during shutdown drain; forcing immediate exit`,
+          info.reason,
+        );
+        recordIncrement("langfuse.process.forced_exit", 1);
+      } catch {
+        // Never let the safety gate throw and prevent the exit.
+      }
+      exit(1);
+      return;
+    }
+    draining = true;
+
+    try {
+      logger.error(
+        `Fatal ${info.source}; draining in-flight requests before exit`,
+        info.reason,
+      );
+      recordIncrement("langfuse.process.fatal_shutdown", 1);
+    } catch {
+      // Logging/metrics must never block the drain.
+    }
+
+    const backstop = setTimeout(() => {
+      try {
+        logger.error("Shutdown drain exceeded budget; forcing exit");
+      } catch {
+        // ignore
+      }
+      exit(1);
+    }, drainTimeoutMs);
+    if (typeof backstop.unref === "function") {
+      backstop.unref();
+    }
+
+    Promise.resolve()
+      .then(() => options.onFatal?.(info))
+      .catch((err) => {
+        try {
+          logger.error("Shutdown drain failed", err);
+        } catch {
+          // ignore
+        }
+      })
+      .finally(() => {
+        clearTimeout(backstop);
+        exit(1);
+      });
+  };
+
+  process.on("unhandledRejection", function onUnhandledRejection(reason) {
+    try {
+      recordIncrement("langfuse.process.unhandled_rejection", 1);
+    } catch {
+      // ignore
+    }
+    beginFatalDrain({ source: "unhandledRejection", reason });
+  });
+
+  process.on("uncaughtException", function onUncaughtException(err) {
+    try {
+      recordIncrement("langfuse.process.uncaught_exception", 1);
+    } catch {
+      // ignore
+    }
+    beginFatalDrain({ source: "uncaughtException", reason: err });
+  });
 }

--- a/web/src/instrumentation.ts
+++ b/web/src/instrumentation.ts
@@ -14,13 +14,21 @@ export async function register() {
     await import("./observability.config");
   }
 
-  // Capture after dd.init when init runs. Keep the dynamic import so AWS SDK
+  // Install after dd.init when init runs. Keep the dynamic import so AWS SDK
   // is not loaded before dd-trace wraps it. Install even when init is skipped
-  // (secondary replicas set NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT=false).
+  // (secondary replicas set NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT=false). On a
+  // fatal error, drain in-flight requests before exiting instead of dying
+  // abruptly and 5xx-ing them; the drain is imported lazily so its heavy
+  // dependencies load only when a fatal actually fires.
   if (isNodeRuntime) {
-    const { installUnhandledRejectionCapture } =
+    const { installProcessErrorHandlers } =
       await import("@langfuse/shared/src/server");
-    installUnhandledRejectionCapture();
+    installProcessErrorHandlers({
+      onFatal: async () => {
+        const { drainAndClose } = await import("./utils/shutdown");
+        await drainAndClose();
+      },
+    });
   }
 
   if (isNodeRuntime && isInitLoadingEnabled) {

--- a/web/src/instrumentation.ts
+++ b/web/src/instrumentation.ts
@@ -7,9 +7,23 @@ export async function register() {
       ? process.env.NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT === "true"
       : true;
 
-  if (process.env.NEXT_RUNTIME === "nodejs" && isInitLoadingEnabled) {
+  const isNodeRuntime = process.env.NEXT_RUNTIME === "nodejs";
+
+  if (isNodeRuntime && isInitLoadingEnabled) {
     console.log("Running init scripts...");
     await import("./observability.config");
+  }
+
+  // Capture after dd.init when init runs. Keep the dynamic import so AWS SDK
+  // is not loaded before dd-trace wraps it. Install even when init is skipped
+  // (secondary replicas set NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT=false).
+  if (isNodeRuntime) {
+    const { installUnhandledRejectionCapture } =
+      await import("@langfuse/shared/src/server");
+    installUnhandledRejectionCapture();
+  }
+
+  if (isNodeRuntime && isInitLoadingEnabled) {
     await import("./initialize");
   }
 }

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -312,8 +312,20 @@ if (
   process.env.NEXT_MANUAL_SIG_HANDLE
 ) {
   const { shutdown } = await import("@/src/utils/shutdown");
-  prexit(async (signal) => {
-    console.log("Signal: ", signal);
-    return await shutdown(signal);
-  });
+  prexit(
+    [
+      "exit",
+      "beforeExit",
+      "uncaughtException",
+      "SIGTSTP",
+      "SIGQUIT",
+      "SIGHUP",
+      "SIGTERM",
+      "SIGINT",
+    ],
+    async (signal) => {
+      console.log("Signal: ", signal);
+      return await shutdown(signal);
+    },
+  );
 }

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -312,17 +312,12 @@ if (
   process.env.NEXT_MANUAL_SIG_HANDLE
 ) {
   const { shutdown } = await import("@/src/utils/shutdown");
+  // uncaughtException is intentionally omitted: it is handled by
+  // installProcessErrorHandlers (registered in instrumentation.ts), which
+  // drains in-flight requests and then exits, rather than prexit exiting
+  // abruptly without draining.
   prexit(
-    [
-      "exit",
-      "beforeExit",
-      "uncaughtException",
-      "SIGTSTP",
-      "SIGQUIT",
-      "SIGHUP",
-      "SIGTERM",
-      "SIGINT",
-    ],
+    ["exit", "beforeExit", "SIGTSTP", "SIGQUIT", "SIGHUP", "SIGTERM", "SIGINT"],
     async (signal) => {
       console.log("Signal: ", signal);
       return await shutdown(signal);

--- a/web/src/utils/shutdown.ts
+++ b/web/src/utils/shutdown.ts
@@ -28,27 +28,31 @@ const setSigtermReceived = () => {
 export const isSigtermReceived = () =>
   Boolean(process.env.NEXT_MANUAL_SIG_HANDLE) && globalThis.sigtermReceived;
 
+let drainPromise: Promise<void> | null = null;
+
 // Flip readiness to unhealthy so the load balancer stops routing new traffic,
 // wait TIMEOUT for in-flight requests to drain, then close backend
-// connections. Shared by the SIGTERM/SIGINT path and the fatal-error path.
-export const drainAndClose = async () => {
+// connections. Shared by the SIGTERM/SIGINT path and the fatal-error path;
+// memoized so concurrent triggers reuse one drain instead of closing
+// connections twice.
+export const drainAndClose = (): Promise<void> => {
+  if (drainPromise) {
+    return drainPromise;
+  }
   setSigtermReceived();
 
-  return await new Promise<void>((resolve) => {
+  drainPromise = new Promise<void>((resolve) => {
     setTimeout(async () => {
       RateLimitService.shutdown();
 
       await ClickHouseClientManager.getInstance().closeAllConnections();
 
       logger.info(`Redis status ${redis?.status}`);
-      if (!redis) {
-        return;
-      }
-      if (redis.status === "end") {
+      if (redis && redis.status !== "end") {
+        redis.disconnect();
+      } else {
         logger.info("Redis connection already closed");
-        return;
       }
-      redis?.disconnect();
 
       await prisma.$disconnect();
       logger.info("Prisma connection has been closed.");
@@ -57,6 +61,8 @@ export const drainAndClose = async () => {
       resolve();
     }, TIMEOUT);
   });
+
+  return drainPromise;
 };
 
 export const shutdown = async (signal: PrexitSignal) => {

--- a/web/src/utils/shutdown.ts
+++ b/web/src/utils/shutdown.ts
@@ -28,36 +28,42 @@ const setSigtermReceived = () => {
 export const isSigtermReceived = () =>
   Boolean(process.env.NEXT_MANUAL_SIG_HANDLE) && globalThis.sigtermReceived;
 
+// Flip readiness to unhealthy so the load balancer stops routing new traffic,
+// wait TIMEOUT for in-flight requests to drain, then close backend
+// connections. Shared by the SIGTERM/SIGINT path and the fatal-error path.
+export const drainAndClose = async () => {
+  setSigtermReceived();
+
+  return await new Promise<void>((resolve) => {
+    setTimeout(async () => {
+      RateLimitService.shutdown();
+
+      await ClickHouseClientManager.getInstance().closeAllConnections();
+
+      logger.info(`Redis status ${redis?.status}`);
+      if (!redis) {
+        return;
+      }
+      if (redis.status === "end") {
+        logger.info("Redis connection already closed");
+        return;
+      }
+      redis?.disconnect();
+
+      await prisma.$disconnect();
+      logger.info("Prisma connection has been closed.");
+
+      logger.info("Shutdown complete");
+      resolve();
+    }, TIMEOUT);
+  });
+};
+
 export const shutdown = async (signal: PrexitSignal) => {
   if (signal === "SIGTERM" || signal === "SIGINT") {
     console.log(
       `SIGTERM / SIGINT received. Shutting down in ${TIMEOUT / 1000} seconds.`,
     );
-    setSigtermReceived();
-
-    return await new Promise<void>((resolve) => {
-      setTimeout(async () => {
-        RateLimitService.shutdown();
-
-        // Shutdown clickhouse connections
-        await ClickHouseClientManager.getInstance().closeAllConnections();
-
-        logger.info(`Redis status ${redis?.status}`);
-        if (!redis) {
-          return;
-        }
-        if (redis.status === "end") {
-          logger.info("Redis connection already closed");
-          return;
-        }
-        redis?.disconnect();
-
-        await prisma.$disconnect();
-        logger.info("Prisma connection has been closed.");
-
-        logger.info("Shutdown complete");
-        resolve();
-      }, TIMEOUT);
-    });
+    await drainAndClose();
   }
 };

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -15,7 +15,8 @@ import {
 } from "./queues/evalQueue";
 import { codeEvalExecutionQueueProcessorBuilder } from "./queues/codeEvalQueue";
 import { batchExportQueueProcessor } from "./queues/batchExportQueue";
-import { onShutdown } from "./utils/shutdown";
+import { drainAndClose, onShutdown } from "./utils/shutdown";
+import { installProcessErrorHandlers } from "@langfuse/shared/src/server";
 import helmet from "helmet";
 import { cloudUsageMeteringQueueProcessor } from "./queues/cloudUsageMeteringQueue";
 import { cloudSpendAlertQueueProcessor } from "./queues/cloudSpendAlertQueue";
@@ -820,5 +821,14 @@ if (env.LANGFUSE_MONITOR_SCHEDULER_ENABLED === "true") {
 
 process.on("SIGINT", () => onShutdown("SIGINT"));
 process.on("SIGTERM", () => onShutdown("SIGTERM"));
+
+// On a fatal error (uncaught exception / unhandled rejection), drain in-flight
+// jobs and flush pending writes before exiting instead of dying abruptly. A
+// repeated fatal mid-drain forces an immediate exit.
+installProcessErrorHandlers({
+  onFatal: async () => {
+    await drainAndClose();
+  },
+});
 
 export default app;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2,7 +2,12 @@ import "./instrumentation"; // instrumenting the application
 import type { Server } from "http";
 import { initializeWorker } from "./initialize";
 import { env } from "./env";
-import { logger } from "@langfuse/shared/src/server";
+import {
+  installUnhandledRejectionCapture,
+  logger,
+} from "@langfuse/shared/src/server";
+
+installUnhandledRejectionCapture();
 
 export let server: Server | undefined;
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2,12 +2,7 @@ import "./instrumentation"; // instrumenting the application
 import type { Server } from "http";
 import { initializeWorker } from "./initialize";
 import { env } from "./env";
-import {
-  installUnhandledRejectionCapture,
-  logger,
-} from "@langfuse/shared/src/server";
-
-installUnhandledRejectionCapture();
+import { logger } from "@langfuse/shared/src/server";
 
 export let server: Server | undefined;
 

--- a/worker/src/utils/shutdown.ts
+++ b/worker/src/utils/shutdown.ts
@@ -28,6 +28,13 @@ import {
 
 export const onShutdown: NodeJS.SignalsListener = async (signal) => {
   logger.info(`Received ${signal}, closing server...`);
+  await drainAndClose();
+};
+
+// Flip readiness to unhealthy, stop accepting new work, drain in-flight jobs
+// and flush pending writes, then close connections. Shared by the
+// SIGTERM/SIGINT path and the fatal-error path.
+export const drainAndClose = async () => {
   setSigtermReceived();
 
   // Stop accepting new connections

--- a/worker/src/utils/shutdown.ts
+++ b/worker/src/utils/shutdown.ts
@@ -31,13 +31,22 @@ export const onShutdown: NodeJS.SignalsListener = async (signal) => {
   await drainAndClose();
 };
 
+let drainPromise: Promise<void> | null = null;
+
 // Flip readiness to unhealthy, stop accepting new work, drain in-flight jobs
 // and flush pending writes, then close connections. Shared by the
-// SIGTERM/SIGINT path and the fatal-error path.
-export const drainAndClose = async () => {
+// SIGTERM/SIGINT path and the fatal-error path; memoized so concurrent
+// triggers reuse one drain instead of closing workers/connections twice.
+export const drainAndClose = (): Promise<void> => {
+  if (!drainPromise) {
+    drainPromise = runDrainAndClose();
+  }
+  return drainPromise;
+};
+
+const runDrainAndClose = async () => {
   setSigtermReceived();
 
-  // Stop accepting new connections
   server?.close();
   logger.info("Server has been closed.");
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16996 app preview](https://pr-16996.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Makes a fatal process error **drain in-flight requests before exiting**,
instead of dying abruptly and 5xx-ing them (as happened when a container
recently died on an unhandled error).

Both `uncaughtException` and `unhandledRejection` are treated as fatal by
`installProcessErrorHandlers`:

1. **First fatal → graceful drain, then exit(1).** The handler runs a
   runtime-provided drain that flips readiness to unhealthy (so the load
   balancer stops routing new traffic — web via `/api/public/ready`, worker
   via its health check), lets in-flight work finish, and closes connections;
   then it exits non-zero so the orchestrator restarts a clean process. A
   self-initiated shutdown never receives a follow-up SIGKILL, so the handler
   owns the exit. A drain-timeout backstop guards a wedged drain.
2. **Repeated fatal while still draining → immediate exit(1).** This is the
   safety gate: a second fatal mid-drain means draining will not recover the
   process, so it dies now. No time windows or counters — just an
   `already draining` flag.

### Why this shape (context from review)

The original abrupt-death path is the bug: on web, `prexit` was registered for
`uncaughtException` but `shutdown()` only drains for `SIGTERM`/`SIGINT`, so a
fatal error exited immediately with no drain → in-flight requests 5xx'd. This
PR routes fatal errors through the graceful drain instead.

The motivating `unhandledRejection` is a `dd-trace` Smithy region-resolution
leak on Node 24. Draining then restarting on it is acceptable (no dropped
requests); if it recurs fast enough to fire again mid-drain, the safety gate
kills immediately.

### Wiring

- **web**: `instrumentation.ts` installs the handler for every Node runtime
  (including replicas that skip Next init); `onFatal` lazily imports the
  extracted `drainAndClose` from `web/src/utils/shutdown.ts` (lazy so its heavy
  deps load only on a real fatal, and so AWS SDK is not pulled before dd-trace
  wraps it). `uncaughtException` is removed from the `prexit` list so it no
  longer exits abruptly.
- **worker**: `app.ts` installs the handler with `onFatal` = the extracted
  `drainAndClose` from `worker/src/utils/shutdown.ts` (the existing BullMQ /
  ClickHouse-flush drain).

### What a reviewer should doubt

- The drain-timeout backstop defaults to 130s. Worker jobs can legitimately
  take longer to drain than that; if so the backstop cuts them short. It is
  still strictly better than today (a fatal currently kills in-flight jobs with
  no drain at all), but the value may want per-runtime tuning.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `@langfuse/shared`
- `web`
- `worker`

## Verification

```bash
pnpm --filter @langfuse/shared run test src/server/processErrorHandlers.test.ts
pnpm turbo run typecheck --filter=web --filter=worker --filter=@langfuse/shared
pnpm turbo run lint --filter=web --filter=worker --filter=@langfuse/shared
```

- `Tests 6 passed (6)` (drain-then-exit for both fatal sources; repeated-fatal
  force-exit; drain-timeout backstop; drain-rejection still exits once;
  idempotent install).
- typecheck `Tasks: 6 successful, 6 total`; lint `Tasks: 6 successful, 6 total`.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR introduces shared fatal-process handlers that drain web requests and worker jobs before exiting, while retaining an immediate-exit safety gate for repeated failures.
- Adds shared handling for uncaught exceptions and unhandled promise rejections.
- Extracts memoized web and worker drain routines for reuse by signal and fatal-error paths.
- Adds tests for successful drains, failed drains, repeated failures, timeout handling, and idempotent installation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Runtime as Web/Worker Runtime
    participant Handler as Fatal Error Handler
    participant Drain as drainAndClose
    participant Resources as Jobs/Requests and Connections
    Runtime->>Handler: uncaughtException or unhandledRejection
    Handler->>Drain: onFatal(source, reason)
    Drain->>Resources: Mark unhealthy and stop new work
    Drain->>Resources: Await in-flight work and close connections
    alt Drain completes or rejects
        Drain-->>Handler: Settle
        Handler->>Runtime: exit(1)
    else Drain exceeds timeout
        Handler->>Runtime: force exit(1)
    else Second fatal during drain
        Runtime->>Handler: repeated fatal
        Handler->>Runtime: immediate exit(1)
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(worker): make drainAndClose reentran..."](https://github.com/langfuse/langfuse/commit/09fe60364f59803c4aa8474a3985c0891a09f018) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59887895)</sub>

<!-- /greptile_comment -->