### PR TITLE
fix(worker): preserve explicit usage.total of 0 in legacy ingestion (#16503)

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1965,11 +1965,11 @@ export class IngestionService {
         "usage" in obs.body ? obs.body.usage?.output : undefined;
 
       const newTotalCount =
-        ("usage" in obs.body ? obs.body.usage?.total : undefined) ||
+        ("usage" in obs.body ? obs.body.usage?.total : undefined) ??
         (Object.keys(
           "usageDetails" in obs.body ? (obs.body.usageDetails ?? {}) : {},
         ).length === 0
-          ? newInputCount && newOutputCount
+          ? newInputCount != null && newOutputCount != null
             ? newInputCount + newOutputCount
             : (newInputCount ?? newOutputCount)
           : undefined);

--- a/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
@@ -998,4 +998,111 @@ describe("IngestionService unit tests", () => {
       ).resolves.toBe(events.at(-1)?.body.value);
     }
   });
+
+  it("preserves explicit usage.total of 0 in legacy ingestion events", () => {
+    const ingestionService = new IngestionService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    const [record] = (ingestionService as any).mapObservationEventsToRecords({
+      projectId: "project-id",
+      entityId: "observation-id",
+      observationEventList: [
+        {
+          id: "event-id",
+          timestamp: "2026-08-03T00:00:00.000Z",
+          type: "generation-create",
+          body: {
+            id: "observation-id",
+            traceId: "trace-id",
+            name: "cached-generation",
+            usage: {
+              input: 100,
+              output: 50,
+              total: 0,
+            },
+          },
+        },
+      ],
+      prompt: null,
+    });
+
+    expect(record.provided_usage_details).toEqual({
+      input: 100,
+      output: 50,
+      total: 0,
+    });
+  });
+
+  it("computes usage.total correctly when input or output is 0 and total is omitted", () => {
+    const ingestionService = new IngestionService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    const [recordWithZeroInput] = (
+      ingestionService as any
+    ).mapObservationEventsToRecords({
+      projectId: "project-id",
+      entityId: "observation-id-1",
+      observationEventList: [
+        {
+          id: "event-id-1",
+          timestamp: "2026-08-03T00:00:00.000Z",
+          type: "generation-create",
+          body: {
+            id: "observation-id-1",
+            traceId: "trace-id",
+            name: "gen-zero-input",
+            usage: {
+              input: 0,
+              output: 50,
+            },
+          },
+        },
+      ],
+      prompt: null,
+    });
+
+    expect(recordWithZeroInput.provided_usage_details).toEqual({
+      input: 0,
+      output: 50,
+      total: 50,
+    });
+
+    const [recordWithZeroOutput] = (
+      ingestionService as any
+    ).mapObservationEventsToRecords({
+      projectId: "project-id",
+      entityId: "observation-id-2",
+      observationEventList: [
+        {
+          id: "event-id-2",
+          timestamp: "2026-08-03T00:00:00.000Z",
+          type: "generation-create",
+          body: {
+            id: "observation-id-2",
+            traceId: "trace-id",
+            name: "gen-zero-output",
+            usage: {
+              input: 100,
+              output: 0,
+            },
+          },
+        },
+      ],
+      prompt: null,
+    });
+
+    expect(recordWithZeroOutput.provided_usage_details).toEqual({
+      input: 100,
+      output: 0,
+      total: 100,
+    });
+  });
 });


### PR DESCRIPTION
Closes #16503

### What Was the Issue?
In the legacy ingestion pipeline (`mapObservationEventsToRecords`), when an observation event explicitly provided `usage.total: 0` (e.g. from cached generations or instrumentors intentionally reporting 0 total tokens), the `||` operator treated `0` as falsy and fell back to computing a total from `input + output`. This silently corrupted stored usage details, inflating token counts and downstream cost metrics.

Additionally, in the fallback calculation, `newInputCount && newOutputCount` evaluated `0 && 50` to `0` (falsy) instead of summing them, causing `input: 0, output: 50` to evaluate to `0` instead of `50`.

### What Did We Fix?
In `worker/src/services/IngestionService/index.ts`:
1. Replaced the `||` operator with nullish coalescing `??` for `obs.body.usage?.total` so that an explicit `0` is preserved and not treated as missing.
2. Replaced `newInputCount && newOutputCount` with `newInputCount != null && newOutputCount != null` in the fallback expression so that `0` inputs or outputs are correctly summed when computing total counts.

### Why This Change Was Made
`0` is a valid numeric token count in LLM telemetry and should not be treated as falsy or replaced with an estimated sum when explicitly supplied by the caller.

### Testing & Verification
Added unit tests in `worker/src/services/IngestionService/tests/IngestionService.unit.test.ts`:
- Verified that explicit `usage.total: 0` is preserved in `provided_usage_details` even when `input` and `output` are non-zero.
- Verified that omitting `total` while providing `input: 0, output: 50` correctly sums to `total: 50`.
- Verified that omitting `total` while providing `input: 100, output: 0` correctly sums to `total: 100`.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects legacy observation usage normalization so valid zero-valued token counts are not treated as absent.
- Preserves an explicitly supplied `usage.total: 0`.
- Correctly derives totals when either input or output is zero.
- Adds focused regression tests for both cases.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The changed expressions preserve explicit zero totals and sum zero-valued input or output correctly, with focused tests covering each corrected path and no accepted regressions.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): preserve explicit usage.tot..."](https://github.com/langfuse/langfuse/commit/1be89514af195e0bff88fea9c4c09055ab84adb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60045616)</sub>

<!-- /greptile_comment -->