### PR TITLE
fix(playground): close tools popover when opening create or edit tool…

### DIFF
--- a/web/src/features/playground/page/components/ConfigurationDropdowns.tsx
+++ b/web/src/features/playground/page/components/ConfigurationDropdowns.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import { Badge } from "@/src/components/ui/badge";
 import { ChevronDown, Wrench, Braces, Variable } from "lucide-react";
@@ -7,8 +7,12 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/src/components/ui/popover";
+import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
+import { type LlmTool } from "@prisma/client";
 import { usePlaygroundContext } from "../context";
 import { usePlaygroundWindowSize } from "../hooks/usePlaygroundWindowSize";
+import { type PlaygroundTool } from "../types";
+import { CreateOrEditLLMToolDialog } from "./CreateOrEditLLMToolDialog";
 import { PlaygroundTools, PlaygroundToolsPopover } from "./PlaygroundTools";
 import {
   StructuredOutputSchemaSection,
@@ -20,18 +24,98 @@ import { MessagePlaceholders } from "./MessagePlaceholders";
 export const ConfigurationDropdowns: React.FC = () => {
   const { containerRef, width, isVeryCompact, isCompact } =
     usePlaygroundWindowSize();
+  const projectId = useProjectIdFromURL();
   const {
     tools,
+    setTools,
     structuredOutputSchema,
     promptVariables,
     messagePlaceholders,
   } = usePlaygroundContext();
+
+  const [isToolsPopoverOpen, setIsToolsPopoverOpen] = useState(false);
+  const [toolDialogState, setToolDialogState] = useState<{
+    isOpen: boolean;
+    tool?: LlmTool;
+    defaultValues?: {
+      name: string;
+      description: string;
+      parameters: string;
+    };
+  }>({ isOpen: false });
 
   const toolsCount = tools.length;
   const hasSchema = structuredOutputSchema ? 1 : 0;
   const variablesCount = promptVariables.length + messagePlaceholders.length;
   const toolsPopoverWidth =
     width > 0 ? Math.min(Math.max(width - 24, 0), 320) : undefined;
+
+  const handleSelectTool = (selectedLLMTool: LlmTool) => {
+    setTools((prev: PlaygroundTool[]) => {
+      let existingToolIndex = -1;
+      existingToolIndex = prev.findIndex((t) => t.id === selectedLLMTool.id);
+
+      if (existingToolIndex === -1) {
+        const unsavedToolIndexWithSameName = prev.findIndex(
+          (t) => t.name === selectedLLMTool.name,
+        );
+
+        if (unsavedToolIndexWithSameName !== -1) {
+          existingToolIndex = unsavedToolIndexWithSameName;
+        }
+      }
+
+      const newTool: PlaygroundTool = {
+        id: selectedLLMTool.id,
+        name: selectedLLMTool.name,
+        description: selectedLLMTool.description,
+        parameters: selectedLLMTool.parameters as Record<string, unknown>,
+        existingLlmTool: selectedLLMTool,
+      };
+
+      if (existingToolIndex !== -1) {
+        const newTools = [...prev];
+        newTools[existingToolIndex] = newTool;
+        return newTools;
+      }
+
+      return [...prev, newTool];
+    });
+  };
+
+  const handleRemoveTool = (toolId: string) => {
+    setTools(
+      (prev: PlaygroundTool[]) =>
+        prev.filter((t) => !(t.id === toolId)) as PlaygroundTool[],
+    );
+  };
+
+  const handleOpenCreateTool = () => {
+    setIsToolsPopoverOpen(false);
+    setToolDialogState({ isOpen: true });
+  };
+
+  const handleOpenEditSavedTool = (tool: LlmTool) => {
+    setIsToolsPopoverOpen(false);
+    setToolDialogState({ isOpen: true, tool });
+  };
+
+  const handleOpenEditAttachedTool = (
+    _tool: PlaygroundTool,
+    existingLlmTool?: LlmTool,
+    defaultValues?: {
+      name: string;
+      description: string;
+      parameters: string;
+    },
+  ) => {
+    setIsToolsPopoverOpen(false);
+    setToolDialogState({
+      isOpen: true,
+      tool: existingLlmTool,
+      defaultValues,
+    });
+  };
 
   // Helper function to get responsive content (text or icon)
   const getResponsiveContent = (
@@ -62,7 +146,7 @@ export const ConfigurationDropdowns: React.FC = () => {
     <div ref={containerRef} className="bg-muted/25 shrink-0 border-b px-3 py-2">
       <div className="flex items-center justify-start gap-2">
         {/* Tools Dropdown */}
-        <Popover>
+        <Popover open={isToolsPopoverOpen} onOpenChange={setIsToolsPopoverOpen}>
           <PopoverTrigger asChild>
             <Button variant="outline" size="sm" className="h-8 gap-2">
               {getResponsiveContent("Tools", Wrench)}
@@ -87,7 +171,7 @@ export const ConfigurationDropdowns: React.FC = () => {
             </div>
             {toolsCount > 0 ? (
               <div className="mb-3">
-                <PlaygroundTools />
+                <PlaygroundTools onEditTool={handleOpenEditAttachedTool} />
               </div>
             ) : (
               <div className="mb-3">
@@ -97,10 +181,27 @@ export const ConfigurationDropdowns: React.FC = () => {
               </div>
             )}
             <div className="border-t pt-3">
-              <PlaygroundToolsPopover />
+              <PlaygroundToolsPopover
+                onCreateTool={handleOpenCreateTool}
+                onEditTool={handleOpenEditSavedTool}
+              />
             </div>
           </PopoverContent>
         </Popover>
+
+        {toolDialogState.isOpen && projectId && (
+          <CreateOrEditLLMToolDialog
+            open={toolDialogState.isOpen}
+            onOpenChange={(open) =>
+              setToolDialogState((prev) => ({ ...prev, isOpen: open }))
+            }
+            projectId={projectId}
+            existingLlmTool={toolDialogState.tool}
+            defaultValues={toolDialogState.defaultValues}
+            onSave={handleSelectTool}
+            onDelete={(deletedTool) => handleRemoveTool(deletedTool.id)}
+          />
+        )}
 
         {/* Structured Output Dropdown */}
         <Popover>

--- a/web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
+++ b/web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
@@ -43,7 +43,7 @@ const formSchema = z.object({
 type FormValues = z.infer<typeof formSchema>;
 
 type CreateOrEditLLMToolDialog = {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   projectId: string;
   onSave: (llmTool: LlmTool) => void;
   onDelete?: (llmTool: LlmTool) => void;
@@ -53,6 +53,8 @@ type CreateOrEditLLMToolDialog = {
     description: string;
     parameters: string;
   };
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 };
 
 export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
@@ -65,7 +67,15 @@ export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
   const updateLlmTool = api.llmTools.update.useMutation();
   const deleteLlmTool = api.llmTools.delete.useMutation();
 
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = props.open !== undefined;
+  const open = isControlled ? props.open : internalOpen;
+  const setOpen = (newOpen: boolean) => {
+    if (!isControlled) {
+      setInternalOpen(newOpen);
+    }
+    props.onOpenChange?.(newOpen);
+  };
 
   const form = useForm({
     resolver: zodResolver(formSchema),
@@ -87,14 +97,33 @@ export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
 
   // Populate form when in edit mode
   useEffect(() => {
-    if (existingLlmTool && !props.defaultValues) {
-      form.reset({
-        name: existingLlmTool.name,
-        description: existingLlmTool.description,
-        parameters: JSON.stringify(existingLlmTool.parameters, null, 2),
-      });
+    if (open) {
+      if (existingLlmTool && !props.defaultValues) {
+        form.reset({
+          name: existingLlmTool.name,
+          description: existingLlmTool.description,
+          parameters: JSON.stringify(existingLlmTool.parameters, null, 2),
+        });
+      } else if (props.defaultValues) {
+        form.reset(props.defaultValues);
+      } else {
+        form.reset({
+          name: "",
+          description: "",
+          parameters: JSON.stringify(
+            {
+              type: "object",
+              properties: {},
+              required: [],
+              additionalProperties: false,
+            },
+            null,
+            2,
+          ),
+        });
+      }
     }
-  }, [existingLlmTool, form, props.defaultValues]);
+  }, [existingLlmTool, form, props.defaultValues, open]);
 
   async function onSubmit(values: FormValues) {
     let result;
@@ -152,9 +181,11 @@ export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild onClick={(e) => e.stopPropagation()}>
-        {children}
-      </DialogTrigger>
+      {children ? (
+        <DialogTrigger asChild onClick={(e) => e.stopPropagation()}>
+          {children}
+        </DialogTrigger>
+      ) : null}
       <DialogContent
         className="flex flex-col sm:min-w-128 md:min-w-160"
         onClick={(e) => e.stopPropagation()}

--- a/web/src/features/playground/page/components/PlaygroundTools/index.tsx
+++ b/web/src/features/playground/page/components/PlaygroundTools/index.tsx
@@ -7,7 +7,6 @@ import { PlusIcon, PencilIcon, MinusCircle, WrenchIcon } from "lucide-react";
 import { type LlmTool } from "@prisma/client";
 import { api } from "@/src/utils/api";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
-import { CreateOrEditLLMToolDialog } from "@/src/features/playground/page/components/CreateOrEditLLMToolDialog";
 import {
   Command,
   CommandEmpty,
@@ -20,8 +19,16 @@ import {
 
 import { type PlaygroundTool } from "@/src/features/playground/page/types";
 
+type PlaygroundToolsPopoverProps = {
+  onCreateTool?: () => void;
+  onEditTool?: (tool: LlmTool) => void;
+};
+
 // Popover content component for use in CollapsibleSection action buttons
-export const PlaygroundToolsPopover = () => {
+export const PlaygroundToolsPopover: React.FC<PlaygroundToolsPopoverProps> = ({
+  onCreateTool,
+  onEditTool,
+}) => {
   const { setTools } = usePlaygroundContext();
   const projectId = useProjectIdFromURL();
 
@@ -68,13 +75,6 @@ export const PlaygroundToolsPopover = () => {
     });
   };
 
-  const handleRemoveTool = (toolId: string) => {
-    setTools(
-      (prev: PlaygroundTool[]) =>
-        prev.filter((t) => !(t.id === toolId)) as PlaygroundTool[],
-    );
-  };
-
   return (
     <Command className="flex flex-col">
       <CommandInput
@@ -105,43 +105,53 @@ export const PlaygroundToolsPopover = () => {
                   </div>
                 </div>
               </div>
-              <CreateOrEditLLMToolDialog
-                projectId={projectId as string}
-                onSave={handleSelectTool}
-                onDelete={() => handleRemoveTool(tool.id)}
-                existingLlmTool={tool}
+              <Button
+                variant="ghost"
+                size="icon"
+                className="ml-2 h-7 w-7 shrink-0"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEditTool?.(tool);
+                }}
               >
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="ml-2 h-7 w-7 shrink-0"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <PencilIcon className="h-3.5 w-3.5" />
-                </Button>
-              </CreateOrEditLLMToolDialog>
+                <PencilIcon className="h-3.5 w-3.5" />
+              </Button>
             </CommandItem>
           ))}
         </CommandGroup>
         <CommandSeparator />
       </CommandList>
       <div className="mt-auto p-1">
-        <CreateOrEditLLMToolDialog
-          projectId={projectId as string}
-          onSave={handleSelectTool}
+        <Button
+          variant="outline"
+          size="default"
+          className="w-full"
+          onClick={() => onCreateTool?.()}
         >
-          <Button variant="outline" size="default" className="w-full">
-            <PlusIcon className="mr-2 h-4 w-4" />
-            Create new tool
-          </Button>
-        </CreateOrEditLLMToolDialog>
+          <PlusIcon className="mr-2 h-4 w-4" />
+          Create new tool
+        </Button>
       </div>
     </Command>
   );
 };
 
+type PlaygroundToolsProps = {
+  onEditTool?: (
+    tool: PlaygroundTool,
+    existingLlmTool?: LlmTool,
+    defaultValues?: {
+      name: string;
+      description: string;
+      parameters: string;
+    },
+  ) => void;
+};
+
 // Main component for embedding in CollapsibleSection content
-export const PlaygroundTools = () => {
+export const PlaygroundTools: React.FC<PlaygroundToolsProps> = ({
+  onEditTool,
+}) => {
   const { tools, setTools } = usePlaygroundContext();
   const projectId = useProjectIdFromURL();
 
@@ -188,39 +198,6 @@ export const PlaygroundTools = () => {
     });
   }, [savedTools, tools, setTools]);
 
-  const handleSelectTool = (selectedLLMTool: LlmTool) => {
-    setTools((prev: PlaygroundTool[]) => {
-      let existingToolIndex = -1;
-      existingToolIndex = prev.findIndex((t) => t.id === selectedLLMTool.id);
-
-      if (existingToolIndex === -1) {
-        const unsavedToolIndexWithSameName = prev.findIndex(
-          (t) => t.name === selectedLLMTool.name,
-        );
-
-        if (unsavedToolIndexWithSameName !== -1) {
-          existingToolIndex = unsavedToolIndexWithSameName;
-        }
-      }
-
-      const newTool: PlaygroundTool = {
-        id: selectedLLMTool.id,
-        name: selectedLLMTool.name,
-        description: selectedLLMTool.description,
-        parameters: selectedLLMTool.parameters as Record<string, unknown>,
-        existingLlmTool: selectedLLMTool,
-      };
-
-      if (existingToolIndex !== -1) {
-        const newTools = [...prev];
-        newTools[existingToolIndex] = newTool;
-        return newTools;
-      }
-
-      return [...prev, newTool];
-    });
-  };
-
   const handleRemoveTool = (toolId: string) => {
     setTools(
       (prev: PlaygroundTool[]) =>
@@ -236,24 +213,28 @@ export const PlaygroundTools = () => {
         </div>
       ) : (
         <div className="space-y-1">
-          {tools.map((tool) => (
-            <CreateOrEditLLMToolDialog
-              key={tool.id}
-              projectId={projectId as string}
-              onSave={handleSelectTool}
-              onDelete={() => handleRemoveTool(tool.id)}
-              existingLlmTool={tool.existingLlmTool}
-              defaultValues={
-                !isToolSaved(tool)
-                  ? {
-                      name: tool.name,
-                      description: tool.description,
-                      parameters: JSON.stringify(tool.parameters, null, 2),
-                    }
-                  : undefined
-              }
-            >
-              <div className="bg-background hover:bg-accent/50 relative cursor-pointer rounded-md border p-2 pr-10 transition-colors duration-200">
+          {tools.map((tool) => {
+            const isSaved = isToolSaved(tool);
+            const matchingSavedTool = savedTools.find(
+              (s) => s.id === tool.id || s.name === tool.name,
+            );
+            const existingLlmTool = tool.existingLlmTool ?? matchingSavedTool;
+            const defaultValues = !isSaved
+              ? {
+                  name: tool.name,
+                  description: tool.description,
+                  parameters: JSON.stringify(tool.parameters, null, 2),
+                }
+              : undefined;
+
+            return (
+              <div
+                key={tool.id}
+                className="bg-background hover:bg-accent/50 relative cursor-pointer rounded-md border p-2 pr-10 transition-colors duration-200"
+                onClick={() =>
+                  onEditTool?.(tool, existingLlmTool, defaultValues)
+                }
+              >
                 <Button
                   variant="ghost"
                   size="sm"
@@ -276,7 +257,7 @@ export const PlaygroundTools = () => {
                     >
                       {tool.name}
                     </h3>
-                    {!isToolSaved(tool) ? (
+                    {!isSaved ? (
                       <span className="bg-muted text-muted-foreground mt-1 inline-flex rounded px-1 py-0.5 text-xs">
                         Unsaved
                       </span>
@@ -290,8 +271,8 @@ export const PlaygroundTools = () => {
                   </p>
                 </div>
               </div>
-            </CreateOrEditLLMToolDialog>
-          ))}
+            );
+          })}
         </div>
       )}
     </ScrollArea>


### PR DESCRIPTION
Closes #16738

## What does this PR do?

Closes the playground Tools popover when opening the Create or Edit LLM Tool dialog, and lifts the tool dialog outside the popover to prevent the dropdown menu from remaining mounted underneath/over the dialog overlay.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] My changes generate no new warnings (`pnpm run lint`)
- [x] Typechecks pass (`pnpm --filter web exec tsc --noEmit`)