### PR TITLE
refactor(experiments): keep the movement arrows on the delta's line

### DIFF
--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -970,6 +970,12 @@ export default function ExperimentItemsTable({
 
         return {
           ...scoreCol,
+          // The header holds this column's analysis, so it also sets the
+          // column's floor: the shared table's default lets a column be dragged
+          // to 20px, which is narrower than `−0.12 ↗1 ↘14` and would clip a
+          // count into a different, wrong number. 120px holds the delta and the
+          // movement counts whole.
+          minSize: 120,
           // The header carries the column's aggregate over the items in view, and
           // the movement against the comparison. Keeps the plain name for the
           // column picker.

--- a/web/src/features/experiments/components/table/ScoreColumnHeaderSummary.tsx
+++ b/web/src/features/experiments/components/table/ScoreColumnHeaderSummary.tsx
@@ -91,6 +91,21 @@ export const ScoreColumnHeaderSummary = ({
 }) => {
   const { baseline, comparison, delta, movement } = summary;
   const { icon, label: nameLabel } = splitScoreDataTypeIcon(label);
+  // A zero delta says nothing a reader cannot see from the two aggregates, so
+  // it does not earn a line; the movement counts still might.
+  const deltaToShow = delta !== null && delta !== 0 ? delta : null;
+  const hasMovementCounts = Boolean(
+    movement && (movement.improved || movement.regressed || movement.changed),
+  );
+  // The counts are the part a narrow column clips, so they say the same thing
+  // in words on hover.
+  const movementCountsTitle = [
+    movement?.improved ? `${movement.improved} improved` : null,
+    movement?.regressed ? `${movement.regressed} regressed` : null,
+    movement?.changed ? `${movement.changed} changed` : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
 
   return (
     // The filter menu sits outside the hover-card trigger so its own popover is
@@ -105,49 +120,85 @@ export const ScoreColumnHeaderSummary = ({
                 {nameLabel}
               </span>
             </span>
+            {/* The values: this column's aggregate, and the one it moved from.
+              The item count is deliberately NOT here — of the numbers competing
+              for these two lines it is the least valuable, it already has a
+              labelled row in the hover, and giving it up is what leaves the
+              movement counts room to stay beside their delta. */}
             <span className="text-muted-foreground flex flex-wrap items-center gap-x-1 text-[10px] leading-tight font-normal tabular-nums">
+              {/* `truncate`: each aggregate is one value, so it moves to the
+                next line whole rather than breaking in the middle of itself —
+                a categorical's `mostly-grounded 9/11` is long enough to do
+                that. And if one value alone is wider than the column, it ends
+                in an ellipsis: a value that stops with no mark reads as the
+                whole value. */}
               {baseline ? (
-                <>
-                  <span className="text-foreground font-bold">
-                    {formatScoreColumnAggregate(baseline)}
-                  </span>
-                  {baseline.kind !== "distribution" && (
-                    <span>· {baseline.count}</span>
-                  )}
-                </>
+                <span
+                  className="text-foreground min-w-0 truncate font-bold"
+                  title={formatScoreColumnAggregate(baseline)}
+                >
+                  {formatScoreColumnAggregate(baseline)}
+                </span>
               ) : (
                 <span>no values</span>
               )}
+              {/* Independent of the baseline's own aggregate: a score the
+                comparison recorded and this run has not yet is exactly the
+                case worth seeing. */}
+              {comparison && (
+                <span
+                  className="min-w-0 truncate"
+                  title={`vs ${formatScoreColumnAggregate(comparison)}`}
+                >
+                  vs {formatScoreColumnAggregate(comparison)}
+                </span>
+              )}
             </span>
-            {movement && (
-              <span className="text-muted-foreground flex flex-wrap items-center gap-x-1 text-[10px] leading-tight font-normal tabular-nums">
-                {comparison && (
-                  <span>vs {formatScoreColumnAggregate(comparison)}</span>
-                )}
-                {delta !== null && delta !== 0 && (
+            {/* The movement: how far, and how many items moved which way.
+              One line that does not wrap — a count is only readable as a
+              movement next to the delta it belongs to. The delta keeps its
+              full width; the counts are what give way, whole and marked with
+              an ellipsis, so a narrow column drops them here instead of
+              bleeding over the header beside it — the hover card carries every
+              count in full.
+
+              The not-scored count is deliberately not here either — it is
+              accounted for in the hover card. */}
+            {(deltaToShow !== null || hasMovementCounts) && (
+              <span className="text-muted-foreground flex min-w-0 items-center gap-x-1 overflow-hidden text-[10px] leading-tight font-normal tabular-nums">
+                {deltaToShow !== null && (
                   <DiffLabel
                     diff={{
                       type: "NUMERIC",
-                      absoluteDifference: Math.abs(delta),
-                      direction: delta > 0 ? "+" : "-",
+                      absoluteDifference: Math.abs(deltaToShow),
+                      direction: deltaToShow > 0 ? "+" : "-",
                     }}
                     formatValue={formatScoreValue}
                   />
                 )}
-                {movement.improved > 0 && (
-                  <span className="text-dark-green font-bold">
-                    ↗{movement.improved}
+                {hasMovementCounts && (
+                  // Not a flex row: `text-overflow` only applies to a block
+                  // box's inline content, and it is what drops a count whole
+                  // and marks it, instead of clipping `↘141` into `↘1`.
+                  <span
+                    className="min-w-0 truncate"
+                    title={movementCountsTitle}
+                  >
+                    {movement && movement.improved > 0 && (
+                      <span className="text-dark-green pr-1 font-bold">
+                        ↗{movement.improved}
+                      </span>
+                    )}
+                    {movement && movement.regressed > 0 && (
+                      <span className="text-dark-red pr-1 font-bold">
+                        ↘{movement.regressed}
+                      </span>
+                    )}
+                    {movement && movement.changed > 0 && (
+                      <span className="pr-1">↻{movement.changed}</span>
+                    )}
                   </span>
                 )}
-                {movement.regressed > 0 && (
-                  <span className="text-dark-red font-bold">
-                    ↘{movement.regressed}
-                  </span>
-                )}
-                {movement.changed > 0 && <span>↻{movement.changed}</span>}
-                {/* The not-scored count is deliberately NOT here: it is the
-                  least-used of these numbers and the line only holds three.
-                  It stays accounted for, in the hover. */}
               </span>
             )}
           </div>


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17010 app preview](https://pr-17010.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

The improved/regressed arrows wrapped away from the delta they describe at the default column width. The header's second line is now split by what the numbers *are* rather than which run they came from — values on one line, movement on a line that cannot wrap — and a score column can no longer be dragged narrower than the movement line needs. The header also got 13px shorter.

Closes [LFE-15942](https://linear.app/clickhouse/issue/LFE-15942). **Position in the stack:** PR 12; #17009 has merged, so this now targets `main` as a single commit.

## Why

The reviewer: *"I would put the regressed arrows (red/green) always into that row instead. rather than it wrapping across lines."*

Measured on the seeded data at the default 150px column, the movement line was **29px tall — two rows** — on the columns where anything actually moved: `vs 87% true −0.20 ↗1 ↘4` and `vs Ø 0.93 −0.12 ↗1 ↘14`. Dropping the not-scored count (PR 11) bought a line but not enough room: four things were still competing for one line. A movement count only means something next to its delta, so the two coming apart is the summary at its least readable — and it is what made it read as busy.

## What

**One commit, two parts.**

1. **Re-split the lines.** The comparison's aggregate joins this column's aggregate on the values line; the delta and the movement counts get a line of their own with no `flex-wrap`, so they cannot come apart. What pays for the room is the **item count**, which leaves the header for the hover, where it already had a labelled row — the ticket's stated order of value is delta → movement → comparison aggregate → item count, and the item count is last. A zero delta also stops taking a line: it says nothing the two aggregates above it do not.

   Each aggregate became atomic (`truncate`), so it moves to the next line whole instead of breaking mid-value — a categorical's `mostly-grounded 9/11 vs mostly-grounded 9/10` was rendering on three lines — and if one value alone is wider than the column it ends in an ellipsis rather than just stopping.

2. **A 120px floor on score columns.** The shared table's default lets any column go to 20px. That is narrower than `−0.12 ↗1 ↘14`, and a cut count does not read as truncation: it reads as `↘1`, a different and wrong number.

## Result

`Ø 0.70 vs Ø 0.70` / `−0.01 ↗6`. Every movement line is a single row at the default width **and** at the narrowest width the resizer now allows, with no horizontal overflow on any of the 11 score columns in the demo project. The header shrank from 78px to 65px.

<details>
<summary>Measurements and verification</summary>

Line heights, `answered_in_right_language` and `citation_markers_resolve` (the two with the most movement), line-height 12.5px:

| width | values line | movement line |
| --- | --- | --- |
| 150px (default), before | `67% true · 15` — 13px | `vs 87% true −0.20 ↗1 ↘4` — **29px, wrapped** |
| 150px, after | `67% true vs 87% true` — 13px | `−0.20 ↗1 ↘4` — 17px, one row |
| 120px (the new floor), after | 25px, two whole values | 17px, one row, 0px overflow |
| 20px (the old floor), after | overflowed the cell | one row, but overflowed it by 25px — which is what the floor exists to prevent |

The floor was checked by driving the resize handle itself, not by setting state: dragging 300px left now stops at 120px, and at 120px the movement line's `scrollWidth` equals its `clientWidth` on every numeric and boolean column. On a categorical column at 120px the aggregate ellipsises, which is the deliberate degradation — it has no delta or movement counts to protect.

**Per-branch checks** (`shared` rebuilt with `db:generate` + `build` first):

- `pnpm exec knip` — clean
- `pnpm --filter=web run typecheck` — clean
- `turbo lint --force` after `rm -rf web/.next/cache/eslint` — 7 successful, **`Cached: 0`**
- `vitest run --project client` — 411 files, 4,069 tests passed

**Browser**: dark and light, 1512×800 and 1280×720, on a diff view with a comparison selected. All six movement lines single-row in every combination.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bxa4EbY1xw1VkJwxABKgm3


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reorganizes experiment score-column headers so aggregates and movement indicators occupy separate lines, removes item counts from the visible header, and enforces a 120px minimum score-column width.
- Places baseline and comparison aggregates together with atomic truncation.
- Keeps delta and movement counts on a non-wrapping line.
- Prevents score columns from being resized below 120px.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The comparison-header omission should be fixed before merging because valid comparison-only score data becomes invisible in the table header.

Baseline and comparison aggregates are constructed independently, but the new rendering nests the comparison inside the baseline branch, causing a reachable comparison-only state to display only "no values."

**Files Needing Attention:** web/src/features/experiments/components/table/ScoreColumnHeaderSummary.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/experiments/components/table/ScoreColumnHeaderSummary.tsx:113-138
**Comparison aggregate disappears without baseline**

When the comparison has scores for this column but the primary experiment has none, `comparison` is populated independently while this branch renders only `no values`, causing the available comparison aggregate to disappear from the table header.

```suggestion
              {baseline ? (
                <span
                  className="text-foreground min-w-0 truncate font-bold"
                  title={formatScoreColumnAggregate(baseline)}
                >
                  {formatScoreColumnAggregate(baseline)}
                </span>
              ) : (
                <span>no values</span>
              )}
              {comparison && (
                <span
                  className="min-w-0 truncate"
                  title={`vs ${formatScoreColumnAggregate(comparison)}`}
                >
                  vs {formatScoreColumnAggregate(comparison)}
                </span>
              )}
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments): stop a score column be..."](https://github.com/langfuse/langfuse/commit/9e27f3481b11b16e65f98c63e760460d3e8170f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59917448)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
