### PR TITLE
test(shared): guard S3 upload against source-stream error leaks

### DIFF
--- a/packages/shared/src/server/services/StorageService.test.ts
+++ b/packages/shared/src/server/services/StorageService.test.ts
@@ -456,3 +456,92 @@ describe("S3StorageService DeleteObjects checksum", () => {
     expect(findHeader(request, "x-amz-checksum-crc32")).toBeUndefined();
   });
 });
+
+/**
+ * Regression guard: the S3 (@aws-sdk/lib-storage) upload path consumes the
+ * source `Readable` via async iteration, which attaches an error listener to
+ * the source. A mid-read source error must therefore reject the awaited
+ * upload rather than leak as an uncaught 'error' event — unlike the GCS
+ * `.pipe()` path, which only listened on the destination. This locks that
+ * behavior in so a future refactor cannot reintroduce the GCS-class leak on
+ * S3.
+ */
+describe("S3StorageService.uploadFile source stream errors", () => {
+  it("rejects when the source stream fails without leaking process events", async () => {
+    const service = StorageServiceFactory.getInstance({
+      accessKeyId: "test-access-key",
+      secretAccessKey: "test-secret-key",
+      bucketName: "test-bucket",
+      endpoint: undefined,
+      region: "us-east-1",
+      forcePathStyle: false,
+      useAzureBlob: false,
+      useGoogleCloudStorage: false,
+      useOCIObjectStorage: false,
+      awsSse: undefined,
+      awsSseKmsKeyId: undefined,
+    });
+
+    // Stub the S3 client so lib-storage's only failure source is the body
+    // stream: every send() resolves, so a rejected upload can only come from
+    // the source Readable erroring.
+    (service as unknown as { client: unknown }).client = {
+      config: {},
+      middlewareStack: { clone: () => ({ add: () => {}, resolve: () => {} }) },
+      send: async (command: unknown) => {
+        const name =
+          (command as { constructor?: { name?: string } })?.constructor?.name ??
+          "";
+        if (name.includes("CreateMultipartUpload")) return { UploadId: "u1" };
+        if (name.includes("UploadPart")) return { ETag: "e1" };
+        if (name.includes("CompleteMultipartUpload")) return { Location: "x" };
+        if (name.includes("PutObject")) return { ETag: "e1" };
+        return {};
+      },
+    };
+
+    const unhandled: unknown[] = [];
+    const uncaught: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    const onUncaught = (err: unknown) => {
+      uncaught.push(err);
+    };
+    process.on("unhandledRejection", onUnhandled);
+    process.on("uncaughtException", onUncaught);
+
+    try {
+      const source = new Readable({
+        read() {
+          this.destroy(new Error("source stream failed"));
+        },
+      });
+
+      await expect(
+        (
+          service as unknown as {
+            uploadFile(params: {
+              fileName: string;
+              fileType: string;
+              data: Readable;
+            }): Promise<void>;
+          }
+        ).uploadFile({
+          fileName: "export.json",
+          fileType: "application/json",
+          data: source,
+        }),
+      ).rejects.toThrow();
+
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(unhandled).toHaveLength(0);
+      expect(uncaught).toHaveLength(0);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      process.off("uncaughtException", onUncaught);
+    }
+  });
+});


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17001 app preview](https://pr-17001.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Adds a regression guard for the S3 upload path. #16995 fixed the GCS
backend, where `data.pipe(writeStream).on("error", …)` only listened on
the **destination**, so a failing **source** stream escaped as an uncaught
`'error'` event instead of rejecting the awaited upload.

The S3 path (`@aws-sdk/lib-storage` `Upload`) does **not** have that bug: it
consumes the source `Readable` via async iteration (`for await … of data`),
which attaches an error listener to the source, so a mid-read error rejects
the awaited `.done()`. This was confirmed both by reading lib-storage's
source and by an empirical probe (upload rejected, zero
`unhandledRejection`/`uncaughtException`).

This PR adds a test that locks that behavior in, so a future refactor of the
S3 path cannot silently reintroduce the GCS-class leak. **Test only — no
production change.**

For the record, the Azure path (`@azure/storage-blob` `uploadStream`) was
checked the same way and is also safe (its `BufferScheduler` attaches a
source error listener and rejects the awaited promise), so no guard is added
there in this PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `@langfuse/shared`

## Verification

```bash
pnpm --filter @langfuse/shared run test src/server/services/StorageService.test.ts
```

`Tests 19 passed (19)`.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a regression test ensuring that an S3 upload rejects cleanly when its source stream errors, without leaking an unhandled rejection or uncaught exception.
- Stubs the S3 client to isolate source-stream failure handling.
- Verifies `uploadFile` rejects and no process-level error events are observed.
- Cleans up temporary process listeners in a `finally` block.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the test exercising the intended S3 source-stream rejection behavior and cleaning up its temporary listeners.

The change affects only tests, follows the service’s actual client injection path, and introduces no concrete build, runtime, isolation, or correctness failure.
</details>

<sub>Reviews (1): Last reviewed commit: ["test(shared): guard S3 upload against so..."](https://github.com/langfuse/langfuse/commit/b068d56ff6ed3b138e730a2de016de97efab0268) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59895082)</sub>

<!-- /greptile_comment -->