### PR TITLE
chore(ci): bump corepack to 0.36.0

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -33,6 +33,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 24 from NodeSource and activate the repository's pinned pnpm.
+# Pass --build-arg NODE_USE_ENV_PROXY=1 when building behind a proxy.
+ARG NODE_USE_ENV_PROXY
 RUN install -m 0755 -d /etc/apt/keyrings \
     && curl --retry 3 --retry-delay 5 -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
       | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
@@ -42,7 +44,7 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     && apt-get install -y --no-install-recommends nodejs \
     && npm install --global corepack@0.36.0 \
     && corepack enable \
-    && NODE_USE_ENV_PROXY=1 corepack prepare pnpm@11.22.0 --activate \
+    && corepack prepare pnpm@11.22.0 --activate \
     && rm -rf /var/lib/apt/lists/*
 
 # Cursor Cloud runs Docker inside its own container layer. fuse-overlayfs and

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -40,9 +40,9 @@ RUN install -m 0755 -d /etc/apt/keyrings \
       > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends nodejs \
-    && npm install --global corepack@0.34.7 \
+    && npm install --global corepack@0.36.0 \
     && corepack enable \
-    && corepack prepare pnpm@11.22.0 --activate \
+    && NODE_USE_ENV_PROXY=1 corepack prepare pnpm@11.22.0 --activate \
     && rm -rf /var/lib/apt/lists/*
 
 # Cursor Cloud runs Docker inside its own container layer. fuse-overlayfs and

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,9 +16,9 @@ FROM mcr.microsoft.com/devcontainers/universal:6-noble
 COPY --from=migrate-builder /out/migrate /usr/local/bin/migrate
 
 # Activate the repo's pinned pnpm through a Corepack release compatible with pnpm 12.
-RUN npm install --global corepack@0.34.7 \
+RUN npm install --global corepack@0.36.0 \
     && corepack enable \
-    && corepack prepare pnpm@11.22.0 --activate
+    && NODE_USE_ENV_PROXY=1 corepack prepare pnpm@11.22.0 --activate
 
 # Install Clickhouse
 RUN curl https://clickhouse.com/ | sh && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,9 +16,11 @@ FROM mcr.microsoft.com/devcontainers/universal:6-noble
 COPY --from=migrate-builder /out/migrate /usr/local/bin/migrate
 
 # Activate the repo's pinned pnpm through a Corepack release compatible with pnpm 12.
+# Pass --build-arg NODE_USE_ENV_PROXY=1 when building behind a proxy.
+ARG NODE_USE_ENV_PROXY
 RUN npm install --global corepack@0.36.0 \
     && corepack enable \
-    && NODE_USE_ENV_PROXY=1 corepack prepare pnpm@11.22.0 --activate
+    && corepack prepare pnpm@11.22.0 --activate
 
 # Install Clickhouse
 RUN curl https://clickhouse.com/ | sh && \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -10,9 +10,9 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS build-base
 RUN npm install turbo@2.10.5 --global
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install --global corepack@0.34.7 \
+RUN npm install --global corepack@0.36.0 \
     && corepack enable \
-    && corepack prepare pnpm@11.22.0 --activate
+    && NODE_USE_ENV_PROXY=1 corepack prepare pnpm@11.22.0 --activate
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS runtime-base
 # Remove build-only package managers. npm stays here because the runner stage

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -10,9 +10,11 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS build-base
 RUN npm install turbo@2.10.5 --global
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+# Pass --build-arg NODE_USE_ENV_PROXY=1 when building behind a proxy.
+ARG NODE_USE_ENV_PROXY
 RUN npm install --global corepack@0.36.0 \
     && corepack enable \
-    && NODE_USE_ENV_PROXY=1 corepack prepare pnpm@11.22.0 --activate
+    && corepack prepare pnpm@11.22.0 --activate
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS runtime-base
 # Remove build-only package managers. npm stays here because the runner stage

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -10,9 +10,9 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS build-base
 RUN npm install turbo@2.10.5 --global
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install --global corepack@0.34.7 \
+RUN npm install --global corepack@0.36.0 \
     && corepack enable \
-    && corepack prepare pnpm@11.22.0 --activate
+    && NODE_USE_ENV_PROXY=1 corepack prepare pnpm@11.22.0 --activate
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS runtime-base
 # package managers and build-only CLIs only increase exposure to CVEs -> remove them

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -10,9 +10,11 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS build-base
 RUN npm install turbo@2.10.5 --global
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+# Pass --build-arg NODE_USE_ENV_PROXY=1 when building behind a proxy.
+ARG NODE_USE_ENV_PROXY
 RUN npm install --global corepack@0.36.0 \
     && corepack enable \
-    && NODE_USE_ENV_PROXY=1 corepack prepare pnpm@11.22.0 --activate
+    && corepack prepare pnpm@11.22.0 --activate
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS runtime-base
 # package managers and build-only CLIs only increase exposure to CVEs -> remove them


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17005 app preview](https://pr-17005.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR consistently upgrades Corepack from 0.34.7 to 0.36.0 and enables Node's environment-proxy handling while activating the repository-pinned pnpm 11.22.0.
- Updates Corepack in the Cursor Cloud and devcontainer images.
- Applies the same toolchain setup to the web and worker build images.
- Keeps the activated pnpm version aligned with the root package-manager declaration.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete build or runtime defect identified in the changed Docker setup.

The four Dockerfiles consistently install the same Corepack release, activate the pnpm version pinned by the repository, and scope proxy handling to the activation command without altering later image behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): bump corepack to 0.36.0"](https://github.com/langfuse/langfuse/commit/5d61388f886df1ad8267d3247c7659692a8bcb40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59906446)</sub>

<!-- /greptile_comment -->