### PR TITLE
perf(clickhouse): enable text index caches on the events read path

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -290,9 +290,10 @@ LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH=false
 
 CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE="true"
 # Each `auto` detects its affected ClickHouse versions on startup. Set `true`
-# to force a workaround or `false` to force-disable it.
+# to force the setting on or `false` to force it off.
 CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION=auto
 CLICKHOUSE_DISABLE_TOP_K_THROUGH_JOIN=auto
+CLICKHOUSE_ENABLE_SKIP_INDEXES_ON_DATA_READ=auto
 
 # ClickHouse Billing (CHB) integration (Langfuse Cloud only). First-time
 # upgrades on/after this UTC date (YYYY-MM-DD) route to CHB; unset = off.

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -154,6 +154,11 @@ const EnvSchema = z.object({
   CLICKHOUSE_DISABLE_TOP_K_THROUGH_JOIN: z
     .enum(["auto", "true", "false"])
     .default("auto"),
+  // Read-time skip-index evaluation, applied only from the version that fixes
+  // the patch-part read bug. See the compatibility rule for details.
+  CLICKHOUSE_ENABLE_SKIP_INDEXES_ON_DATA_READ: z
+    .enum(["auto", "true", "false"])
+    .default("auto"),
   CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY: z.coerce
     .number()
     .default(32_000_000_000), // ~32GB

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -116,11 +116,15 @@ export class ClickHouseClientManager {
       preferredClickhouseService === "EventsReadOnly"
         ? {
             enable_full_text_index: 1,
-            // Text index caches and read-time skip-index evaluation, all
-            // default off on ClickHouse 25.12 (the Langfuse v4 minimum). Newer
-            // servers default some on, and use_text_index_dictionary_cache is
-            // accepted but ignored from 26.3.
-            use_skip_indexes_on_data_read: 1,
+            // Text index caches, all default off on ClickHouse 25.12 (the
+            // Langfuse v4 minimum). use_text_index_header_cache defaults on
+            // from 26.7, and use_text_index_dictionary_cache is accepted but
+            // ignored from 26.3.
+            //
+            // use_skip_indexes_on_data_read must stay unset: on 25.12 it fails
+            // reads of columns patched by a lightweight update with "Not found
+            // column _part_offset in block". ClickHouse 26.2 fixes that and
+            // enables the setting by default, so there is nothing to set here.
             use_text_index_dictionary_cache: 1,
             use_text_index_header_cache: 1,
             use_text_index_postings_cache: 1,

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -114,7 +114,17 @@ export class ClickHouseClientManager {
   ): ServiceClickhouseSettings {
     const eventROSettings: ServiceClickhouseSettings =
       preferredClickhouseService === "EventsReadOnly"
-        ? { enable_full_text_index: 1 }
+        ? {
+            enable_full_text_index: 1,
+            // Text index caches and read-time skip-index evaluation, all
+            // default off on ClickHouse 25.12 (the Langfuse v4 minimum). Newer
+            // servers default some on, and use_text_index_dictionary_cache is
+            // accepted but ignored from 26.3.
+            use_skip_indexes_on_data_read: 1,
+            use_text_index_dictionary_cache: 1,
+            use_text_index_header_cache: 1,
+            use_text_index_postings_cache: 1,
+          }
         : {};
 
     return {

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -120,11 +120,6 @@ export class ClickHouseClientManager {
             // Langfuse v4 minimum). use_text_index_header_cache defaults on
             // from 26.7, and use_text_index_dictionary_cache is accepted but
             // ignored from 26.3.
-            //
-            // use_skip_indexes_on_data_read must stay unset: on 25.12 it fails
-            // reads of columns patched by a lightweight update with "Not found
-            // column _part_offset in block". ClickHouse 26.2 fixes that and
-            // enables the setting by default, so there is nothing to set here.
             use_text_index_dictionary_cache: 1,
             use_text_index_header_cache: 1,
             use_text_index_postings_cache: 1,

--- a/packages/shared/src/server/clickhouse/compatibility.test.ts
+++ b/packages/shared/src/server/clickhouse/compatibility.test.ts
@@ -4,6 +4,7 @@ const envMock = vi.hoisted(() => ({
   env: {
     CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: "auto",
     CLICKHOUSE_DISABLE_TOP_K_THROUGH_JOIN: "auto",
+    CLICKHOUSE_ENABLE_SKIP_INDEXES_ON_DATA_READ: "auto",
   },
 }));
 
@@ -21,6 +22,7 @@ const disableLazyMaterialization = {
   query_plan_optimize_lazy_materialization: 0,
 };
 const disableTopKThroughJoin = { query_plan_top_k_through_join: 0 };
+const enableSkipIndexesOnDataRead = { use_skip_indexes_on_data_read: 1 };
 
 describe("ClickHouse compatibility version parsing", () => {
   it("parses and compares ClickHouse build components", () => {
@@ -59,32 +61,47 @@ describe("resolveClickHouseCompatibility", () => {
     // Patch-parts lower bound and upstream fix.
     ["25.3.99.9999", noCompatibilitySettings],
     ["25.4.0.0", disableLazyMaterialization],
-    ["26.4.1.1005", noCompatibilitySettings],
+    ["26.4.1.1005", enableSkipIndexesOnDataRead],
+    // Read-time skip-index evaluation, from the release that fixes the
+    // patch-part read. It must stay off on 25.12, the Langfuse v4 minimum,
+    // where it breaks reads of lightweight-update patch parts.
+    ["25.12.11.4", disableLazyMaterialization],
+    ["26.1.99.9999", disableLazyMaterialization],
+    [
+      "26.2.0.0",
+      { ...disableLazyMaterialization, ...enableSkipIndexesOnDataRead },
+    ],
     // Top-K introduction and the exact fix on each release line.
-    ["26.5.1.650", noCompatibilitySettings],
-    ["26.5.1.651", disableTopKThroughJoin],
-    ["26.5.6.70", noCompatibilitySettings],
-    ["26.6.0.0", disableTopKThroughJoin],
-    ["26.6.2.108", noCompatibilitySettings],
-    ["26.7.0.0", disableTopKThroughJoin],
-    ["26.7.1.1334", noCompatibilitySettings],
-    ["26.7.2.0", disableTopKThroughJoin],
-    ["26.7.2.11", noCompatibilitySettings],
-    ["26.7.99.9999", noCompatibilitySettings],
-    ["26.8.0.0", noCompatibilitySettings],
-    ["26.8.1.2041", noCompatibilitySettings],
+    ["26.5.1.650", enableSkipIndexesOnDataRead],
+    [
+      "26.5.1.651",
+      { ...disableTopKThroughJoin, ...enableSkipIndexesOnDataRead },
+    ],
+    ["26.5.6.70", enableSkipIndexesOnDataRead],
+    ["26.6.0.0", { ...disableTopKThroughJoin, ...enableSkipIndexesOnDataRead }],
+    ["26.6.2.108", enableSkipIndexesOnDataRead],
+    ["26.7.0.0", { ...disableTopKThroughJoin, ...enableSkipIndexesOnDataRead }],
+    ["26.7.1.1334", enableSkipIndexesOnDataRead],
+    ["26.7.2.0", { ...disableTopKThroughJoin, ...enableSkipIndexesOnDataRead }],
+    ["26.7.2.11", enableSkipIndexesOnDataRead],
+    ["26.7.99.9999", enableSkipIndexesOnDataRead],
+    ["26.8.0.0", enableSkipIndexesOnDataRead],
+    ["26.8.1.2041", enableSkipIndexesOnDataRead],
   ])("resolves automatic settings for %s", (version, expectedSettings) => {
     expect(resolveClickHouseCompatibility({ version }).settings).toEqual(
       expectedSettings,
     );
   });
 
-  it("reports both independently computed compatibility flags", () => {
+  it("reports each independently computed compatibility flag", () => {
     const resolved = resolveClickHouseCompatibility({
       version: "26.5.5.8",
     });
 
-    expect(resolved.settings).toEqual(disableTopKThroughJoin);
+    expect(resolved.settings).toEqual({
+      ...disableTopKThroughJoin,
+      ...enableSkipIndexesOnDataRead,
+    });
     expect(resolved.flags).toEqual([
       expect.objectContaining({
         id: "disable-lazy-materialization-for-patch-parts",
@@ -95,6 +112,12 @@ describe("resolveClickHouseCompatibility", () => {
       expect.objectContaining({
         id: "disable-top-k-through-join",
         setting: "query_plan_top_k_through_join",
+        matchesVersionBand: true,
+        applied: true,
+      }),
+      expect.objectContaining({
+        id: "enable-skip-indexes-on-data-read",
+        setting: "use_skip_indexes_on_data_read",
         matchesVersionBand: true,
         applied: true,
       }),
@@ -112,6 +135,7 @@ describe("resolveClickHouseCompatibility", () => {
       }).settings,
     ).toEqual({
       ...disableLazyMaterialization,
+      ...enableSkipIndexesOnDataRead,
     });
   });
 });

--- a/packages/shared/src/server/clickhouse/compatibility.ts
+++ b/packages/shared/src/server/clickhouse/compatibility.ts
@@ -25,7 +25,8 @@ export type ClickHouseVersionBand = {
 
 type ClickHouseCompatibilityEnvKey =
   | "CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION"
-  | "CLICKHOUSE_DISABLE_TOP_K_THROUGH_JOIN";
+  | "CLICKHOUSE_DISABLE_TOP_K_THROUGH_JOIN"
+  | "CLICKHOUSE_ENABLE_SKIP_INDEXES_ON_DATA_READ";
 
 type ClickHouseCompatibilityEnvValue = "auto" | "true" | "false";
 
@@ -86,6 +87,15 @@ const CLICKHOUSE_COMPATIBILITY_RULES: ClickHouseCompatibilityRule[] = [
       { minInclusive: "26.7.2.0", maxExclusive: "26.7.2.11" },
     ],
     overrideEnvKey: "CLICKHOUSE_DISABLE_TOP_K_THROUGH_JOIN",
+  },
+  {
+    id: "enable-skip-indexes-on-data-read",
+    setting: "use_skip_indexes_on_data_read",
+    value: 1,
+    reason:
+      "Evaluate skip indexes at granule read time to cut query startup latency. Held back below 26.2, where reading a column patched by a lightweight update fails with `Not found column _part_offset in block`.",
+    versionBands: [{ minInclusive: "26.2.0.0" }],
+    overrideEnvKey: "CLICKHOUSE_ENABLE_SKIP_INDEXES_ON_DATA_READ",
   },
 ];
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17023 app preview](https://pr-17023.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Turns on ClickHouse text index caching and read-time skip-index evaluation, which are off by default on the versions we run.

**The three text index caches** go on the `EventsReadOnly` service, next to the `enable_full_text_index` we already set there — that service is the read path for `events_core` / `events_full`, the tables carrying the text indexes:

```ts
use_text_index_dictionary_cache: 1,
use_text_index_header_cache: 1,
use_text_index_postings_cache: 1,
```

**`use_skip_indexes_on_data_read` needs a version gate**, so it goes through the existing `compatibility.ts` rules with a `>= 26.2` band rather than being set inline. On 25.12 — the Langfuse v4 minimum — enabling it fails any read of a column patched by a lightweight update:

```
Not found column _part_offset in block ... (NOT_FOUND_COLUMN_IN_BLOCK)
While executing MergeTreeSelect
```

The events tables take lightweight updates for the `public` and `bookmarked` flags, so this is not a corner case: it broke the `events_only` trace read paths outright. Setting it unconditionally is what the first commit here did, and CI caught it — `tests-web` failed on both 25.12-based matrix variants (`mode`, `mode-azure`) while the 26.8 variant was cancelled by fail-fast.

Minimal reproduction on 25.12, with the setting as the only variable:

```sql
CREATE TABLE t (id UInt64, name String, public Bool DEFAULT false,
                INDEX idx_name name TYPE bloom_filter GRANULARITY 1)
ENGINE = MergeTree ORDER BY id
SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
INSERT INTO t SELECT number, concat('n', toString(number)), false FROM numbers(200000);
UPDATE t SET public = true WHERE id = 42;          -- lightweight update -> patch part

SELECT id, name, public FROM t WHERE name = 'n100'
  SETTINGS use_skip_indexes_on_data_read = 0;      -- 100  n100  false
SELECT id, name, public FROM t WHERE name = 'n100'
  SETTINGS use_skip_indexes_on_data_read = 1;      -- NOT_FOUND_COLUMN_IN_BLOCK
```

The same script runs clean on 26.2 and 26.7, where the setting is already default-on — hence the `>= 26.2` floor. The setting is still worth sending explicitly above that floor because a server default can leave it off even on a fixed version, which is the case on Langfuse Cloud.

### Version reference

| Setting | Introduced | Default flips to 1 | On 26.3+ |
| --- | --- | --- | --- |
| `use_skip_indexes_on_data_read` | 25.9 | 26.2 | Production |
| `use_text_index_dictionary_cache` | 25.11 | never | **Obsolete** |
| `use_text_index_header_cache` | 25.11 | 26.7 | Production |
| `use_text_index_postings_cache` | 25.11 | never | Production |

Introduction and default-change versions come from `system.settings_changes`; the 26.x columns were read off 26.2 / 26.3 / 26.7 servers.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## What a reviewer should doubt

- **The `26.2.0.0` floor may be one release too conservative.** 26.2 is the release I verified works, and it is where the default flipped, but the actual fix could have landed in 26.1 — I did not test 26.1. Erring high only costs us the setting on 26.1.
- **Scope changed for the skip-index setting.** Compatibility rules apply to every ClickHouse service, not just `EventsReadOnly`, so on 26.2+ this setting now also rides along on the legacy traces/observations/scores read paths and on write clients. That is defensible — it governs all skip indexes, not just text ones, and it is a no-op for inserts — but if you want it confined to the events read path, it needs a different mechanism than a compatibility rule.
- **`use_text_index_dictionary_cache` is dead weight on ClickHouse 26.3+**, where it is obsolete: accepted and silently ignored, not an error. It still helps on 25.12–26.2, which is why it is included, but it wants removing once the floor passes 26.3.
- **No test for the events-service settings themselves.** The version-band behavior is covered in `compatibility.test.ts`, including an explicit 25.12 row asserting the skip-index setting stays off there. The three cache keys are a plain object literal with no branching, so they are unverified beyond CI going green.

## Verification

- `pnpm run lint` → `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` → `Tasks: 8 successful, 8 total`
- `packages/shared` clickhouse suites → `Tests 65 passed (65)`, including the new 25.12 / 26.1 / 26.2 band rows
- The reproduction above, run against local 25.12.11.4, plus the clean run on 26.2.19.43 and 26.7.2.59
- The `_part_offset` regression is CI-verified rather than locally verified: `traces-trpc-events-only.servertest.ts` cannot run in my worktree (unrelated Prisma init failure that also reproduces on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
