### PR TITLE
fix(web): keep password reveal toggle out of the tab order

### DIFF
--- a/web/src/components/design-system/PasswordInput/PasswordInput.stories.tsx
+++ b/web/src/components/design-system/PasswordInput/PasswordInput.stories.tsx
@@ -43,6 +43,23 @@ export const TestTogglesVisibility = meta.story({
   },
 });
 
+export const TestSkipsVisibilityToggleWhenTabbing = meta.story({
+  name: "(Test) Skips Visibility Toggle When Tabbing",
+  args: {
+    "aria-label": "Password",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText("Password");
+    const toggle = canvas.getByRole("button", { name: "Show password" });
+
+    input.focus();
+    await userEvent.tab();
+
+    await expect(toggle).not.toHaveFocus();
+  },
+});
+
 export const TestDisablesVisibilityToggle = meta.story({
   name: "(Test) Disables Visibility Toggle",
   args: {

--- a/web/src/components/design-system/PasswordInput/PasswordInput.tsx
+++ b/web/src/components/design-system/PasswordInput/PasswordInput.tsx
@@ -42,6 +42,9 @@ export function PasswordInput({ ref, disabled, ...props }: PasswordInputProps) {
         aria-label={isPasswordVisible ? "Hide password" : "Show password"}
         aria-pressed={isPasswordVisible}
         disabled={disabled}
+        // Keep the reveal toggle out of the tab order so Tab moves between the
+        // form's inputs. It stays reachable for pointer and screen reader users.
+        tabIndex={-1}
         className="absolute top-1/2 right-3 -translate-y-1/2 transform cursor-pointer disabled:cursor-not-allowed"
         onClick={() => setIsPasswordVisible((visible) => !visible)}
       >


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17020 app preview](https://pr-17020.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Tabbing through any form built on `PasswordInput` — sign up, sign in, set/reset password — stops on the eye icon inside the field before reaching the next input. On the set-password form that means an extra Tab press to get from Password to Confirm Password.

## Change

`PasswordInput`'s reveal button now carries `tabIndex={-1}`, so Tab moves straight between the form's inputs. The button keeps its `aria-label`, `aria-pressed`, and `role=button`, so pointer, touch, and screen reader users can still toggle visibility; only the sequential tab stop is removed.

## Proof

Sign-up form on the locally built stack, focus starting in the Name field and Tab pressed repeatedly. Left is the pre-fix DOM, right is this branch.

<a href="https://cursor.com/agents/bc-ce65e628-fd11-4b6a-8c42-8973c285307e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsignup_password_tab_order_before_after.mp4"><img src="https://cursor.com/artifacts/c/art-b86b5ac0-936a-4da0-9bb1-100ccec1fd53" alt="signup_password_tab_order_before_after.mp4" /></a>

Focus chain captured from the same runs:

```
### before (starting from the Name field)
  Tab 1: input name=email
  Tab 2: input type=password name=password
  Tab 3: button type=button aria-label="Show password"
  Tab 4: button type=submit text="Sign up"

### after (starting from the Name field)
  Tab 1: input name=email
  Tab 2: input type=password name=password
  Tab 3: button type=submit text="Sign up"
  Tab 4: a text="Sign in"
```

## Verification

Added a Storybook interaction test, `(Test) Skips Visibility Toggle When Tabbing`, which focuses the input, presses Tab, and asserts the toggle does not receive focus. It fails on `main` and passes with the fix.

- `pnpm --filter web run test-storybook`: `Test Files 181 passed (181)`, `Tests 904 passed (904)`
- `pnpm run lint`: `Tasks: 7 successful, 7 total`
- `pnpm run typecheck`: `Tasks: 8 successful, 8 total`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce65e628-fd11-4b6a-8c42-8973c285307e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce65e628-fd11-4b6a-8c42-8973c285307e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes PasswordInput's visibility toggle from sequential tab navigation and adds a Storybook interaction test for that behavior. The change improves movement between fields but makes the reveal action unavailable to keyboard-only users.
- Adds `tabIndex={-1}` to the password-visibility button.
- Adds a Storybook test asserting that Tab does not focus the visibility toggle.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The keyboard accessibility regression should be fixed before merging because keyboard-only users lose access to password visibility controls.

The visibility state can only be changed through a button that this PR removes from sequential keyboard focus, and the added test does not verify the intended next-field destination.

**Files Needing Attention:** web/src/components/design-system/PasswordInput/PasswordInput.tsx, web/src/components/design-system/PasswordInput/PasswordInput.stories.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/design-system/PasswordInput/PasswordInput.tsx:45-47
**Reveal control loses keyboard access**

When a keyboard-only user needs to inspect an obscured password or credential, `tabIndex={-1}` prevents reaching the only control that changes visibility, causing the reveal and hide functionality to become unavailable without a pointer.

```suggestion

```

### Issue 2
web/src/components/design-system/PasswordInput/PasswordInput.stories.tsx:56-59
**Test omits focus destination**

This isolated story only asserts that the toggle lacks focus, so it still passes when Tab moves to the document body or another unintended element instead of the next form input. Render a following input and positively assert that it receives focus.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): keep password reveal toggle ou..."](https://github.com/langfuse/langfuse/commit/fd4963cf801c906bab6efd7a827948cf0d35dd46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59980402)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->