### PR TITLE
refactor(experiments): say baseline and not-scored, and take a number off the header line

### DIFF
--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -983,6 +983,7 @@ export default function ExperimentItemsTable({
                     dataType={dataType}
                     summary={summary}
                     comparisonName={primaryComparisonName}
+                    hasBaseline={hasBaseline}
                     filterMenu={
                       comparisonTargets.length === 0 ? undefined : (
                         <ScoreColumnFilterMenu

--- a/web/src/features/experiments/components/table/ExperimentScoreMatrix.tsx
+++ b/web/src/features/experiments/components/table/ExperimentScoreMatrix.tsx
@@ -91,9 +91,8 @@ const MatrixCell = ({
         <span className="text-muted-foreground">↻{movement.changed}</span>
       )}
       {/* Items only one of the two runs scored: never folded into the delta.
-          Spelled out rather than abbreviated to `n/a`, which the reviewer read
-          as "not available" and had to ask about. A matrix cell has no hover to
-          move the count into, so unlike the score column header it stays. */}
+          Spelled out rather than abbreviated, because a matrix cell has no
+          hover to move the count into — the words are all the reader gets. */}
       {hasBaselineColumn && notComparable > 0 && (
         <span className="text-muted-foreground opacity-70">
           {notComparable} not scored
@@ -259,10 +258,10 @@ export const ExperimentScoreMatrix = ({
                           colorStyles.markerClass,
                         )}
                       />
-                      {/* No `baseline` badge: the column is already the first
-                          one and the only one whose cells carry no delta, and
-                          the badge was the third thing competing for a 150px
-                          header. */}
+                      {/* No `baseline` badge: this column is already the
+                          first one and the only one whose cells carry no
+                          delta, and a 150px header has room for the run's
+                          name or a badge, not both. */}
                       <span
                         className="truncate font-bold"
                         title={experiment.experimentName}

--- a/web/src/features/experiments/components/table/ExperimentScoreMatrix.tsx
+++ b/web/src/features/experiments/components/table/ExperimentScoreMatrix.tsx
@@ -7,7 +7,6 @@ import {
   type PaginationState,
   type Table as TanStackTable,
 } from "@tanstack/react-table";
-import { Badge } from "@/src/components/ui/badge";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { DataTablePagination } from "@/src/components/table/data-table-pagination";
 import {
@@ -260,21 +259,16 @@ export const ExperimentScoreMatrix = ({
                           colorStyles.markerClass,
                         )}
                       />
+                      {/* No `baseline` badge: the column is already the first
+                          one and the only one whose cells carry no delta, and
+                          the badge was the third thing competing for a 150px
+                          header. */}
                       <span
                         className="truncate font-bold"
                         title={experiment.experimentName}
                       >
                         {experiment.experimentName}
                       </span>
-                      {experiment.isBaseline && (
-                        <Badge
-                          size="sm"
-                          variant="secondary"
-                          className="shrink-0"
-                        >
-                          baseline
-                        </Badge>
-                      )}
                     </span>
                   </th>
                 );

--- a/web/src/features/experiments/components/table/ExperimentScoreMatrix.tsx
+++ b/web/src/features/experiments/components/table/ExperimentScoreMatrix.tsx
@@ -91,10 +91,13 @@ const MatrixCell = ({
       {hasBaselineColumn && movement && movement.changed > 0 && (
         <span className="text-muted-foreground">↻{movement.changed}</span>
       )}
-      {/* Items only one of the two runs scored: never folded into the delta. */}
+      {/* Items only one of the two runs scored: never folded into the delta.
+          Spelled out rather than abbreviated to `n/a`, which the reviewer read
+          as "not available" and had to ask about. A matrix cell has no hover to
+          move the count into, so unlike the score column header it stays. */}
       {hasBaselineColumn && notComparable > 0 && (
         <span className="text-muted-foreground opacity-70">
-          {notComparable} n/a
+          {notComparable} not scored
         </span>
       )}
     </span>

--- a/web/src/features/experiments/components/table/ScoreColumnHeaderSummary.tsx
+++ b/web/src/features/experiments/components/table/ScoreColumnHeaderSummary.tsx
@@ -63,10 +63,10 @@ const SummaryRow = ({
 
 /**
  * A score column's header, carrying the analysis instead of only the column's
- * name: this experiment's aggregate and the item count behind it, and — with a
- * comparison selected — the comparison's aggregate, the signed delta and how
- * many items moved which way. This is what the deleted Analytics tab was going
- * to be, put where the eye already is.
+ * name: the baseline experiment's aggregate and the item count behind it, and —
+ * with a comparison selected — the comparison's aggregate, the signed delta and
+ * how many items moved which way. This is what the deleted Analytics tab was
+ * going to be, put where the eye already is.
  */
 export const ScoreColumnHeaderSummary = ({
   label,
@@ -157,7 +157,7 @@ export const ScoreColumnHeaderSummary = ({
             {getScoreDataTypeExplanation(dataType)}
           </span>
           <SummaryRow
-            label={`This experiment (${DIFF_LABEL_TITLES[dataType]})`}
+            label={`Baseline experiment (${DIFF_LABEL_TITLES[dataType]})`}
             value={
               baseline ? formatScoreColumnAggregate(baseline) : "no values"
             }
@@ -188,13 +188,11 @@ export const ScoreColumnHeaderSummary = ({
                 </>
               )}
               <SummaryRow label="Unchanged" value={movement.unchanged} />
-              <SummaryRow
-                label="Not comparable"
-                value={movement.notComparable}
-              />
+              <SummaryRow label="Not scored" value={movement.notComparable} />
               <span className="text-muted-foreground text-[10px]">
-                Not comparable: only one of the two experiments has a score for
-                the item, so it counts as neither an improvement nor a
+                Not scored: only one of the two experiments has a score for the
+                item — or, for a categorical score, the item has no single value
+                to compare — so it counts as neither an improvement nor a
                 regression.
               </span>
             </>

--- a/web/src/features/experiments/components/table/ScoreColumnHeaderSummary.tsx
+++ b/web/src/features/experiments/components/table/ScoreColumnHeaderSummary.tsx
@@ -73,12 +73,19 @@ export const ScoreColumnHeaderSummary = ({
   dataType,
   summary,
   comparisonName,
+  hasBaseline,
   filterMenu,
 }: {
   label: string;
   dataType: ScoreColumnDataType;
   summary: ScoreColumnSummary;
   comparisonName?: string;
+  /**
+   * Whether the run the aggregate belongs to is the selected baseline. With
+   * comparisons but no baseline the first selected run stands in, and calling
+   * that a baseline claims a selection the user has not made.
+   */
+  hasBaseline: boolean;
   /** The column's way into the score comparison filter, rendered beside the name. */
   filterMenu?: React.ReactNode;
 }) => {
@@ -138,10 +145,9 @@ export const ScoreColumnHeaderSummary = ({
                   </span>
                 )}
                 {movement.changed > 0 && <span>↻{movement.changed}</span>}
-                {/* The not-scored count is deliberately NOT here. It is the
-                  least-used of the four numbers and it is what pushed this
-                  line onto a second row, which is what made the summary read
-                  as busy. It stays accounted for, in the hover. */}
+                {/* The not-scored count is deliberately NOT here: it is the
+                  least-used of these numbers and the line only holds three.
+                  It stays accounted for, in the hover. */}
               </span>
             )}
           </div>
@@ -155,7 +161,9 @@ export const ScoreColumnHeaderSummary = ({
             {getScoreDataTypeExplanation(dataType)}
           </span>
           <SummaryRow
-            label={`Baseline experiment (${DIFF_LABEL_TITLES[dataType]})`}
+            label={`${
+              hasBaseline ? "Baseline experiment" : "This experiment"
+            } (${DIFF_LABEL_TITLES[dataType]})`}
             value={
               baseline ? formatScoreColumnAggregate(baseline) : "no values"
             }

--- a/web/src/features/experiments/components/table/ScoreColumnHeaderSummary.tsx
+++ b/web/src/features/experiments/components/table/ScoreColumnHeaderSummary.tsx
@@ -83,7 +83,6 @@ export const ScoreColumnHeaderSummary = ({
   filterMenu?: React.ReactNode;
 }) => {
   const { baseline, comparison, delta, movement } = summary;
-  const notComparable = movement?.notComparable ?? 0;
   const { icon, label: nameLabel } = splitScoreDataTypeIcon(label);
 
   return (
@@ -139,11 +138,10 @@ export const ScoreColumnHeaderSummary = ({
                   </span>
                 )}
                 {movement.changed > 0 && <span>↻{movement.changed}</span>}
-                {/* Items only one of the two runs scored: visible, and never
-                  folded into the regression count. */}
-                {notComparable > 0 && (
-                  <span className="opacity-70">{notComparable} n/a</span>
-                )}
+                {/* The not-scored count is deliberately NOT here. It is the
+                  least-used of the four numbers and it is what pushed this
+                  line onto a second row, which is what made the summary read
+                  as busy. It stays accounted for, in the hover. */}
               </span>
             )}
           </div>

--- a/web/src/features/experiments/fns/summariseScoreColumn.ts
+++ b/web/src/features/experiments/fns/summariseScoreColumn.ts
@@ -30,7 +30,12 @@ type ScoreColumnMovement = {
   unchanged: number;
   /** A different value with no order to it — categorical only. */
   changed: number;
-  /** One side has no score for this item, or the two cannot be compared. */
+  /**
+   * One side has no score for this item, or the two cannot be compared. The
+   * reader is shown this as "not scored", but the name here stays
+   * `notComparable`: an item both sides scored lands in this bucket too, when
+   * its categorical values leave no single value to stand for it.
+   */
   notComparable: number;
 };
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17009 app preview](https://pr-17009.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Five wording and noise fixes in the score column summary the reviewer called *"very nice but feels very busy"*: it says **baseline** where it said "this experiment", **not scored** where it said "not comparable", drops the fourth number from the header line (it moves to the hover, where it was already labelled), spells the abbreviation out where there is no hover to move it into, and drops the redundant `baseline` badge from the score matrix.

Closes [LFE-15941](https://linear.app/clickhouse/issue/LFE-15941). **Position in the stack:** PR 11, based on `lfe-15711-10-output-scroll` (#17007).

**One line in the parent ticket is deliberately not acted on:** *"drop the tile"*. The screenshots in [LFE-15768](https://linear.app/clickhouse/issue/LFE-15768) are signed URLs that have since expired, so which tile is meant cannot be recovered from the ticket — and there are several candidates on that screen. Guessing would remove something a reader relies on. It needs one sentence from the reviewer, and stays open until then.

## Why

The header carried four numbers on one line — this column's aggregate, the comparison's, the signed delta, the movement counts — plus a fifth, the not-scored count, rendered as `3 n/a`. That fifth was the least-used of them, it was what pushed the line onto a second row, and it was opaque: the reviewer's note was *"`5 n/a` : what does this mean? 'not available' scores?"*.

The two vocabulary problems were the app disagreeing with itself. Everywhere else that column is the **baseline** — the URL param is `baseline=`, the toolbar chip reads `Baseline`, the matrix labels the column baseline — but its own hover called it "This experiment". And "not comparable" names our arithmetic, where the reader is judging what happened to the *item*.

## What

Four commits, one change each — the ticket's items (3) and (4) are one decision, so they are one commit.

1. **Vocabulary.** "This experiment (average)" → "Baseline experiment (average)". "Not comparable" → "Not scored".
2. **The header line loses the not-scored count.** It keeps its labelled row in the hover, so the breakdown still accounts for every item in view.
3. **The matrix spells it out.** `3 n/a` → `3 not scored`. A matrix cell has no hover to move a count into, so there it stays and says what it is.
4. **The matrix drops the `baseline` badge.** "column indicator not needed?" — it is not.

## Result

`Ø 0.70 · 13` / `vs Ø 0.70 −0.01 ↗6`, and a hover that reads `Baseline experiment (average) · Items scored · vs opus-strict-verification · Change · Improved · Regressed · Unchanged · Not scored`, summing to the 15 items on the page.

<details>
<summary>The one thing the ticket got wrong, and the invariant</summary>

**The internal field keeps its name, on purpose.** The ticket left this open ("renaming the user-facing label should not rename the internal field unless it is cheap and total"). It would have been cheap — 16 references — but it would also have been wrong. `notComparable` counts more than unscored items: a categorical score that *both* experiments recorded still lands in that bucket when the item's values leave no single value to compare. "Not scored" is the right word for the reader (it is what happens in almost every case, and it is the reviewer's word); `notComparable` is the right name in code. The field's doc comment now says so, and the explanation under the hover's count covers both cases instead of claiming one side is always missing.

**The invariant.** improved + regressed + unchanged + changed + not-scored = the item count. That is what made dropping the count from the header a *move* rather than a loss, and it is asserted in `summariseScoreColumn.clienttest.ts`, which compares the whole movement object. `summariseScoreColumn` itself is untouched here — the labels were wrong, not the counting — so no test needed editing, and none was deleted.

**Also deliberately untouched:** the score matrix's own empty-cell text already said `not scored`, so the two now agree.

**Per-branch checks** (`shared` rebuilt with `db:generate` + `build` first):

- `pnpm exec knip` — clean
- `pnpm --filter=web run typecheck` — clean
- `turbo lint --force` after `rm -rf web/.next/cache/eslint` — 7 successful, **`Cached: 0`**
- `vitest run --project client` — 411 files, 4,069 tests passed

**Browser** (the seeded 7-run demo project, dark + light, 1512×800 and 1280×720): no `n/a` left in any of the 11 score column headers; hover verified on a numeric, a boolean and a categorical column; the matrix header keeps the colour marker and the run name and reads correctly without the badge.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bxa4EbY1xw1VkJwxABKgm3


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR simplifies experiment score summaries by revising baseline and not-scored terminology, moving the not-scored count into the hover, and removing the matrix baseline badge.

- Rewords score-summary labels and explanations.
- Reduces the score-header movement line.
- Spells out matrix not-scored counts and simplifies matrix headers.
- Documents the broader meaning of the internal `notComparable` field.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The incorrect baseline attribution should be fixed before merging because clearing the baseline leaves score hovers displaying a run as the baseline.

The score calculations remain unchanged, but the new unconditional label conflicts with the existing state model in which selected runs can remain visible without an explicit baseline.

**Files Needing Attention:** web/src/features/experiments/components/table/ScoreColumnHeaderSummary.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/experiments/components/table/ScoreColumnHeaderSummary.tsx:158
**Baseline label misidentifies primary run**

When a user clears the baseline while runs remain selected, the first selected run still supplies the summary aggregate, but this row labels it as the `Baseline experiment`, causing the hover to attribute the aggregate to a baseline that no longer exists.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(experiments): drop the baseline..."](https://github.com/langfuse/langfuse/commit/655381186c500ba3661c7cf73ee116c603aa1f15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59914554)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->