### PR TITLE
feat(experiments): resolve the experiment behind a trace-attached score

### DIFF
--- a/packages/shared/src/eventsTable.ts
+++ b/packages/shared/src/eventsTable.ts
@@ -7,6 +7,22 @@ export const eventsTableIsRootObservationSqlForAlias = (alias: string) => {
 };
 export const eventsTableIsRootObservationSql =
   eventsTableIsRootObservationSqlForAlias("e");
+
+/**
+ * The row the `scores -> events_traces` relation resolves a trace through:
+ * strictly the parentless one, and deliberately NOT the semantic root that
+ * `eventsTableIsRootObservationSqlForAlias` matches. Joining on a semantic root
+ * can match two rows in dual-write data and multiply a score, which is why that
+ * relation has always been narrow.
+ *
+ * The cost is that a trace whose only root is an app root (a newer SDK marking
+ * its own root under an upstream parent) is not attributable to an experiment
+ * through this relation at all. So anything that decides WHICH traces the
+ * relation can attribute has to use this predicate, not the semantic one, or it
+ * offers something the join cannot resolve.
+ */
+export const eventsTableScoreTraceRootSqlForAlias = (alias: string) =>
+  `${alias}.parent_span_id = ''`;
 export const eventsTableTraceNameSqlForAlias = (alias: string) =>
   `COALESCE(nullIf(${alias}.trace_name, ''), if(${eventsTableIsRootObservationSqlForAlias(alias)}, nullIf(${alias}.name, ''), NULL))`;
 export const eventsTableTraceNameSql = eventsTableTraceNameSqlForAlias("e");

--- a/packages/shared/src/features/query/dataModel.ts
+++ b/packages/shared/src/features/query/dataModel.ts
@@ -882,6 +882,29 @@ const scoresV2BaseDimensions: DimensionsDeclarationType = {
     highCardinality: true,
     uiHidden: true,
   },
+  // The same two fields for trace-attached scores. A trace-level score has no
+  // `observation_id`, so the `events_observations` join above never matches and
+  // the dimensions next to it read null — which is where an LLM-as-judge on a
+  // dataset run writes. These read the experiment off the trace's root event
+  // instead.
+  traceExperimentName: {
+    sql: "nullIf(events_traces.experiment_name, '')",
+    alias: "traceExperimentName",
+    type: "string",
+    relationTable: "events_traces",
+    description: "Name of the experiment the scored trace belongs to.",
+    highCardinality: true,
+    uiHidden: true,
+  },
+  traceExperimentId: {
+    sql: "nullIf(events_traces.experiment_id, '')",
+    alias: "traceExperimentId",
+    type: "string",
+    relationTable: "events_traces",
+    description: "ID of the experiment the scored trace belongs to.",
+    highCardinality: true,
+    uiHidden: true,
+  },
 };
 
 // Factory for shared score-specific dimensions (both numeric and categorical)

--- a/packages/shared/src/features/query/dataModel.ts
+++ b/packages/shared/src/features/query/dataModel.ts
@@ -9,6 +9,7 @@ import {
 import { InvalidRequestError } from "../../errors";
 import {
   eventsTableIsRootObservationSqlForAlias,
+  eventsTableScoreTraceRootSqlForAlias,
   eventsTableTraceNameAggregationSqlForAlias,
   eventsTableTraceNameSqlForAlias,
 } from "../../eventsTable";
@@ -1039,8 +1040,9 @@ const createScoreTableRelations = (
       // its app roots come from newer SDKs and are expected to carry trace_name.
       // A semantic-root join can match both rows in dual-write data and
       // multiply scores for little fallback value.
-      joinConditionSql:
-        "ON scores.trace_id = events_traces.trace_id AND scores.project_id = events_traces.project_id AND events_traces.parent_span_id = ''",
+      joinConditionSql: `ON scores.trace_id = events_traces.trace_id AND scores.project_id = events_traces.project_id AND ${eventsTableScoreTraceRootSqlForAlias(
+        "events_traces",
+      )}`,
       timeDimension: "start_time",
       useFinal: false,
     },

--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -440,6 +440,23 @@ export const eventsExperimentsRootSpans = (params: {
   );
 
 /**
+ * Narrows to the trace's parentless row, and only when that row itself carries
+ * the experiment. `experiment_id` is stamped on an item's root span and its
+ * subtree, so a trace whose item is nested inside a wider trace has a
+ * parentless row without one.
+ *
+ * This is the linkage the scores -> events_traces relation joins on, so a
+ * trace-level score reachable through this fragment is one a chart over that
+ * relation can actually plot. Use `eventsExperimentsRootSpans` instead for the
+ * per-item semantics the item tables need.
+ */
+export const eventsExperimentsTraceRootSpans = (params: {
+  projectId: string;
+  experimentIds?: string[];
+}): EventsQueryBuilder =>
+  eventsExperiments(params).whereRaw("e.parent_span_id = ''");
+
+/**
  * Session-level scores aggregation CTE.
  * Groups scores by (project_id, session_id), computing numeric/boolean averages
  * and categorical value lists.

--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -16,7 +16,10 @@ import {
   SCORE_TO_TRACE_OBSERVATIONS_INTERVAL,
 } from "../../repositories/constants";
 import type { ClickhouseFilter } from "./clickhouse-filter";
-import { eventsTableTraceNameSql } from "../../../eventsTable";
+import {
+  eventsTableScoreTraceRootSqlForAlias,
+  eventsTableTraceNameSql,
+} from "../../../eventsTable";
 
 /**
  * Lightweight trace metadata query: one row per trace with name, user_id, tags.
@@ -440,21 +443,23 @@ export const eventsExperimentsRootSpans = (params: {
   );
 
 /**
- * Narrows to the trace's parentless row, and only when that row itself carries
- * the experiment. `experiment_id` is stamped on an item's root span and its
- * subtree, so a trace whose item is nested inside a wider trace has a
- * parentless row without one.
+ * Narrows to the row the scores -> events_traces relation joins on, and only
+ * when that row itself carries the experiment. `experiment_id` is stamped on an
+ * item's root span and its subtree, so a trace whose item is nested inside a
+ * wider trace has a parentless row without one.
  *
- * This is the linkage the scores -> events_traces relation joins on, so a
- * trace-level score reachable through this fragment is one a chart over that
- * relation can actually plot. Use `eventsExperimentsRootSpans` instead for the
- * per-item semantics the item tables need.
+ * Shares its predicate with that relation's join condition so the two cannot
+ * drift: a trace-level score reachable through this fragment is one a chart
+ * over the relation can actually plot. Note this is deliberately NOT the
+ * semantic-root test — see `eventsTableScoreTraceRootSqlForAlias`. Use
+ * `eventsExperimentsRootSpans` instead for the per-item semantics the item
+ * tables need.
  */
 export const eventsExperimentsTraceRootSpans = (params: {
   projectId: string;
   experimentIds?: string[];
 }): EventsQueryBuilder =>
-  eventsExperiments(params).whereRaw("e.parent_span_id = ''");
+  eventsExperiments(params).whereRaw(eventsTableScoreTraceRootSqlForAlias("e"));
 
 /**
  * Session-level scores aggregation CTE.

--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -892,7 +892,9 @@ const getExperimentScoreOptionsByLevel = async ({
   });
 
   // Trace-level names are half of what the level-agnostic facets offer; without
-  // this a score recorded on the trace was never even suggested.
+  // this a score recorded on the trace was never even suggested — and it is also
+  // where an LLM-as-judge on a dataset run writes, so it belongs in the chart's
+  // metric list next to the other two levels.
   const traceQuery = buildScoreFilterOptionsQuery({
     projectId,
     experimentIds: uniqueExperimentIds,

--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -19,6 +19,7 @@ import {
   buildScoreRowsCTE,
   buildScoresCTE,
   eventsExperimentsRootSpans,
+  eventsExperimentsTraceRootSpans,
   eventsExperimentsForItems,
   eventsExperiments,
   eventsExperimentsAggregation,
@@ -691,14 +692,23 @@ const buildScoreFilterOptionsQuery = (params: {
   projectId: string;
   experimentIds: string[];
   level: "observation" | "trace";
+  /**
+   * Which span has to carry the experiment for a score to count as belonging
+   * to it. `itemRoot` (the default) is the per-item view the item tables
+   * filter on. `traceLinkage: "traceRoot"` matches what a chart over the
+   * scores -> events_traces relation can resolve, so an option offered under
+   * it can actually be plotted. Only meaningful at trace level.
+   */
+  traceLinkage?: "itemRoot" | "traceRoot";
 }): { query: string; params: Record<string, unknown> } => {
-  const { projectId, experimentIds, level } = params;
+  const { projectId, experimentIds, level, traceLinkage = "itemRoot" } = params;
 
   // Build experiment events CTE using existing fragment
-  const experimentEventsCTE = eventsExperimentsRootSpans({
-    projectId,
-    experimentIds,
-  })
+  const experimentEventsCTE = (
+    traceLinkage === "traceRoot"
+      ? eventsExperimentsTraceRootSpans({ projectId, experimentIds })
+      : eventsExperimentsRootSpans({ projectId, experimentIds })
+  )
     .selectRaw("e.project_id", "e.trace_id", "e.span_id")
     .limitBy("e.project_id", "e.trace_id", "e.span_id")
     .buildWithParams();
@@ -895,10 +905,17 @@ const getExperimentScoreOptionsByLevel = async ({
   // this a score recorded on the trace was never even suggested — and it is also
   // where an LLM-as-judge on a dataset run writes, so it belongs in the chart's
   // metric list next to the other two levels.
+  //
+  // These names feed a metric dropdown, so they are matched on the trace's own
+  // parentless row: that is the linkage the chart resolves the experiment
+  // through, and offering a metric that draws nothing is worse than leaving it
+  // out. A trace-level score on a trace shared with non-experiment work is not
+  // attributable to a single run through that linkage, so it stays out.
   const traceQuery = buildScoreFilterOptionsQuery({
     projectId,
     experimentIds: uniqueExperimentIds,
     level: "trace",
+    traceLinkage: "traceRoot",
   });
 
   const runQuery = buildExperimentRunScoreFilterOptionsQuery({

--- a/web/src/__tests__/server/experiment-score-levels.servertest.ts
+++ b/web/src/__tests__/server/experiment-score-levels.servertest.ts
@@ -269,6 +269,74 @@ maybeEventTables("level-agnostic experiment score filters", () => {
     ]);
     expect(options.score_name_levels_numeric[traceOnly]).toEqual(["trace"]);
   });
+
+  it("withholds a chart metric for a trace-level score it cannot attribute", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const startTimeMs = Date.now();
+    const scoreName = `nested-${randomUUID().slice(0, 8)}`;
+    const traceId = randomUUID();
+    const appRootSpanId = randomUUID();
+    const itemRootSpanId = randomUUID();
+    const experimentId = `exp-${randomUUID()}`;
+
+    // The item runs inside a wider trace, so the trace's parentless row is app
+    // work that carries no experiment. The chart resolves a run through that
+    // row, so it can never attribute this score to the run.
+    await createEventsCh([
+      createEvent({
+        id: appRootSpanId,
+        span_id: appRootSpanId,
+        trace_id: traceId,
+        project_id: projectId,
+        name: "app-root",
+        type: "SPAN",
+        start_time: startTimeMs * 1000,
+        end_time: (startTimeMs + 200) * 1000,
+      }),
+      createEvent({
+        id: itemRootSpanId,
+        span_id: itemRootSpanId,
+        parent_span_id: appRootSpanId,
+        trace_id: traceId,
+        project_id: projectId,
+        name: "nested-item-root",
+        type: "SPAN",
+        start_time: startTimeMs * 1000,
+        end_time: (startTimeMs + 100) * 1000,
+        experiment_id: experimentId,
+        experiment_name: "nested-item-run",
+        experiment_dataset_id: "dataset-score-levels",
+        experiment_item_id: randomUUID(),
+        experiment_item_root_span_id: itemRootSpanId,
+      }),
+    ]);
+
+    await createScoresCh([
+      createTraceScore({
+        project_id: projectId,
+        trace_id: traceId,
+        observation_id: null,
+        name: scoreName,
+        value: 0.9,
+        data_type: "NUMERIC",
+        timestamp: startTimeMs,
+      }),
+    ]);
+
+    const chartOptions = await getExperimentScoreOptions({
+      projectId,
+      experimentIds: [experimentId],
+    });
+    expect(chartOptions.trace_scores_avg).not.toContain(scoreName);
+
+    // The item table filters per item, not through the chart's linkage, so the
+    // same score stays available there.
+    const itemOptions = await getExperimentItemsFilterOptions({
+      projectId,
+      experimentIds: [experimentId],
+    });
+    expect(itemOptions.trace_scores_avg).toContain(scoreName);
+  });
 });
 
 maybeEventTables("level-agnostic experiment ITEM score filters", () => {

--- a/web/src/__tests__/server/repositories/experiment-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/experiment-repository.servertest.ts
@@ -1775,6 +1775,56 @@ describe("Clickhouse Experiment Repository Test", () => {
       });
     });
 
+    it("should return trace-level score options", async () => {
+      const experimentId = randomUUID();
+      const traceId = randomUUID();
+      const rootSpanId = randomUUID();
+
+      await createEventsCh([
+        createEvent({
+          id: randomUUID(),
+          span_id: rootSpanId,
+          project_id: projectId,
+          trace_id: traceId,
+          type: "GENERATION",
+          name: "test-generation",
+          experiment_id: experimentId,
+          experiment_name: "exp-" + randomUUID(),
+          experiment_metadata_names: [],
+          experiment_metadata_values: [],
+          experiment_dataset_id: randomUUID(),
+          experiment_item_id: randomUUID(),
+          experiment_item_version: null,
+          experiment_item_root_span_id: rootSpanId,
+          start_time: new Date().getTime() * 1000,
+        }),
+      ]);
+
+      await createScoresCh([
+        createTraceScore({
+          project_id: projectId,
+          trace_id: traceId,
+          observation_id: null,
+          name: "trace_groundedness",
+          value: 0.42,
+          source: "API",
+          data_type: "NUMERIC",
+        }),
+      ]);
+
+      const result = await getExperimentScoreOptions({
+        projectId,
+        experimentIds: [experimentId],
+      });
+
+      expect(result.trace_scores_avg).toContain("trace_groundedness");
+      expect(result.trace_score_columns).toContainEqual({
+        name: "trace_groundedness",
+        dataType: "NUMERIC",
+        source: "API",
+      });
+    });
+
     it("should return experiment-run score filter options", async () => {
       const experimentId = randomUUID();
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17022 app preview](https://pr-17022.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

A score attached to a **trace** could not be resolved back to the experiment it
belongs to, so it was invisible to charts and to the experiment metric list —
and trace level is exactly where an LLM-as-judge on a dataset run writes. This
adds the two dimensions that resolve it, plus the linkage rule that decides
which trace-level scores are actually attributable to a single run.

**Backend-only, extracted deliberately so a backend engineer can review it on
its own.** 5 files, +183/−6, of which 118 lines are tests. No Prisma schema, no
ClickHouse migration, no worker, no public API, no queue contract.

It is the backend half of an 11-PR frontend stack (#16914 … #17011) and lands
first; the five files here are byte-identical to their state in #16914, so that
PR absorbs this merge as a no-op.

## Why

`scoresV2` resolves a score's experiment by joining `events_observations`. A
trace-attached score has no `observation_id`, so that join never matches and
`experimentName` / `experimentId` read null next to it. The score exists, is
aggregated correctly everywhere else, and simply cannot be grouped by run.

## What

**1. Two trace-scoped dimensions** (`dataModel.ts`) — `traceExperimentName` and
`traceExperimentId`, reading `events_traces` instead of `events_observations`.
Both `uiHidden`, both on a relation the model already declares, so they only
add a join when something selects them.

**2. A root-span fragment and an opt-in linkage**
(`query-fragments.ts`, `experiments.ts`) — a trace-level score name is only
offered as a metric when the trace's own parentless row carries the experiment.
That is the linkage the `scores → events_traces` relation joins on, so a name
offered under it can actually be plotted; offering a metric that draws nothing
is worse than leaving it out. The repository parameter defaults to the existing
per-item linkage, which is what the item tables filter on.

## What I would like a second opinion on

1. **Two notions of "root" now coexist.** This fragment uses the narrow
   `parent_span_id = ''`, matching the join it mirrors
   (`dataModel.ts`, the `events_traces` relation). But `eventsTable.ts` uses the
   broader `(parent_span_id = '' OR is_app_root = true)`. Consistent with what
   it mirrors — but if app-root traces should also count, then both places are
   wrong today, not just this one.
2. **Cost of the two dimensions.** They are `uiHidden` and per-dimension
   `relationTable`, so I read that as "join only when selected". Worth
   confirming against how the builder assembles relations.
3. **The narrowing's blast radius.** It changes the trace-level and agnostic
   fields returned by `getExperimentScoreOptions`. On `main` the only consumer
   of that procedure is the experiments charts grid, which reads the
   observation- and run-level fields and never the trace-level or agnostic ones
   — so nothing on `main` observes the change. The **item** table's facets and
   score columns come from `getExperimentItemScoreOptionsByLevel`, which this
   PR does not touch. Please sanity-check that reading.

<details>
<summary>Verification</summary>

- `parent_span_id` is a non-`Nullable` `String` in `events_full` and
  `events_core`, so `= ''` is a sound root test — a `Nullable` column would have
  made the predicate silently match nothing.
- `turbo run typecheck` — `Tasks: 8 successful, 8 total`
- `turbo lint --force` — `Tasks: 7 successful, 7 total`, `Cached: 0 cached`
- `pnpm exec knip` — clean
- `experiment-score-levels.servertest.ts` — `Tests 9 passed (9)`
- `experiment-repository.servertest.ts` — `Tests 26 passed (26)`
- Exercised end-to-end in the browser on the stack, against a project whose
  trace-level scores are the whole story: the metric list offers them, the
  score matrix aggregates them, and the per-run series plot.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables experiment attribution for trace-attached scores while ensuring score discovery follows the same linkage used by experiment charts.

- Adds hidden trace-scoped experiment name and ID dimensions to the v2 score model.
- Adds a parentless trace-root experiment query fragment.
- Uses trace-root linkage for experiment chart score options while preserving item-root linkage for item tables.
- Adds server tests for trace-level options and nested-item behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The new dimensions and score-option query use the same parentless trace linkage, nested-item behavior is deliberately separated from item-table semantics, and tests cover the affected trace-level paths.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  S[Trace-attached score] --> T{Consumer}
  T -->|Experiment charts| R[Parentless trace-root linkage]
  R --> D[traceExperimentName / traceExperimentId]
  D --> C[Experiment metric series]
  T -->|Experiment item table| I[Item-root linkage]
  I --> F[Item score options and filters]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments): only offer trace-score..."](https://github.com/langfuse/langfuse/commit/82f34f092af5ec22611e8ae7d7507c4cd838f864) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59993478)</sub>

**Context used:**

- Knowledge Base — [Analytics and query data](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/analytics-query-data.md)
- Knowledge Base — [Datasets and experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-and-experiments.md)

<!-- /greptile_comment -->