### PR TITLE
fix(experiments): make a long output readable in place, and say that it scrolls

### DIFF
--- a/web/src/components/design-system/table/components/IOTableCell/IOTableCell.tsx
+++ b/web/src/components/design-system/table/components/IOTableCell/IOTableCell.tsx
@@ -146,6 +146,10 @@ export const IOTableCell = memo(function IOTableCell({
     ? decodeUnicodeEscapesOnly(stringifiedJson, true)
     : stringifiedJson;
 
+  // The multi-line branches scroll inside the cell, so their scrollport is
+  // marked `scrollbar-visible`: a region that scrolls without ever painting a
+  // scrollbar is indistinguishable from one whose content was cut off, and
+  // nobody reaches for the wheel on content they read as truncated.
   let content: ReactNode;
   if (singleLine) {
     content = (
@@ -192,7 +196,10 @@ export const IOTableCell = memo(function IOTableCell({
             "h-full w-full self-stretch overflow-hidden rounded-sm",
             variantClassName,
           )}
-          codeClassName={cn("min-h-0 h-full overflow-y-auto", paddingClassName)}
+          codeClassName={cn(
+            "scrollbar-visible min-h-0 h-full overflow-y-auto",
+            paddingClassName,
+          )}
           collapseStringsAfterLength={null}
           borderless
         />
@@ -213,7 +220,10 @@ export const IOTableCell = memo(function IOTableCell({
           "h-full w-full self-stretch overflow-hidden rounded-sm",
           variantClassName,
         )}
-        codeClassName={cn("min-h-0 h-full overflow-y-auto", paddingClassName)}
+        codeClassName={cn(
+          "scrollbar-visible min-h-0 h-full overflow-y-auto",
+          paddingClassName,
+        )}
         collapseStringsAfterLength={null}
         borderless
       />

--- a/web/src/features/experiments/components/table/ExperimentGridCell.tsx
+++ b/web/src/features/experiments/components/table/ExperimentGridCell.tsx
@@ -856,8 +856,13 @@ export const ExperimentGridCell = ({
     }))
     .filter((section) => section.content !== null);
 
+  // The cell is the scrollport in this layout: the output section keeps its
+  // content's height as its base, so a long output makes the cell taller than
+  // the row and the reader scrolls the cell to reach the scores under it.
+  // `scrollbar-visible` is what says so — under the platform's overlay
+  // scrollbars a cell with more to show reads as one that was cut off.
   return (
-    <div className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-auto">
+    <div className="scrollbar-visible flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-auto">
       {sectionsToRender.map((section, index) => {
         const { row, content } = section;
         const isFirst = index === 0;

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -273,6 +273,12 @@ const StackedExperimentCell = ({
 /**
  * A single experiment's output within the stacked list cell. Renders the
  * compact (truncated) output value from the list query.
+ *
+ * `h-full min-h-0` is what makes a long output scrollable rather than clipped:
+ * the IO cell inside sizes itself to its parent, so an auto-height row hands it
+ * the content's own height and the row's `overflow-hidden` then cuts it off
+ * with no way to read the rest. Bounded to the row, the IO cell's own
+ * scrollport takes over.
  */
 const StackedOutputRow = ({
   output,
@@ -287,7 +293,7 @@ const StackedOutputRow = ({
   chip?: React.ReactNode;
 }) => {
   return (
-    <div className="flex min-w-0 items-start">
+    <div className="flex h-full min-h-0 min-w-0 items-start">
       <span
         className={cn(
           "mt-0.5 mr-2 block h-4 w-0.5 shrink-0 rounded-full",
@@ -376,7 +382,7 @@ const StackedOutputCell = ({
     >
       {showExpectedLine && (
         <div className="flex min-h-0 items-start overflow-hidden py-0.5 pr-1 pl-1.5">
-          <div className="flex min-w-0 items-start">
+          <div className="flex h-full min-h-0 min-w-0 items-start">
             <span className="text-muted-foreground mt-0.5 mr-1 shrink-0 text-[10px] font-bold uppercase">
               Exp
             </span>
@@ -404,7 +410,7 @@ const StackedOutputCell = ({
             className="flex min-h-0 items-start overflow-hidden py-0.5 pr-1 pl-1.5"
           >
             {isLoading ? (
-              <div className="flex min-w-0 items-start">
+              <div className="flex h-full min-h-0 min-w-0 items-start">
                 <span className="bg-muted mt-0.5 mr-2 block h-4 w-0.5 shrink-0 rounded-full" />
                 <ConnectedIOTableCell isLoading singleLine={singleLine} />
               </div>

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -726,6 +726,42 @@
   }
 }
 
+/* A scrollport that says so. Overlay scrollbars — the platform default on
+   macOS, and Chrome's default everywhere — paint nothing until a scroll is
+   already under way, so a region holding more than it shows is
+   indistinguishable from one whose content was truncated: the reader has no
+   reason to try the wheel. This paints a thin scrollbar whenever the content
+   overflows, and still nothing when it fits. `scrollbar-color` also opts
+   Firefox out of overlay scrollbars, which it uses by default too. */
+@utility scrollbar-visible {
+  &::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 9999px;
+    background-color: hsl(var(--muted-foreground) / 0.4);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background-color: hsl(var(--muted-foreground) / 0.6);
+  }
+
+  /* Firefox has no `::-webkit-scrollbar`, so the standard properties are its
+     only way in — and they must NOT reach Chrome, where they take precedence
+     and switch the always-painted scrollbar above back off for an overlay one.
+     Hence the gate rather than declaring both unconditionally. */
+  @supports not selector(::-webkit-scrollbar) {
+    scrollbar-width: thin;
+    scrollbar-color: hsl(var(--muted-foreground) / 0.4) transparent;
+  }
+}
+
 /* Tailwind's `sr-only` verbatim, plus `top: 0; left: 0`. Without them the box
    sits at its static position, and since it is absolute, its containing block
    is the nearest positioned ancestor — usually far outside the scroll container


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17007 app preview](https://pr-17007.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Long outputs in the results view were clipped, not scrollable — and where they *were* scrollable, nothing said so. Both halves are fixed: the stacked output line in the diff layout now gets a real scrollport instead of overflowing a hidden box, and a scrollable table cell paints a thin scrollbar whenever it holds more than it shows.

Closes [LFE-15944](https://linear.app/clickhouse/issue/LFE-15944). **Position in the stack:** PR 10, based on `lfe-15711-09-storage-render-update` (#17006).

## Why

The reviewer's note on the diff-layout screenshot was three words: *"output is not scrollable"*. Measured on the seeded demo data at the Medium row height, the output line needed **109px inside an 86px box** — and:

- the line had no height of its own, so the IO cell inside it sized to the *content*, grew past the row, and the row's `overflow-hidden` cut it off;
- the IO cell's own `overflow-y-auto` therefore measured **zero** overflow, so the wheel did nothing either. Truncated content and clipped content looked identical, and behaved identically.

The side-by-side layout has the opposite shape: the cell *is* the scrollport and scrolling works — 406px of content in a 248px cell — but Chrome's overlay scrollbars paint nothing until a scroll is already under way, so the cell reads as content that was cut off. That is also the open half of [#15631](https://github.com/langfuse/langfuse/issues/15631) (a dataset item with 3,096px of content in an 88px box, no scrollbar, wheel works).

## What

**Two commits, in order.**

1. **The overflow.** Each line the stacked output cell draws — an experiment's output, the expected-output line, the loading skeleton — is bounded to its grid row (`h-full min-h-0`). The IO cell then has a definite height to scroll inside: 23px of overflow at Medium, 67 at Small, none at Large (where the content fits, so no scrollbar appears at all).

2. **The affordance.** A new `scrollbar-visible` utility, applied to the two scrollports a reader meets here: the multi-line IO table cell, and the side-by-side experiment cell.

## Result

The output is readable in place at every row height, in both layouts, in both themes, with a visible 8px scrollbar that appears only when there is something to scroll. The dataset items table gets the same affordance for free, since it uses the same IO cell.

<details>
<summary>Mechanism, blast radius, verification</summary>

**Why the utility is not just `scrollbar-width: thin`.** Setting the standard properties in Chrome keeps the scrollbar an overlay one — measured: `offsetWidth - clientWidth === 0`, nothing painted. Chrome needs `::-webkit-scrollbar`, and it *ignores* the pseudo-element as soon as the standard properties are also set. Firefox has no such pseudo-element and needs the standard properties. So the utility declares `::-webkit-scrollbar` unconditionally and puts `scrollbar-width` / `scrollbar-color` behind `@supports not selector(::-webkit-scrollbar)`. After that, the gutter measures 8px in Chrome.

**Blast radius.** The utility on `IOTableCell` reaches every table's multi-line IO cell. That is deliberate — it is the same defect on every one of them, and there is no way to scope it to this feature without adding a prop that leaves the rest broken. It is self-limiting: `overflow-y: auto` means a scrollbar exists only when the content overflows, so a cell whose content fits is pixel-identical to before. Checked on the dataset items table (32 of 41 cells overflowing → scrollbar; layout otherwise unchanged) and on the results view's own Input / Expected Output columns.

**A note for whoever edits `globals.css` next:** a *new* `@utility` is not picked up by HMR. The class stays undefined until the dev server restarts, which looks exactly like a typo in the class name.

**Per-branch checks** (`shared` rebuilt with `db:generate` + `build` first):

- `pnpm exec knip` — clean
- `pnpm --filter=web run typecheck` — clean
- `turbo lint --force` after `rm -rf web/.next/cache/eslint` — 7 successful, **`Cached: 0`**
- `vitest run --project client` — 411 files, 4,069 tests passed

**Browser** (the seeded 7-run demo project, 15 items with multi-paragraph outputs):

| state | before | after |
| --- | --- | --- |
| diff layout, row height Medium | 86px box, 109px content, `overflow: hidden`, wheel inert | scrolls 23px, 8px scrollbar |
| diff layout, row height Small | 42px box, 109px content, clipped | scrolls 67px |
| diff layout, row height Large | content fits | no scrollbar (correct) |
| side-by-side | 248px cell, 406px content, no scrollbar drawn | same scroll, scrollbar drawn |

Dark mode and light mode; 1512×800 and 1280×720. Screenshots in the linked ticket.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bxa4EbY1xw1VkJwxABKgm3


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes long experiment and dataset outputs readable within bounded table rows and adds an explicit scrollbar affordance to affected scrollports.

- Bounds stacked experiment, expected-output, and loading rows so their IO cells can scroll internally.
- Adds a reusable cross-browser `scrollbar-visible` utility.
- Applies the utility to shared multi-line IO cells and side-by-side experiment cells.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The changed height propagation establishes bounded internal scrollports, and the new utility is applied directly to existing overflow elements using syntax supported by the repository’s styling toolchain.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): paint a scrollbar where a tab..."](https://github.com/langfuse/langfuse/commit/e150215812b50a9a0fc9c0cb1037180a34e06826) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59912124)</sub>

<!-- /greptile_comment -->