### PR TITLE
feat(public-api): add ?fromTimestamp / ?toTimestamp filters to GET /api/public/datasets

### DIFF
--- a/fern/apis/server/definition/datasets.yml
+++ b/fern/apis/server/definition/datasets.yml
@@ -20,6 +20,32 @@ service:
             type: optional<integer>
             docs: limit of items per page
       response: PaginatedDatasets
+    list-legacy:
+      method: GET
+      docs: |
+        Get all datasets (deprecated v1 endpoint, also returns `items` and `runs` arrays per dataset).
+        New integrations should use the v2 endpoint above.
+      path: /datasets
+      request:
+        name: GetDatasetsLegacyRequest
+        query-parameters:
+          fromTimestamp:
+            type: optional<nullable<datetime>>
+            docs: |
+              Optional ISO-8601 lower bound on the dataset row's `createdAt`
+              (inclusive). Omit for an open-ended start.
+          toTimestamp:
+            type: optional<nullable<datetime>>
+            docs: |
+              Optional ISO-8601 upper bound on the dataset row's `createdAt`
+              (exclusive). Omit for an open-ended end.
+          page:
+            type: optional<integer>
+            docs: page number, starts at 1
+          limit:
+            type: optional<integer>
+            docs: limit of items per page
+      response: PaginatedDatasetsLegacy
     get:
       method: GET
       docs: Get a dataset
@@ -80,6 +106,22 @@ types:
     properties:
       data: list<commons.Dataset>
       meta: pagination.MetaResponse
+  PaginatedDatasetsLegacy:
+    properties:
+      data:
+        type: list<DatasetLegacy>
+        docs: Datasets with their item ids and run names embedded (v1 response shape).
+      meta: pagination.MetaResponse
+  DatasetLegacy:
+    docs: Dataset with the v1 response shape that embeds item ids and run names.
+    extends: commons.Dataset
+    properties:
+      items:
+        type: list<string>
+        docs: Dataset item ids belonging to this dataset.
+      runs:
+        type: list<string>
+        docs: Names of runs that have been executed against this dataset.
   CreateDatasetRequest:
     properties:
       name: string

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -2200,4 +2200,153 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     });
     expect(runAfterSecond?.createdAt).toEqual(customCreatedAt); // Still original timestamp
   });
+
+  describe("GET /api/public/datasets timestamp window", () => {
+    // Three datasets at deterministic, well-separated `createdAt` values so the
+    // half-open `[fromTimestamp, toTimestamp)` window can be exercised without
+    // relying on clock or ordering accidents.
+    const OLD = new Date("2021-01-01T00:00:00.000Z");
+    const MID = new Date("2021-06-01T00:00:00.000Z");
+    const NEW = new Date("2022-01-01T00:00:00.000Z");
+
+    let oldName: string;
+    let midName: string;
+    let newName: string;
+
+    beforeEach(async () => {
+      // The describe's beforeEach already created the project + api key for
+      // this test. Each dataset is force-pinned to its target createdAt via
+      // Prisma so the time window is deterministic.
+      oldName = `ts-old-${v4()}`;
+      midName = `ts-mid-${v4()}`;
+      newName = `ts-new-${v4()}`;
+
+      await prisma.dataset.create({
+        data: { name: oldName, projectId, createdAt: OLD },
+      });
+      await prisma.dataset.create({
+        data: { name: midName, projectId, createdAt: MID },
+      });
+      await prisma.dataset.create({
+        data: { name: newName, projectId, createdAt: NEW },
+      });
+    });
+
+    it("omits the filter when neither timestamp is provided (existing behavior)", async () => {
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV1Response,
+        "GET",
+        "/api/public/datasets",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const names = response.body.data.map((d) => d.name);
+      expect(names).toEqual(
+        expect.arrayContaining([oldName, midName, newName]),
+      );
+      expect(response.body.meta.totalItems).toBe(3);
+    });
+
+    it("filters by fromTimestamp only (inclusive lower bound)", async () => {
+      // Anything on or after MID: the mid and new datasets.
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV1Response,
+        "GET",
+        `/api/public/datasets?fromTimestamp=${MID.toISOString()}`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const names = response.body.data.map((d) => d.name);
+      expect(names).toEqual(expect.arrayContaining([midName, newName]));
+      expect(names).not.toContain(oldName);
+      expect(response.body.meta.totalItems).toBe(2);
+    });
+
+    it("filters by toTimestamp only (exclusive upper bound)", async () => {
+      // Anything strictly before NEW: the old and mid datasets. The dataset
+      // created exactly at NEW is excluded because the upper bound is `lt`.
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV1Response,
+        "GET",
+        `/api/public/datasets?toTimestamp=${NEW.toISOString()}`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const names = response.body.data.map((d) => d.name);
+      expect(names).toEqual(expect.arrayContaining([oldName, midName]));
+      expect(names).not.toContain(newName);
+      expect(response.body.meta.totalItems).toBe(2);
+    });
+
+    it("filters by a half-open [fromTimestamp, toTimestamp) window when both are provided", async () => {
+      // Window [OLD, NEW) → exactly the mid dataset.
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV1Response,
+        "GET",
+        `/api/public/datasets?fromTimestamp=${OLD.toISOString()}&toTimestamp=${NEW.toISOString()}`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const names = response.body.data.map((d) => d.name);
+      expect(names).toEqual([midName]);
+      expect(response.body.meta.totalItems).toBe(1);
+    });
+
+    it("returns 400 on an invalid fromTimestamp format", async () => {
+      const response = await makeAPICall(
+        "GET",
+        "/api/public/datasets?fromTimestamp=not-a-date",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 on an invalid toTimestamp format", async () => {
+      const response = await makeAPICall(
+        "GET",
+        "/api/public/datasets?toTimestamp=2021-13-40T99:99:99Z",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("composes the time window with the existing project scope", async () => {
+      // Create a separate project + api key so we can prove the filter does
+      // not leak datasets across the project boundary.
+      const other = await createOrgProjectAndApiKey();
+
+      await prisma.dataset.create({
+        data: {
+          name: `ts-other-project-${v4()}`,
+          projectId: other.projectId,
+          createdAt: NEW,
+        },
+      });
+
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV1Response,
+        "GET",
+        `/api/public/datasets?fromTimestamp=${NEW.toISOString()}`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      // Only `newName` belongs to `projectId` with createdAt >= NEW.
+      expect(response.body.meta.totalItems).toBe(1);
+      expect(response.body.data.map((d) => d.name)).toEqual([newName]);
+    });
+  });
 });

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -380,11 +380,33 @@ export const getDatasetByIdForApi = async ({
 
 export const listDatasetsByProjectForApi = async ({
   projectId,
+  fromTimestamp,
+  toTimestamp,
   page,
   limit,
 }: ListDatasetsV1Input) => {
   const shouldReadLegacyDatasetRuns =
     env.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "events_only";
+
+  // Build the time-window filter on `createdAt`. Both params are independently
+  // optional; together they form a half-open `[fromTimestamp, toTimestamp)`
+  // range. The window composes with the existing project scope — it can only
+  // narrow the result set, never widen it.
+  const createdAtFilter =
+    fromTimestamp || toTimestamp
+      ? {
+          createdAt: {
+            ...(fromTimestamp ? { gte: new Date(fromTimestamp) } : {}),
+            ...(toTimestamp ? { lt: new Date(toTimestamp) } : {}),
+          },
+        }
+      : {};
+
+  const where: Prisma.DatasetWhereInput = {
+    projectId,
+    ...createdAtFilter,
+  };
+
   const datasets = await prisma.dataset.findMany({
     select: {
       name: true,
@@ -407,7 +429,7 @@ export const listDatasetsByProjectForApi = async ({
           }
         : {}),
     },
-    where: { projectId },
+    where,
     orderBy: [{ createdAt: "desc" }, { id: "asc" }],
     take: limit,
     skip: (page - 1) * limit,
@@ -432,7 +454,7 @@ export const listDatasetsByProjectForApi = async ({
   }
 
   const totalItems = await prisma.dataset.count({
-    where: { projectId },
+    where,
   });
 
   return {

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -316,6 +316,11 @@ export const PostDatasetsV1Response = APIDataset.extend({
 
 // GET /datasets
 export const GetDatasetsV1Query = z.object({
+  // Optional ISO-8601 time window on dataset creation time. Both params are
+  // independently optional and compose into a half-open `[fromTimestamp, toTimestamp)`
+  // range. Omitting both preserves the historical "all datasets" behavior.
+  fromTimestamp: stringDateTime,
+  toTimestamp: stringDateTime,
   ...paginationZod,
 });
 export const GetDatasetsV1Response = z

--- a/web/src/pages/api/public/datasets/index.ts
+++ b/web/src/pages/api/public/datasets/index.ts
@@ -39,6 +39,8 @@ export default withMiddlewares({
     fn: async ({ query, auth }) =>
       await listDatasetsByProjectForApi({
         projectId: auth.scope.projectId,
+        fromTimestamp: query.fromTimestamp,
+        toTimestamp: query.toTimestamp,
         page: query.page,
         limit: query.limit,
       }),


### PR DESCRIPTION
## Problem

`GET /api/public/datasets` previously supported only pagination (`?page`, `?limit`). Customers with a large dataset catalog (hundreds of project-owned dataset definitions accumulated over time) could not scope the list to a recent time window — every page scan returned the full history.

The companion `GET /api/public/comments` endpoint already accepts `?fromTimestamp` / `?toTimestamp` (PR #15692) on `createdAt`. The same pattern fits naturally on `/datasets` since datasets are project-owned rows with a `createdAt` column.

Concretely:
- A customer integrating the public API for a CI-side dataset audit needs "datasets added since $DATE" — currently they must paginate through the full list and filter client-side.
- A bulk-rotation job that needs to know "what did I change this week" has no way to ask the API.

## Proposed solution

Extend `GetDatasetsV1Query` to accept two optional ISO-8601 timestamp query params and pipe them through to `listDatasetsByProjectForApi` as a Prisma `createdAt` range filter.

- `?fromTimestamp=2026-08-01T00:00:00Z` → `createdAt >= fromTimestamp` (inclusive)
- `?toTimestamp=2026-08-31T23:59:59Z` → `createdAt < toTimestamp` (exclusive)
- Either param can be omitted (open-ended range). Both together form a half-open `[fromTimestamp, toTimestamp)` window.
- Filter composes with the existing `projectId` scope. Datasets outside the project are still filtered out.
- The pagination count uses the same `where` clause so `totalItems` reflects the windowed result.
- `stringDateTime` (strict ISO-8601) ensures malformed wire values return 400, not 500.

## Files

- `web/src/features/public-api/types/datasets.ts` — add `fromTimestamp` and `toTimestamp` (`stringDateTime`) on `GetDatasetsV1Query`.
- `web/src/features/datasets/server/publicDatasetService.ts` — pipe the two params through to the Prisma `where.createdAt` as a half-open window (`gte: fromTimestamp`, `lt: toTimestamp`), composed with the existing `projectId` clause. Apply the same `where` to the count query.
- `web/src/pages/api/public/datasets/index.ts` — pass the new params from the route handler to the service.
- `web/src/__tests__/server/datasets-api.servertest.ts` — new `describe("GET /api/public/datasets timestamp window", ...)` block with 7 cases: omit both (existing behavior), fromTimestamp only, toTimestamp only, both params forming a half-open window, invalid fromTimestamp format (400), invalid toTimestamp format (400), and a project-scope composition test. Three datasets are force-pinned to deterministic `createdAt` values via `prisma.dataset.create`.
- `fern/apis/server/definition/datasets.yml` — add the missing v1 `list` endpoint definition (previously the v1 list was not in the spec at all) with the two new query params, plus a new `PaginatedDatasetsLegacy` response type documenting the v1 response shape (items and runs embedded per dataset).

## Compatibility

- Both params are optional. Existing API consumers see no change.
- `GetDatasetsV1Query` is widened (more allowed keys), not narrowed, so no client breaks.
- `listDatasetsByProjectForApi` accepts the new optional fields. The only caller is the v1 `GET /datasets` route, which now passes them through.

## Verification

- `pnpm exec prettier --check` on the 4 source files and the Fern yml: clean.
- `pnpm exec tsc --noEmit` from `web/`: no new errors in the changed files (pre-existing tsc errors in `scores.ts`, `auth.ts`, `otelRequestBody.ts`, etc. are unrelated).
- `npx fern-api check --api server`: `All checks passed`.
- Standalone smoke test (`/tmp/datasets-timestamp-smoke.py`) verifies the structural invariants: Zod uses `stringDateTime` (not `z.coerce.date()`), service uses `gte`+`lt` (not `lte`), route handler passes both params. All assertions pass.
- `pnpm --filter web exec vitest run web/src/__tests__/server/datasets-api.servertest.ts` is blocked locally by a pre-existing storybook dep mismatch (`@typescript/typescript6` package-name issue in `.storybook/main.ts`); CI is expected to exercise the new cases on the standard test infrastructure.

## Risk

Minimal. The change adds a filter that narrows the result set; it cannot widen it. A malformed timestamp is caught by `stringDateTime` and returns 400, not 500. The v1 `GET /datasets` route is on the deprecation path toward v2 — adding the filter here keeps the v1 endpoint parity with `GET /api/public/comments` while v1 is still supported.

## Future work

- Mirror the same `?fromTimestamp` / `?toTimestamp` parameters on `GET /v2/datasets` (the forward-compat endpoint) once the v1 deprecation window ends.
- Consider the same filter on `GET /api/public/dataset-items` (already supports a single `version` timestamp, but a `createdAt` window would let customers scope to a recent batch of additions).

Fixes #16985


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds optional inclusive/exclusive creation-time filters to the legacy public dataset listing and documents that endpoint in Fern.
- Validates `fromTimestamp` and `toTimestamp` as optional ISO-8601 values.
- Applies one project-scoped Prisma filter to both dataset retrieval and pagination counts.
- Adds server tests for open-ended, half-open, invalid-input, and tenant-scoping cases.
- Adds the legacy endpoint and response shape to the Fern API definition.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation itself appears sound, but the incorrect half-open-window assertion must be fixed before merging because it fails against the intended inclusive lower bound.

The service correctly applies project-scoped timestamp filtering, while one new regression test expects OLD to be excluded from `[OLD, NEW)` and therefore fails; the Fern endpoint also lacks non-blocking structured deprecation metadata.

**Files Needing Attention:** web/src/__tests__/server/datasets-api.servertest.ts, fern/apis/server/definition/datasets.yml
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[API client] --> V[Validate timestamp query]
  V --> R[Dataset route]
  R --> S[Dataset service]
  S --> W[Project ID plus createdAt window]
  W --> L[Paginated dataset query]
  W --> N[Matching count query]
  L --> O[Legacy response]
  N --> O
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/datasets-api.servertest.ts:2299
**Inclusive bound breaks assertion**

When this test requests `[OLD, NEW)`, the inclusive `gte` lower bound returns both the OLD and MID datasets, so expecting only `midName` causes the new regression test to fail against the intended endpoint behavior.

```suggestion
      expect(names).toEqual(expect.arrayContaining([oldName, midName]));
```

### Issue 2
fern/apis/server/definition/datasets.yml:23-29
**Legacy endpoint lacks deprecation metadata**

The endpoint is described as deprecated only in prose and lacks Fern's structured `availability.status: deprecated` metadata, so generated documentation and SDKs will not expose the lifecycle warning provided by neighboring legacy endpoints.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add ?fromTimestamp / ?..."](https://github.com/langfuse/langfuse/commit/0341b735269be8009daa6582b24cef9b07bd937c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59897177)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Datasets and experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-and-experiments.md)
- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->