### PR TITLE
fix(clickhouse): classify memory limit variants as ClickHouseResource…

### DIFF
--- a/packages/shared/src/features/monitors/processor/processor.ts
+++ b/packages/shared/src/features/monitors/processor/processor.ts
@@ -164,7 +164,7 @@ export class MonitorProcessor {
       metricMap["count_count"] = parseNumericValue(row["count_count"]);
     } catch (error) {
       // Resource pressure is transient, not a bad query; rethrow so the monitor stays ACTIVE and the scheduler retries.
-      if (error instanceof ClickHouseResourceError) {
+      if (ClickHouseResourceError.is(error)) {
         logger.warn("queryMetrics hit a ClickHouse resource limit; retrying", {
           errorType: error.errorType,
           projectId: event.projectId,

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -55,13 +55,19 @@ const ERROR_TYPE_CONFIG: Record<
   }
 > = {
   MEMORY_LIMIT: {
-    discriminators: ["memory limit exceeded"],
+    discriminators: [
+      "memory limit exceeded",
+      "memory limit (for query) exceeded",
+      "memory limit (total) exceeded",
+      "memory limit (for user) exceeded",
+      "memory limit",
+    ],
   },
   OVERCOMMIT: {
-    discriminators: ["OvercommitTracker"],
+    discriminators: ["overcommittracker"],
   },
   TIMEOUT: {
-    discriminators: ["Timeout", "timeout", "timed out"],
+    discriminators: ["timeout", "timed out"],
   },
 };
 
@@ -88,11 +94,18 @@ export class ClickHouseResourceError extends Error {
     }
   }
 
+  static is(error: unknown): error is ClickHouseResourceError {
+    return (
+      error instanceof ClickHouseResourceError ||
+      (error instanceof Error && error.name === "ClickHouseResourceError")
+    );
+  }
+
   static wrapIfResourceError(
     originalError: Error,
     tags?: NormalizedClickHouseQueryTags,
   ): Error {
-    const errorMessage = originalError.message || "";
+    const errorMessage = (originalError.message || "").toLowerCase();
 
     for (const [type, config] of Object.entries(ERROR_TYPE_CONFIG) as Array<
       [
@@ -101,7 +114,7 @@ export class ClickHouseResourceError extends Error {
       ]
     >) {
       const hasDiscriminator = config.discriminators.some((discriminator) =>
-        errorMessage.includes(discriminator),
+        errorMessage.includes(discriminator.toLowerCase()),
       );
 
       if (hasDiscriminator) {

--- a/packages/shared/src/server/repositories/clickhouseResourceError.test.ts
+++ b/packages/shared/src/server/repositories/clickhouseResourceError.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { ClickHouseResourceError } from "./clickhouse";
+
+describe("ClickHouseResourceError", () => {
+  describe("wrapIfResourceError", () => {
+    const cases = [
+      {
+        name: "capitalized per-query memory limit",
+        message:
+          "Memory limit (for query) exceeded: would use 2.25 GiB (attempt to allocate chunk of 0.00 B), current RSS: 1.42 GiB, maximum: 2.25 GiB",
+        expectedType: "MEMORY_LIMIT",
+      },
+      {
+        name: "capitalized total memory limit",
+        message:
+          "Memory limit (total) exceeded: would use 2.25 GiB, current RSS: 1.42 GiB, maximum: 2.25 GiB",
+        expectedType: "MEMORY_LIMIT",
+      },
+      {
+        name: "capitalized user memory limit",
+        message: "Memory limit (for user) exceeded: would use 2.25 GiB",
+        expectedType: "MEMORY_LIMIT",
+      },
+      {
+        name: "lowercase total memory limit",
+        message:
+          "(total) memory limit exceeded: would use 2.25 GiB (attempt to allocate chunk of 0.00 B)",
+        expectedType: "MEMORY_LIMIT",
+      },
+      {
+        name: "simple memory limit exceeded",
+        message: "memory limit exceeded",
+        expectedType: "MEMORY_LIMIT",
+      },
+      {
+        name: "OvercommitTracker decision",
+        message:
+          "OvercommitTracker decision: Query was selected to stop by OvercommitTracker: While executing AggregatingTransform",
+        expectedType: "OVERCOMMIT",
+      },
+      {
+        name: "case-insensitive overcommittracker",
+        message: "query stopped by overcommittracker",
+        expectedType: "OVERCOMMIT",
+      },
+      {
+        name: "socket timeout",
+        message: "Timeout exceeded while reading from socket",
+        expectedType: "TIMEOUT",
+      },
+      {
+        name: "timed out error",
+        message: "Request timed out after 30000ms",
+        expectedType: "TIMEOUT",
+      },
+    ];
+
+    cases.forEach(({ name, message, expectedType }) => {
+      it(`wraps ${name} as ${expectedType}`, () => {
+        const error = new Error(message);
+        const wrapped = ClickHouseResourceError.wrapIfResourceError(error);
+
+        expect(wrapped).toBeInstanceOf(ClickHouseResourceError);
+        expect(ClickHouseResourceError.is(wrapped)).toBe(true);
+        expect((wrapped as ClickHouseResourceError).errorType).toBe(
+          expectedType,
+        );
+      });
+    });
+
+    it("does not wrap regular SQL errors", () => {
+      const error = new Error("Table 'test.non_existent' doesn't exist");
+      const wrapped = ClickHouseResourceError.wrapIfResourceError(error);
+
+      expect(wrapped).toBe(error);
+      expect(wrapped).not.toBeInstanceOf(ClickHouseResourceError);
+      expect(ClickHouseResourceError.is(wrapped)).toBe(false);
+    });
+  });
+
+  describe("is", () => {
+    it("returns true for ClickHouseResourceError instances", () => {
+      const error = new ClickHouseResourceError(
+        "MEMORY_LIMIT",
+        new Error("out of memory"),
+      );
+      expect(ClickHouseResourceError.is(error)).toBe(true);
+    });
+
+    it("returns true for errors matching name ClickHouseResourceError across boundaries", () => {
+      const fakeError = new Error("resource limit");
+      fakeError.name = "ClickHouseResourceError";
+      expect(ClickHouseResourceError.is(fakeError)).toBe(true);
+    });
+
+    it("returns false for standard errors and non-errors", () => {
+      expect(ClickHouseResourceError.is(new Error("generic"))).toBe(false);
+      expect(ClickHouseResourceError.is(null)).toBe(false);
+      expect(ClickHouseResourceError.is(undefined)).toBe(false);
+      expect(ClickHouseResourceError.is("ClickHouseResourceError")).toBe(false);
+      expect(ClickHouseResourceError.is({})).toBe(false);
+    });
+  });
+});

--- a/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
+++ b/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
@@ -249,6 +249,33 @@ describe("ClickHouse Resource Error Handling", () => {
         errorType: "OVERCOMMIT",
       },
       {
+        name: "Memory limit for query exceeded (capitalized)",
+        errorMessage:
+          "Memory limit (for query) exceeded: would use 2.25 GiB (attempt to allocate chunk of 0.00 B), current RSS: 1.42 GiB, maximum: 2.25 GiB",
+        shouldBeResourceError: true,
+        errorType: "MEMORY_LIMIT",
+      },
+      {
+        name: "Memory limit total exceeded (capitalized)",
+        errorMessage:
+          "Memory limit (total) exceeded: would use 2.25 GiB, current RSS: 1.42 GiB, maximum: 2.25 GiB",
+        shouldBeResourceError: true,
+        errorType: "MEMORY_LIMIT",
+      },
+      {
+        name: "Memory limit for user exceeded (capitalized)",
+        errorMessage: "Memory limit (for user) exceeded: would use 2.25 GiB",
+        shouldBeResourceError: true,
+        errorType: "MEMORY_LIMIT",
+      },
+      {
+        name: "Overcommit decision with memory limit message",
+        errorMessage:
+          "(total) memory limit exceeded: would use 2.25 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker: While executing AggregatingTransform",
+        shouldBeResourceError: true,
+        errorType: "MEMORY_LIMIT",
+      },
+      {
         name: "Simple memory error",
         errorMessage: "memory limit exceeded",
         shouldBeResourceError: true,
@@ -288,6 +315,9 @@ describe("ClickHouse Resource Error Handling", () => {
           })(wrappedError);
 
           expect(isResourceError).toBe(shouldBeResourceError);
+          expect(ClickHouseResourceError.is(wrappedError)).toBe(
+            shouldBeResourceError,
+          );
 
           const resourceError = wrappedError as ClickHouseResourceError;
           if (shouldBeResourceError && errorType) {

--- a/worker/src/__tests__/monitorProcessor.test.ts
+++ b/worker/src/__tests__/monitorProcessor.test.ts
@@ -100,7 +100,7 @@ type ProcessCase = {
   injectError?: {
     stage: InjectErrorStage;
     message: string;
-    errorClass?: "invalid-request" | "resource";
+    errorClass?: "invalid-request" | "resource" | "resource-memory";
   };
   preempt?: { newClaimedAt: Date };
   preemptPause?: { at: Date };
@@ -736,6 +736,37 @@ const cases: ProcessCase[] = [
     },
   },
   {
+    name: "ClickHouse memory limit resource error on executeQuery: rethrows, stays ACTIVE, not ERROR_BAD_QUERY",
+    monitors: [
+      {
+        id: monitorAId,
+        severity: MonitorSeveritySchema.enum.OK,
+        severityChangedAt: tenMinutesAgo,
+        lastPublishedAt: runAt,
+      },
+    ],
+    injectError: {
+      stage: "executeQuery",
+      errorClass: "resource-memory",
+      message: "Memory limit (for query) exceeded: would use 2.25 GiB",
+    },
+    expect: {
+      throws: "Memory limit (for query) exceeded: would use 2.25 GiB",
+      publishCallCount: 0,
+      rows: [
+        {
+          id: monitorAId,
+          status: MonitorStatusSchema.enum.ACTIVE,
+          severity: MonitorSeveritySchema.enum.OK,
+          severityChangedAt: tenMinutesAgo,
+          alertedAt: null,
+          lastClaimedAt: justAfterRunAt,
+          lastCompletedAt: null,
+        },
+      ],
+    },
+  },
+  {
     name: "error on getTriggers: claim, no complete, no sev change, no emit",
     monitors: [
       {
@@ -1349,6 +1380,11 @@ describe("MonitorProcessor.process (integration)", () => {
         if (c.injectError.errorClass === "resource") {
           throw new ClickHouseResourceError(
             "TIMEOUT",
+            new Error(c.injectError.message),
+          );
+        }
+        if (c.injectError.errorClass === "resource-memory") {
+          throw ClickHouseResourceError.wrapIfResourceError(
             new Error(c.injectError.message),
           );
         }


### PR DESCRIPTION
Closes #16610

## What does this PR do?

ClickHouse emits memory limit errors with capitalization and specific scopes (e.g. `Memory limit (for query) exceeded: would use X GiB`, `Memory limit (total) exceeded`, or `(total) memory limit exceeded`).

Previously, `ClickHouseResourceError.wrapIfResourceError()` checked strictly case-sensitive `"memory limit exceeded"`, causing real ClickHouse OOM/overcommit errors to remain unwrapped. When evaluating monitors, `MonitorProcessor` failed to detect transient resource pressure and permanently disabled monitors with `ERROR_BAD_QUERY`.

This PR:
- Makes `wrapIfResourceError()` matching case-insensitive.
- Expands `MEMORY_LIMIT` discriminators to recognize standard ClickHouse memory limit error variants.
- Adds `ClickHouseResourceError.is(error)` type guard for reliable detection across module boundaries.
- Adds unit tests covering capitalized and lowercase variants, overcommit decisions, and monitor retry behavior.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] My changes generate no new warnings (`pnpm run lint`)
- [x] Typechecks pass (`pnpm --filter web exec tsc --noEmit && pnpm --filter worker exec tsc --noEmit`)
- [x] Added unit tests proving the fix