### PR TITLE
fix(pricing): validate added model audit metadata

### DIFF
--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -606,12 +606,8 @@ jobs:
             esac
           done
 
-          CURRENT_PRICING_FILE="worker/src/constants/default-model-prices.json"
           BASE_PRICING_FILE="$RUNNER_TEMP/default-model-prices-base.json"
-          TYPES_DIFF_FILE="$RUNNER_TEMP/llm-types.diff"
-          git show "HEAD:$CURRENT_PRICING_FILE" > "$BASE_PRICING_FILE"
-          git diff --unified=0 -- "packages/shared/src/server/llm/types.ts" > "$TYPES_DIFF_FILE"
-          export BASE_PRICING_FILE CHANGED_MODEL_TYPES CHANGED_PRICING_JSON CURRENT_PRICING_FILE TYPES_DIFF_FILE
+          git show "HEAD:worker/src/constants/default-model-prices.json" > "$BASE_PRICING_FILE"
 
           mapfile -t untracked_files < <(git ls-files --others --exclude-standard)
           if [ "${#untracked_files[@]}" -gt 0 ]; then
@@ -622,16 +618,6 @@ jobs:
             --base "$BASE_PRICING_FILE"
           node scripts/agents/sync-agent-shims.mjs --check
           git diff --check -- "${changed_files[@]}"
-
-          git config user.name "langfuse-bot"
-          git config user.email "langfuse-bot@langfuse.com"
-          git -c core.hooksPath=/dev/null checkout -b "$BOT_BRANCH"
-
-          STRUCTURED_OUTPUT_PATH="$RUNNER_TEMP/claude-model-price-audit.json"
-          PR_TITLE_PATH="$RUNNER_TEMP/model-price-audit-pr-title.txt"
-          export STRUCTURED_OUTPUT_PATH
-          node scripts/model-price-audit/prepare-metadata.mjs > "$PR_TITLE_PATH"
-          PR_TITLE="$(cat "$PR_TITLE_PATH")"
 
           GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git -c core.hooksPath=/dev/null add -- "${changed_files[@]}"
           mapfile -t staged_files < <(git diff --cached --name-only)
@@ -660,10 +646,24 @@ jobs:
 
           staged_pricing_file="$RUNNER_TEMP/default-model-prices-staged.json"
           git show ":worker/src/constants/default-model-prices.json" > "$staged_pricing_file"
+          git diff --cached --binary > "$RUNNER_TEMP/model-price-audit-diagnostic.patch"
+          test -s "$RUNNER_TEMP/model-price-audit-diagnostic.patch"
+          CURRENT_PRICING_FILE="$staged_pricing_file"
+          TYPES_DIFF_FILE="$RUNNER_TEMP/llm-types.diff"
+          git diff --cached --unified=0 -- "packages/shared/src/server/llm/types.ts" > "$TYPES_DIFF_FILE"
+
+          STRUCTURED_OUTPUT_PATH="$RUNNER_TEMP/claude-model-price-audit.json"
+          PR_TITLE_PATH="$RUNNER_TEMP/model-price-audit-pr-title.txt"
+          export BASE_PRICING_FILE CHANGED_MODEL_TYPES CHANGED_PRICING_JSON CURRENT_PRICING_FILE STRUCTURED_OUTPUT_PATH TYPES_DIFF_FILE
+          node scripts/model-price-audit/prepare-metadata.mjs > "$PR_TITLE_PATH"
+          PR_TITLE="$(cat "$PR_TITLE_PATH")"
+
           node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs \
             "$staged_pricing_file" --base "$BASE_PRICING_FILE"
           git diff --cached --check -- "${staged_files[@]}"
 
+          git config user.name "langfuse-bot"
+          git config user.email "langfuse-bot@langfuse.com"
           git -c core.hooksPath=/dev/null commit --no-verify -m "$PR_TITLE"
           node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs \
             --base "$BASE_PRICING_FILE"
@@ -716,6 +716,17 @@ jobs:
             ${{ runner.temp }}/model-price-audit.patch
             ${{ runner.temp }}/model-price-audit-pr-body.md
           if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: model-price-audit-failure-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/model-price-audit-diagnostic.patch
+            ${{ runner.temp }}/claude-model-price-audit.txt
+          if-no-files-found: ignore
           retention-days: 1
 
   publish:

--- a/scripts/model-price-audit/prepare-metadata.mjs
+++ b/scripts/model-price-audit/prepare-metadata.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 
 process.on("uncaughtException", (error) => {
@@ -45,12 +46,16 @@ if (
   );
 }
 
-const basePrices = JSON.parse(
-  fs.readFileSync(process.env.BASE_PRICING_FILE, "utf8"),
+const basePricingText = fs.readFileSync(
+  process.env.BASE_PRICING_FILE,
+  "utf8",
 );
-const currentPrices = JSON.parse(
-  fs.readFileSync(process.env.CURRENT_PRICING_FILE, "utf8"),
+const currentPricingText = fs.readFileSync(
+  process.env.CURRENT_PRICING_FILE,
+  "utf8",
 );
+const basePrices = JSON.parse(basePricingText);
+const currentPrices = JSON.parse(currentPricingText);
 const basePricesByName = new Map(
   basePrices.map((item) => [normalize(item.modelName), item]),
 );
@@ -58,9 +63,10 @@ const currentPricesByName = new Map(
   currentPrices.map((item) => [normalize(item.modelName), item]),
 );
 const pricingModelChanges = [];
-for (const modelName of new Set(
-  Array.from(basePricesByName.keys()).concat(currentPricesByName.keys()),
-)) {
+for (const modelName of new Set([
+  ...basePricesByName.keys(),
+  ...currentPricesByName.keys(),
+])) {
   const before = basePricesByName.get(modelName);
   const after = currentPricesByName.get(modelName);
   if (JSON.stringify(before) !== JSON.stringify(after)) {
@@ -83,7 +89,13 @@ if (
   process.env.CHANGED_PRICING_JSON === "true" &&
   pricingModelChanges.length === 0
 ) {
-  throw new Error("Pricing JSON changed without a concrete model-entry change");
+  const digest = (value) =>
+    createHash("sha256").update(value).digest("hex").slice(0, 12);
+  throw new Error(
+    "Pricing JSON changed without a concrete model-entry change " +
+      `(base entries: ${basePrices.length}, current entries: ${currentPrices.length}, ` +
+      `base sha256: ${digest(basePricingText)}, current sha256: ${digest(currentPricingText)})`,
+  );
 }
 if (process.env.CHANGED_MODEL_TYPES === "true" && typeModelChanges.size === 0) {
   throw new Error(

--- a/scripts/model-price-audit/prepare-metadata.test.mjs
+++ b/scripts/model-price-audit/prepare-metadata.test.mjs
@@ -6,6 +6,10 @@ import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 const scriptPath = path.join(import.meta.dirname, "prepare-metadata.mjs");
+const workflowPath = path.join(
+  import.meta.dirname,
+  "../../.github/workflows/model-price-audit.yml",
+);
 
 function runValidator({
   basePrices = [],
@@ -50,6 +54,24 @@ const changedPrices = {
   before: [{ modelName, pricingTiers: [{ prices: { input: 5 } }] }],
   after: [{ modelName, pricingTiers: [{ prices: { input: 10 } }] }],
 };
+
+test("accepts an added pricing entry from the staged snapshot", () => {
+  const addedModel = {
+    modelName: "gpt-6-astra",
+    pricingTiers: [{ prices: { input: 10, output: 50 } }],
+  };
+  const result = runValidator({
+    basePrices: changedPrices.before,
+    currentPrices: [...changedPrices.before, addedModel],
+    changedPricingJson: true,
+    output: {
+      pullRequestTitle: "chore(pricing): add OpenAI gpt-6-astra pricing",
+      modelsChecked: [{ model: addedModel.modelName, change: "added" }],
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+});
 
 test("accepts a unique trailing match-alias annotation", () => {
   const result = runValidator({
@@ -122,4 +144,29 @@ test("rejects a generic pull request title", () => {
     result.stderr,
     /must identify the specific models or audit behavior changed/,
   );
+});
+
+test("validates metadata against the exact staged pricing blob", () => {
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+  const prepareStep = workflow.slice(
+    workflow.indexOf("      - name: Prepare pull request artifact"),
+    workflow.indexOf("      - name: Upload pull request artifact"),
+  );
+  const stageIndex = prepareStep.indexOf(
+    'git -c core.hooksPath=/dev/null add -- "${changed_files[@]}"',
+  );
+  const metadataIndex = prepareStep.indexOf(
+    "node scripts/model-price-audit/prepare-metadata.mjs",
+  );
+
+  assert.ok(stageIndex >= 0, "prepare step must stage the validated file list");
+  assert.ok(
+    stageIndex < metadataIndex,
+    "metadata validation must run after staging",
+  );
+  assert.match(
+    prepareStep,
+    /CURRENT_PRICING_FILE="\$staged_pricing_file"/,
+  );
+  assert.doesNotMatch(prepareStep, /checkout -b "\$BOT_BRANCH"/);
 });


### PR DESCRIPTION
## Summary

- expand both pricing model-name iterators so newly added entries participate in metadata reconciliation
- validate structured metadata against the staged pricing blob and staged types diff that will actually be committed
- retain an allowlisted diagnostic patch and sanitized audit summary for one day when post-agent preparation fails

## Root cause

`Array.concat` treated the current-price `MapIterator` as one array element instead of expanding its keys. Updates to existing entries were validated, but models present only in the current file were skipped and incorrectly triggered the no-entry-change guard.

## Validation

- `node --test scripts/model-price-audit/prepare-metadata.test.mjs scripts/model-price-audit/discard-formatting-only-pricing-diff.test.mjs` — 9 passed
- workflow YAML parsed successfully with Ruby Psych
- extracted `Prepare pull request artifact` shell block passed `bash -n`
- `git diff --check`

## Security

- audit job remains `contents: read`
- no new LLM tools, credentials, permissions, or publish paths
- publisher remains a separate non-LLM job
- failure artifact contains only the validated allowlisted patch and rendered structured audit summary


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes pricing-audit metadata reconciliation by including newly added pricing models and validating metadata against the exact staged content.

- Expands pricing model iteration to include keys from both base and current snapshots.
- Stages changes before validating structured metadata and derives pricing/type inputs from the Git index.
- Adds short-lived failure artifacts containing the staged diagnostic patch and rendered audit summary.
- Adds coverage for newly added pricing entries and staged-snapshot workflow ordering.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The staged pricing blob and cached types diff now match the content used to build the commit, added models participate in reconciliation, and the removed local branch creation is not required by the separate publishing job.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Agent edits allowlisted pricing files] --> B[Validate worktree diff]
  B --> C[Stage changed files]
  C --> D[Read staged pricing blob]
  C --> E[Generate cached types diff]
  D --> F[Reconcile structured metadata]
  E --> F
  F -->|Success| G[Commit and generate patch artifact]
  F -->|Failure| H[Upload one-day diagnostic artifact]
  G --> I[Publish job applies patch on bot branch]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pricing): validate added model audit..."](https://github.com/langfuse/langfuse/commit/0203d4565bc1ee936745cdaa236cd7cc9ecf41fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60169671)</sub>

<!-- /greptile_comment -->