### PR TITLE
refactor(experiments): one Table settings popover on the results view

### DIFF
--- a/web/src/components/table/data-table-settings-popover.tsx
+++ b/web/src/components/table/data-table-settings-popover.tsx
@@ -20,7 +20,8 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 
 /**
  * One "Table settings" surface for the controls that shape the same table —
- * columns and row height — instead of a button per control. Filed against the
+ * columns and row height, plus whatever presentation settings the surface adds
+ * through `extraSections` — instead of a button per control. Filed against the
  * old compare view as "fields vs. columns confused me as a new user"
  * and reproduced by the new experiments UI with one more control.
  *
@@ -39,6 +40,7 @@ export function DataTableSettingsPopover<TData, TValue>({
   tableName,
   isV4,
   onColumnGroupToggle,
+  extraSections,
 }: {
   columns: LangfuseColumnDef<TData, TValue>[];
   columnVisibility: VisibilityState;
@@ -52,6 +54,10 @@ export function DataTableSettingsPopover<TData, TValue>({
   tableName: string;
   isV4: boolean;
   onColumnGroupToggle?: (payload: ColumnGroupTogglePayload) => void;
+  /** A table's own presentation settings, rendered under the shared two. Each
+   *  should be a labelled block; a separator is drawn between them. Keeps
+   *  surface-specific vocabulary out of this component. */
+  extraSections?: React.ReactNode;
 }) {
   const capture = usePostHogClientCapture();
 
@@ -104,6 +110,12 @@ export function DataTableSettingsPopover<TData, TValue>({
               ))}
             </div>
           </div>
+          {extraSections && (
+            <>
+              <Separator />
+              {extraSections}
+            </>
+          )}
         </div>
       )}
     >

--- a/web/src/components/table/data-table-toolbar.clienttest.tsx
+++ b/web/src/components/table/data-table-toolbar.clienttest.tsx
@@ -221,4 +221,22 @@ describe("DataTableToolbar merged table settings", () => {
       screen.queryByRole("button", { name: /^Columns/ }),
     ).not.toBeInTheDocument();
   });
+
+  // A surface can add its own presentation settings to the popover (the
+  // experiment results view adds the cell format). They belong inside it, not
+  // as another button beside it — which is the shape this whole prop exists to
+  // avoid.
+  it("puts a surface's own settings section inside the popover", () => {
+    render(
+      <DataTableToolbar
+        {...settingsProps}
+        mergeSettingsIntoPopover
+        settingsSections={<p>Format</p>}
+      />,
+    );
+
+    expect(screen.queryByText("Format")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Table settings" }));
+    expect(screen.getByText("Format")).toBeInTheDocument();
+  });
 });

--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -170,6 +170,10 @@ interface DataTableToolbarProps<TData, TValue> {
    *  shape is validated on the experiments list; needs both controls, so a
    *  table that passes only one keeps its single button. */
   mergeSettingsIntoPopover?: boolean;
+  /** This surface's own presentation settings, rendered inside the merged
+   *  "Table settings" popover under Columns and row height. Ignored unless
+   *  `mergeSettingsIntoPopover` is on and both shared controls are present. */
+  settingsSections?: React.ReactNode;
   /** Notified when a whole column group is shown or hidden at once, for surfaces
    *  that report their own event for it (the experiments score families). */
   onColumnGroupToggle?: (payload: ColumnGroupTogglePayload) => void;
@@ -255,6 +259,7 @@ export function DataTableToolbar<TData, TValue>({
   viewModeToggle,
   leadingControls,
   mergeSettingsIntoPopover = false,
+  settingsSections,
   onColumnGroupToggle,
 }: DataTableToolbarProps<TData, TValue> & ToolbarTableIdentity) {
   const [searchString, setSearchString] = useState(
@@ -514,6 +519,7 @@ export function DataTableToolbar<TData, TValue>({
               tableName={analyticsTableName}
               isV4={analyticsIsV4}
               onColumnGroupToggle={onColumnGroupToggle}
+              extraSections={settingsSections}
             />
           ) : (
             <>

--- a/web/src/features/experiments/components/ExperimentDisplaySettings.tsx
+++ b/web/src/features/experiments/components/ExperimentDisplaySettings.tsx
@@ -9,7 +9,6 @@ import {
 } from "@/src/components/ui/dropdown-menu";
 import { Button } from "@/src/components/ui/button";
 import { Settings2, Check } from "lucide-react";
-import { type IoRenderMode } from "@/src/components/table/data-table-io-render-mode-switch";
 import {
   type ExperimentDiffMode,
   type ExperimentResultsLayout,
@@ -24,8 +23,6 @@ type ExperimentDisplaySettingsProps = {
   onItemVisibilityChange: (visibility: "baseline-only" | "all") => void;
   hasComparisons: boolean;
   hasBaseline: boolean;
-  ioRenderMode: IoRenderMode;
-  onIoRenderModeChange: (mode: IoRenderMode) => void;
 };
 
 /** A menu row that reads as a radio option. */
@@ -50,6 +47,15 @@ const OptionItem = ({
   </DropdownMenuItem>
 );
 
+/**
+ * The shape of the comparison, as one menu: which layout, what each cell's
+ * second line is measured against, and whether items missing from the baseline
+ * are listed.
+ *
+ * All three live in the URL, so they travel with a shared link — which is the
+ * line between this menu and the table's "Table settings" popover, where the
+ * per-user preferences (columns, row height, cell format) live.
+ */
 export function ExperimentDisplaySettings({
   layout,
   onLayoutChange,
@@ -59,8 +65,6 @@ export function ExperimentDisplaySettings({
   onItemVisibilityChange,
   hasComparisons,
   hasBaseline,
-  ioRenderMode,
-  onIoRenderModeChange,
 }: ExperimentDisplaySettingsProps) {
   const isItemVisibilityDisabled = !hasComparisons || !hasBaseline;
 
@@ -131,22 +135,6 @@ export function ExperimentDisplaySettings({
           onSelect={() => onItemVisibilityChange("all")}
         >
           Show all items
-        </OptionItem>
-
-        <DropdownMenuSeparator />
-
-        <DropdownMenuLabel>Format</DropdownMenuLabel>
-        <OptionItem
-          selected={ioRenderMode === "json"}
-          onSelect={() => onIoRenderModeChange("json")}
-        >
-          JSON
-        </OptionItem>
-        <OptionItem
-          selected={ioRenderMode === "text"}
-          onSelect={() => onIoRenderModeChange("text")}
-        >
-          Formatted
         </OptionItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/web/src/features/experiments/components/ExperimentFormatSetting.tsx
+++ b/web/src/features/experiments/components/ExperimentFormatSetting.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@/src/components/ui/button";
+import { type IoRenderMode } from "@/src/components/table/data-table-io-render-mode-switch";
+
+const FORMAT_OPTIONS: Array<{ id: IoRenderMode; label: string }> = [
+  { id: "json", label: "JSON" },
+  { id: "text", label: "Formatted" },
+];
+
+/**
+ * How an item's input and output are rendered in a cell, as a section of the
+ * table's own "Table settings" popover.
+ *
+ * It sits there rather than with the layout and diff controls because of what
+ * kind of setting it is: layout, diff mode and item visibility live in the URL
+ * and travel with a shared link, while this — like the column set and the row
+ * height it now sits beside — is a per-user preference in local storage that a
+ * link does not carry.
+ */
+export const ExperimentFormatSetting = ({
+  ioRenderMode,
+  onIoRenderModeChange,
+}: {
+  ioRenderMode: IoRenderMode;
+  onIoRenderModeChange: (mode: IoRenderMode) => void;
+}) => (
+  <div>
+    <p className="text-muted-foreground px-1 pb-1 text-xs">Format</p>
+    <div className="grid grid-cols-2 gap-1">
+      {FORMAT_OPTIONS.map(({ id, label }) => (
+        <Button
+          key={id}
+          variant={ioRenderMode === id ? "secondary" : "ghost"}
+          aria-pressed={ioRenderMode === id}
+          className="h-auto py-1.5"
+          onClick={() => onIoRenderModeChange(id)}
+        >
+          <span className="text-xs">{label}</span>
+        </Button>
+      ))}
+    </div>
+  </div>
+);

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -453,6 +453,7 @@ export default function ExperimentItemsTable({
   projectId,
   ioRenderMode,
   hideControls = false,
+  settingsSections,
 }: ExperimentItemsTableProps) {
   const { setDetailPageList } = useDetailPageLists();
   const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
@@ -1884,6 +1885,12 @@ export default function ExperimentItemsTable({
             orderByState={orderByState}
             rowHeight={rowHeight}
             setRowHeight={setRowHeight}
+            // One "Table settings" button for the controls that shape this
+            // table, as on the experiments list — where two buttons plus a
+            // third control in the page header was the inconsistency between
+            // the two surfaces of the same feature.
+            mergeSettingsIntoPopover
+            settingsSections={settingsSections}
             multiSelect={{
               selectAll,
               setSelectAll,

--- a/web/src/features/experiments/components/table/types.ts
+++ b/web/src/features/experiments/components/table/types.ts
@@ -187,6 +187,12 @@ export type ExperimentItemsTableProps = {
   hideControls?: boolean;
   /** Available experiments for filter targeting (baseline + comparisons) */
   availableExperiments?: ExperimentOption[];
+  /**
+   * Extra sections for the toolbar's "Table settings" popover. The page owns
+   * the settings that are not the table's own state (the cell format), so it
+   * renders them and this table only places them.
+   */
+  settingsSections?: ReactNode;
 };
 
 /**

--- a/web/src/pages/project/[projectId]/experiments/results.tsx
+++ b/web/src/pages/project/[projectId]/experiments/results.tsx
@@ -10,6 +10,7 @@ import {
 import useSessionStorage from "@/src/components/useSessionStorage";
 import { useCallback, useEffect } from "react";
 import { ExperimentDisplaySettings } from "@/src/features/experiments/components/ExperimentDisplaySettings";
+import { ExperimentFormatSetting } from "@/src/features/experiments/components/ExperimentFormatSetting";
 import { useExperimentAccess } from "@/src/features/experiments/hooks/useExperimentAccess";
 import Spinner from "@/src/components/design-system/Spinner/Spinner";
 import { ExperimentSelectionControls } from "@/src/features/experiments/components/ExperimentSelectionControls";
@@ -155,8 +156,6 @@ export default function ExperimentResults() {
               onItemVisibilityChange={setItemVisibility}
               hasComparisons={comparisonIds.length > 0}
               hasBaseline={hasBaseline}
-              ioRenderMode={ioRenderMode}
-              onIoRenderModeChange={setIoRenderMode}
             />
 
             <OverviewPanelToggle
@@ -172,9 +171,18 @@ export default function ExperimentResults() {
         persistId={`experiment-detail-${baselineId ?? "none"}`}
         mainContent={
           <ExperimentItemsTable
+            // The shared table body's memo comparator does not look at the
+            // column definitions, so a format change alone never reaches the
+            // cells. Remounting is what makes the switch take effect.
             key={ioRenderMode}
             projectId={projectId}
             ioRenderMode={ioRenderMode}
+            settingsSections={
+              <ExperimentFormatSetting
+                ioRenderMode={ioRenderMode}
+                onIoRenderModeChange={setIoRenderMode}
+              />
+            }
           />
         }
         overviewContent={


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17011 app preview](https://pr-17011.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

The results view now has the same single **Table settings** popover as the experiments list, with the cell format joining Columns and row height inside it. Layout, diff mode and item visibility stay in **Display** — and the PR argues why: those three live in the URL and travel with a shared link, the other three are per-user preferences that a link does not carry.

Closes [LFE-15943](https://linear.app/clickhouse/issue/LFE-15943). **Position in the stack:** PR 13, based on `lfe-15711-12-arrows-one-line` (#17010) — one commit each.

## Why

The reviewer: *"why not unify the row & display options under `Table settings` to be consistent with /experiments table"*.

Two surfaces of the same feature disagreed. The list merged its column picker and row-height switch into one popover; the results view kept **three** controls that shape its table, in **two** places — Columns and Row height in the toolbar, and a Display menu stranded up in the page header. That is the confusion [LFE-8420](https://linear.app/clickhouse/issue/LFE-8420) originally filed against the old compare view, reproduced.

## What

**One commit, two parts.**

1. **The shared seam.** `settingsSections` on the toolbar forwards a node into the merged popover, under the shared two controls. Optional, and only read when the merged popover is opted into.

2. **The results view adopts it.** One `Table settings` button; **Format** (JSON / Formatted) moves out of `Display` and into the popover beside row height; `Display` keeps Layout, Diff and Item visibility.

## Result

| | before | after |
| --- | --- | --- |
| /experiments | `Table settings` | unchanged — Columns + Row height, no Format |
| /results toolbar | `Columns 19/22` + `Row height` | `Table settings` — Columns + Row height + Format |
| /results page header | `Display` — Layout, Diff, Item visibility, Format | `Display` — Layout, Diff, Item visibility |
| every other table | `Columns` + `Row height` | unchanged |

<details>
<summary>The judgement call, and the proof the other tables are untouched</summary>

### Why `Display` stayed separate

The ticket left this open, and warned that one popover mixing "which columns" with "which layout" may be worse than two clear ones. It is — and there is a sharper line available than "view mode vs setting":

**What is in the URL, and what is not.** Layout, diff mode and item visibility are `?layout=`, `?diff=` and `?itemVisibility=`. They are *the view*: they travel with a shared link, and they belong beside the baseline and comparison pickers in the page header, which is where the rest of that same URL state already lives. Columns, row height and cell format are `localStorage`: they are *your* preferences, they do not travel, and they belong on the table's own toolbar.

That line also settles Format, which the old grouping got wrong: it was in `Display` with the URL state, but it is a local preference of the same kind as row height. Moving it is what makes both containers coherent rather than just fewer.

Two further reasons not to merge everything: the layout switch is the most-used control on this page (the reviewer's own notes are organised by layout), and putting it under a settings button next to a list of column checkboxes would cost real discoverability; and the page header is where a reader already looks to see *what* they are comparing.

**And it is cheap to reverse.** The sections are passed in as a node, so if the reviewer wants one button after all, moving Display's sections into the same popover is a one-line change at the call site — no new mechanism.

### Every other table

- **Static:** `mergeSettingsIntoPopover` has exactly two call sites (the experiments list, and now the results view) out of 34 toolbars; `settingsSections` has one. Both are optional and default off.
- **Test:** the existing `data-table-toolbar.clienttest.tsx` case asserts a default toolbar renders `Columns` and row height as separate controls and *no* `Table settings` button. A new case asserts a passed section is absent until the popover opens and then appears inside it.
- **Browser:** the traces table still shows `Columns 16/34` + `Row height` and no `Table settings`; the dataset items table likewise; the experiments list's popover still holds only Columns and Row height, with no Format leaking in.

### Analytics

Unchanged, and none renamed. `table:column_visibility_changed` and `table:row_height_switch_select` fire from inside the popover — the same code path the experiments list has been using — and the old standalone row-height switch is no longer rendered on this surface, so there is one source, not two. `experiment:layout_changed` and `experiment:diff_mode_changed` stay on the page's own handlers, which this PR does not touch. (The dev server has no PostHog key, so these were verified by code path and by the controls behaving, not by captured events.)

### Per-branch checks

`shared` rebuilt with `db:generate` + `build` first.

- `pnpm exec knip` — clean
- `pnpm --filter=web run typecheck` — clean
- `turbo lint --force` after `rm -rf web/.next/cache/eslint` — 7 successful, **`Cached: 0`**
- `vitest run --project client` — 412 files, 4,070 tests passed

**Browser** (dark + light, 1512×800 and 1280×720): each control driven from inside the popover — row height Small → Medium (persisted, popover stays open), Format JSON ↔ Formatted (persisted, cells switch renderer), a column toggled off and back on through the drawer that opens from inside the popover — and `Display` still writing `?layout=` and `?diff=` from the page header. Checked in both the diff and side-by-side layouts.

</details>

## Known limitation, and why it stays

Picking a format **closes the popover**, unlike Columns and Row height. Both reviewers flagged it; it is deliberate, and the naive fix was tried and reverted:

`results.tsx` keys `ExperimentItemsTable` on `ioRenderMode`, so a format change remounts the subtree holding the popover. Dropping that key does keep the popover open — and then the format switch stops working entirely until a reload. The shared table's `MemoizedTableBody` has a hand-written `React.memo` comparator (`web/src/components/table/data-table.tsx`) that compares data, row height, selection, column visibility and column order, but **not the column definitions** — and `singleLine` lives on the IO column defs, so a format change alone never invalidates the body. Verified in the browser: with the key gone, picking *Formatted* flips the buttons and persists the preference while every Input cell keeps rendering the JSON tree; after a reload the same state renders one raw line.

A popover that closes is worse than nothing changing at all, so the remount stays. The real fix belongs to the shared table's comparator, not to this page, and is filed as [LFE-16094](https://linear.app/clickhouse/issue/LFE-16094).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bxa4EbY1xw1VkJwxABKgm3


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates the experiment-results table controls into a single Table settings popover while retaining URL-backed comparison controls under Display.
- Adds an extension section to the shared table-settings popover.
- Moves experiment cell formatting into that section.
- Enables the merged settings popover for ExperimentItemsTable and updates its tests and prop contracts.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking interaction issue where choosing a format immediately closes Table settings.

The consolidated controls otherwise remain reachable, but changing ioRenderMode remounts the keyed table subtree and resets the popover that now contains the format control.

**Files Needing Attention:** web/src/pages/project/[projectId]/experiments/results.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/pages/project/[projectId]/experiments/results.tsx:177-183
**Format selection closes settings**

Selecting JSON or Formatted changes the key of the enclosing `ExperimentItemsTable`, remounting the subtree and resetting the open popover. Table settings therefore closes after every format selection, forcing users to reopen it before adjusting another option or switching back.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(experiments): one Table setting..."](https://github.com/langfuse/langfuse/commit/de82ba276e62e0e1f3497531da0d65c33970d7ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59921533)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

