### PR TITLE
perf(clickhouse): enable block number and offset columns on scores and dataset_run_items_rmt

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0048_enable_block_columns_on_scores_and_dataset_run_items.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0048_enable_block_columns_on_scores_and_dataset_run_items.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE scores ON CLUSTER default
+  RESET SETTING enable_block_number_column, enable_block_offset_column
+  SETTINGS alter_sync = 2;
+ALTER TABLE dataset_run_items_rmt ON CLUSTER default
+  RESET SETTING enable_block_number_column, enable_block_offset_column
+  SETTINGS alter_sync = 2;

--- a/packages/shared/clickhouse/migrations/clustered/0048_enable_block_columns_on_scores_and_dataset_run_items.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0048_enable_block_columns_on_scores_and_dataset_run_items.up.sql
@@ -1,0 +1,7 @@
+-- Lightweight updates (patch parts) require the persisted _block_number and _block_offset columns, as already set on events_full and events_core. Metadata-only: existing parts are not rewritten.
+ALTER TABLE scores ON CLUSTER default
+  MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1
+  SETTINGS alter_sync = 2;
+ALTER TABLE dataset_run_items_rmt ON CLUSTER default
+  MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1
+  SETTINGS alter_sync = 2;

--- a/packages/shared/clickhouse/migrations/unclustered/0048_enable_block_columns_on_scores_and_dataset_run_items.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0048_enable_block_columns_on_scores_and_dataset_run_items.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE scores
+  RESET SETTING enable_block_number_column, enable_block_offset_column;
+ALTER TABLE dataset_run_items_rmt
+  RESET SETTING enable_block_number_column, enable_block_offset_column;

--- a/packages/shared/clickhouse/migrations/unclustered/0048_enable_block_columns_on_scores_and_dataset_run_items.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0048_enable_block_columns_on_scores_and_dataset_run_items.up.sql
@@ -1,0 +1,5 @@
+-- Lightweight updates (patch parts) require the persisted _block_number and _block_offset columns, as already set on events_full and events_core. Metadata-only: existing parts are not rewritten.
+ALTER TABLE scores
+  MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;
+ALTER TABLE dataset_run_items_rmt
+  MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;


### PR DESCRIPTION
# Edit: ported into https://github.com/langfuse/langfuse/pull/17027

## TL;DR

Enable `enable_block_number_column` and `enable_block_offset_column` on `scores` and `dataset_run_items_rmt` so ClickHouse lightweight updates (patch parts) work on those tables, as they already do on `events_full` and `events_core`.

## Why

Langfuse deletes rows with `DELETE FROM scores ...` and `DELETE FROM dataset_run_items_rmt ...`. With `CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE=lightweight_update`, ClickHouse only takes the lightweight-update path when the table persists `_block_number` and `_block_offset` ([lightweight update requirements](https://clickhouse.com/docs/reference/statements/update#lightweight-update-requirements)). Otherwise it silently falls back to a regular `ALTER TABLE ... UPDATE _row_exists = 0` mutation that rewrites parts.

In ClickHouse source this is `InterpreterDeleteQuery` calling `MergeTreeData::supportsLightweightUpdate()`, whose only table-level conditions are the engine family and these two table settings. It never inspects parts, so enabling the settings is sufficient on a populated table.

`events_full` and `events_core` set both settings in their `CREATE TABLE` (migrations 0039 and 0040); `scores` and `dataset_run_items_rmt` do not, so deletes there still run as heavy mutations. Langfuse Cloud's own `scores` table already has both settings enabled.

## Changes

- New migration `0048_enable_block_columns_on_scores_and_dataset_run_items` (clustered and unclustered): `ALTER TABLE ... MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1` for both tables. Down migration resets both settings.
- Both settings are set in one statement per table on purpose: a merge that runs with only `enable_block_offset_column` on writes non-unique row addresses (ClickHouse issue #116997).
- Clustered variant uses `ON CLUSTER default` and `SETTINGS alter_sync = 2`, matching the other ALTER migrations. `ON CLUSTER` is load-bearing here: a settings-only ALTER on `ReplicatedMergeTree` is a local operation and is not propagated through the replication log.
- Metadata-only change: no mutation, no part rewrite. Parts written before the change keep working because readers synthesize `_block_number` from the part's `min_block` and `_block_offset` from `_part_offset`; merges then persist the same values, so patch parts keep matching across merges.

## Verification

**Unclustered, ClickHouse 25.12 (what `docker-compose.yml` ships)**, full chain applied with `golang-migrate`:

```
47/u add_eval_execution_columns (223.44671ms)
48/u enable_block_columns_on_scores_and_dataset_run_items (208.29721ms)
```

`down 1` removes both settings from `scores` and `dataset_run_items_rmt`; `up` re-applies them. Re-running `up` on an already-migrated table and `down` on a never-migrated table both succeed, so a dirty rerun is safe.

Behavior on the real `scores` table, rows seeded and merged into a part **before** 0048 was applied:

| Step | `lightweight_delete_mode` | Result |
|---|---|---|
| Before 0048, `DELETE` | `lightweight_update` | Silent fallback: `system.mutations` gains `UPDATE _row_exists = 0 WHERE ...`, parts rewritten |
| Before 0048, `DELETE` | `lightweight_update_force` | `Code: 344 ... Lightweight updates are supported only for tables with materialized _block_number column. Run 'MODIFY SETTING enable_block_number_column = 1' command to enable it. (SUPPORT_IS_DISABLED)` |
| Apply 0048 | | Part names unchanged, no mutation, old parts still have no stored `_block_number`/`_block_offset` |
| After 0048, `DELETE` row in old merged part | `lightweight_update_force` | No error, no new mutation, a `patch-...` part appears, row gone with and without `FINAL` |
| After 0048, `DELETE` row in fresh part | `lightweight_update` | No new mutation, patch part |
| `OPTIMIZE TABLE scores FINAL` | | Patches applied on merge (merged part has exactly the surviving rows), merged part now stores `_block_number`/`_block_offset` |
| `down`, then `DELETE` | `lightweight_update` | Reverts to heavy mutation and still works; rows already deleted via patch parts stay deleted |

**Clustered, ClickHouse 25.12 with embedded Keeper and a `default` cluster**, tables created from the real clustered 0003/0024 DDL (`ReplicatedReplacingMergeTree`), then the exact clustered 0048 files: both ALTERs show `Finished` in `system.distributed_ddl_queue`, `system.mutations` and `system.replication_queue` unchanged, re-running `up` is idempotent, force and non-force deletes produce patch parts, `down` reverts `engine_full` and force deletes fail again with the message above.

**ClickHouse Cloud 26.4 (`SharedReplacingMergeTree`)**: the same two statements applied by hand on two production services with 2 and 5 replicas. Before: the force-mode probe fails with `SUPPORT_IS_DISABLED`. After: both settings present on every replica via `clusterAllReplicas('default', system.tables)`.

Also checked: all four files parse with `clickhouse-format`, and `alter_sync` binds to the query, not to the `MODIFY SETTING` list. `enable_lightweight_update` (alias `allow_experimental_lightweight_update`) defaults to `1` from 25.8 on, so nothing else needs to be set.

## Operational note for self-hosters

`MODIFY SETTING` needs the `ALTER SETTINGS` privilege. The least-privilege grant list in the [self-hosting ClickHouse docs](https://langfuse.com/self-hosting/infrastructure/clickhouse) does not include it, and a user with exactly those grants fails this migration:

```
Code: 497. DB::Exception: lf: Not enough privileges. To execute this query, it's necessary to have the grant ALTER SETTINGS ON default.scores. (ACCESS_DENIED)
```

Deployments using a restricted user need this before upgrading, and the docs grant list should gain it:

```sql
GRANT ALTER SETTINGS ON default.* TO 'user';
```

## Not in this PR

`traces` and `observations` also receive plain `DELETE FROM` and lack these settings, so their deletes fall back the same way. The identical `ALTER` applies to them; left out to keep this change to the two tables it was scoped to.

## How to confirm in a deployment

```sql
-- settings present?
SELECT name, engine_full FROM system.tables WHERE name IN ('scores', 'dataset_run_items_rmt');
-- would a delete take the lightweight path? (errors with SUPPORT_IS_DISABLED if not; no rows match, so nothing is deleted)
DELETE FROM scores WHERE project_id = '__probe__' AND id = '__probe__' SETTINGS lightweight_delete_mode = 'lightweight_update_force';
-- lightweight deletes show up as patch parts, not mutations
SELECT name, rows FROM system.parts WHERE table = 'scores' AND active AND name LIKE 'patch-%';
```
