### PR TITLE
perf(clickhouse): enable block columns for lightweight updates

### DIFF
--- a/packages/shared/clickhouse/migrations/canonical/0048_enable_block_columns_on_scores_and_dataset_run_items.down.sql
+++ b/packages/shared/clickhouse/migrations/canonical/0048_enable_block_columns_on_scores_and_dataset_run_items.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE scores {CLICKHOUSE_CLUSTER_CLAUSE}
+  RESET SETTING enable_block_number_column, enable_block_offset_column{CLICKHOUSE_CLUSTERED_ONLY:
+  SETTINGS alter_sync = 2};
+ALTER TABLE dataset_run_items_rmt {CLICKHOUSE_CLUSTER_CLAUSE}
+  RESET SETTING enable_block_number_column, enable_block_offset_column{CLICKHOUSE_CLUSTERED_ONLY:
+  SETTINGS alter_sync = 2};

--- a/packages/shared/clickhouse/migrations/canonical/0048_enable_block_columns_on_scores_and_dataset_run_items.up.sql
+++ b/packages/shared/clickhouse/migrations/canonical/0048_enable_block_columns_on_scores_and_dataset_run_items.up.sql
@@ -1,0 +1,7 @@
+-- Lightweight updates (patch parts) require the persisted _block_number and _block_offset columns, as already set on events_full and events_core. Metadata-only: existing parts are not rewritten.
+ALTER TABLE scores {CLICKHOUSE_CLUSTER_CLAUSE}
+  MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1{CLICKHOUSE_CLUSTERED_ONLY:
+  SETTINGS alter_sync = 2};
+ALTER TABLE dataset_run_items_rmt {CLICKHOUSE_CLUSTER_CLAUSE}
+  MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1{CLICKHOUSE_CLUSTERED_ONLY:
+  SETTINGS alter_sync = 2};


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17027 app preview](https://pr-17027.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Ports the migration from #17024 onto the canonical migration mechanism introduced by #17015.

#17015 is now merged. This PR targets `main`, and its diff contains only the canonical `0048` up/down migration files.

The migration enables `enable_block_number_column` and `enable_block_offset_column` on `scores` and `dataset_run_items_rmt`, matching `events_full` and `events_core`. This allows ClickHouse lightweight deletes to use patch parts instead of silently falling back to regular mutations that rewrite parts.

## Migration behavior

- Sets both table settings in one statement per table. This avoids writes occurring while only one of the paired settings is enabled.
- Uses `{CLICKHOUSE_CLUSTER_CLAUSE}` so the migration mechanism renders the correct clustered or unclustered SQL.
- Uses clustered-only `alter_sync = 2`, following the synchronization contract for new canonical metadata ALTERs.
- The down migration resets both settings.
- The change is metadata-only: it does not mutate rows or rewrite existing parts.

## Compatibility

All four rendered outputs—clustered/unclustered and up/down—are byte-for-byte identical to their counterparts in #17024. The runtime validation documented there therefore applies unchanged, including ClickHouse 25.12 clustered/unclustered and ClickHouse Cloud 26.4 SharedMergeTree coverage.

Existing parts remain readable: ClickHouse synthesizes the block coordinates when they are absent, while subsequent merges persist them.

## Operational prerequisite

`MODIFY SETTING` requires the `ALTER SETTINGS` privilege. The currently documented least-privilege self-hosted grant set does not include it. That guidance must be updated before this migration ships so restricted OSS migration users do not fail during upgrade:

```sql
GRANT ALTER SETTINGS ON default.* TO migration_user;
```

The branch remains migration-only; the documentation/grant update should be handled separately before release.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Impacted packages

- `packages/shared/clickhouse/migrations/canonical`: migration `0048` only.

## Mandatory Tasks

- [x] Self-reviewed the code and confirmed the diff is limited to the two migration files.

## Verification

- `pnpm --filter @langfuse/shared run test prepareMigrations.test.ts` — `Tests 10 passed (10)` after rebasing onto merged `main`.
- Materialized both migration trees and compared all four generated `0048` files byte-for-byte with #17024 — all comparisons matched.
- `pnpm ch:migrations:clean` — generated trees removed; working tree clean.
- Mechanism PR #17015 completed `all-ci-passed`, including shared tests and both Docker builds, before merge.
