### PR TITLE
docs(agents): know who you are working for, and what to do today

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -5,6 +5,11 @@ evaluating, and debugging AI applications.
 
 ## How To Work
 
+- Know who you are working for before you assume what they may do. An outside
+  contributor and a Langfuse maintainer get different halves of this repo, and
+  the difference is derivable — `~/.config/langfuse/me.md` if it exists, else
+  `gh api repos/langfuse/langfuse --jq .permissions`. `langfuse-onboarding`
+  establishes it once and records it; never guess it silently.
 - Read the minimal local context required for the task.
 - Keep changes scoped and avoid unrelated refactors.
 - Delegate exploratory or noisy work — broad code search, multi-file

--- a/.agents/skills/langfuse-codebase-navigator/SKILL.md
+++ b/.agents/skills/langfuse-codebase-navigator/SKILL.md
@@ -27,6 +27,8 @@ Use this as the first stop for Langfuse org navigation. Your job is to choose th
 - Product implementation in `langfuse/langfuse`: choose the matching repo-local skill under `.agents/skills`, such as `backend-dev-guidelines`, `frontend-browser-review`, `clickhouse-best-practices`, `add-model-price`, `turborepo`, `pnpm-upgrade-package`, `code-review`, or production-debug skills as applicable.
 - Cursor Cloud or Cursor desktop agents implementing a Linear issue, opening a PR, asking a human to test, or handling Claude, Greptile, or Codex review comments: use `cursor-agents-workflow`.
 - A change too large for one reviewable PR, splitting a long-lived branch into PRs, or propagating and retargeting a stack: use `pr-stack-workflow`.
+- Someone new, or you do not know whether you are talking to an outside contributor or a maintainer: use `langfuse-onboarding`.
+- "What should I do today", or preparing a weekly project update: use `linear-work-rhythm`.
 - Reconstructing why a surface is the way it is before changing it, or writing the reasoning behind finished work onto its Linear ticket: use `linear-context-handover`.
 - Turning a feature into Linear subtickets that map onto an intended PR stack: use `linear-planning`.
 - Before any agent write to Linear — a comment, a description edit, a ticket: use `linear-agent-writes`, the write policy.

--- a/.agents/skills/langfuse-onboarding/SKILL.md
+++ b/.agents/skills/langfuse-onboarding/SKILL.md
@@ -31,9 +31,11 @@ gh api repos/langfuse/langfuse --jq '.permissions | {push, maintain, admin}'
   and the one that matters here: a maintainer with no tracker connection is a
   *setup gap*, not a contributor, and step 4 is where you fix it.
 
-**Do not infer this from an email domain.** Maintainers here commit from at least
-three — a company address, an acquirer address, and personal ones — so a domain
-test misclassifies people in both directions. Write access is definitive; use it.
+**Do not infer this from `git config user.email`.** That is a local setting, not
+an identity: roughly a third of recent commits here come from personal addresses,
+and both `@clickhouse.com` (the company domain — Langfuse is part of ClickHouse)
+and the older `@langfuse.com` are still in daily use. Write access answers the
+question directly, so ask that instead of guessing from a string.
 
 Say what you found and let them correct it. Never announce a role silently — a
 wrong guess sends someone down the wrong half of this file.

--- a/.agents/skills/langfuse-onboarding/SKILL.md
+++ b/.agents/skills/langfuse-onboarding/SKILL.md
@@ -22,15 +22,18 @@ Two signals, in order. Both are read-only.
 
 ```bash
 gh api repos/langfuse/langfuse --jq '.permissions | {push, maintain, admin}'
-git config user.email
 ```
 
 - **`push: true`** → maintainer. They have write access to the app repo.
 - **`push: false`** or the call fails → treat as an outside contributor until they
   say otherwise.
-- A `@clickhouse.com` git email plus reachable Linear tools is a second maintainer
-  signal, and the one that matters for the tracker layer: a maintainer with no
-  Linear connection is a *setup gap*, not a contributor.
+- Then check whether the tracker answers a real read. That is the second signal,
+  and the one that matters here: a maintainer with no tracker connection is a
+  *setup gap*, not a contributor, and step 4 is where you fix it.
+
+**Do not infer this from an email domain.** Maintainers here commit from at least
+three — a company address, an acquirer address, and personal ones — so a domain
+test misclassifies people in both directions. Write access is definitive; use it.
 
 Say what you found and let them correct it. Never announce a role silently — a
 wrong guess sends someone down the wrong half of this file.

--- a/.agents/skills/langfuse-onboarding/SKILL.md
+++ b/.agents/skills/langfuse-onboarding/SKILL.md
@@ -83,6 +83,18 @@ work through them with the person, and answer from what they actually say today 
 do not paraphrase them here, because this file would then be a second, stale copy
 of a document that changes without it.
 
+**Read it from `origin/main`, not the working tree.** A docs checkout is usually
+parked on some branch from the last thing that person shipped, and a working-tree
+read then quotes a handbook from weeks ago without saying so. This is not
+hypothetical: the first run of this skill read a checkout **576 commits behind**.
+Fetch, then read the blob — it needs no checkout switch and cannot disturb work
+in progress:
+
+```bash
+cd <docs checkout> && git fetch -q origin main
+git show origin/main:content/handbook/product-engineering/how-we-work/onboarding.mdx
+```
+
 Start with:
 
 | Page | What it answers |

--- a/.agents/skills/langfuse-onboarding/SKILL.md
+++ b/.agents/skills/langfuse-onboarding/SKILL.md
@@ -50,6 +50,7 @@ cannot live in one repo. Create the directory if it does not exist.
 - **Tracker identity:** <name / email as Linear knows it, or "none">
 - **Focus:** <the areas they own or are learning — their own words>
 - **Checkouts:** <path to langfuse> · <path to langfuse-docs> · <others>
+- **Connectors verified:** <the ones that answered a real read> · **missing:** <the rest>
 - *Recorded <date> by an agent. Edit freely; delete to be asked again.*
 ```
 
@@ -116,7 +117,33 @@ Then, in the repos:
 finding worth reporting, not something to smooth over: one of the two is wrong,
 and the person reading both will trust the wrong one.
 
-## Step 4 — the checkouts, especially the docs one
+## Step 4 — the connectors, and what breaks without each
+
+Skills fail differently from code: an unauthorized connector does not error, the
+agent simply cannot answer, and neither of you finds out why. So walk this list
+and say which ones are missing rather than discovering it mid-task.
+
+| Connect | Needed by |
+| --- | --- |
+| **Linear** | 17 skills — the tracker practice in all of it |
+| **Datadog** | `debug-issue-with-datadog`, `datadog-query-recipes`, `incident-alert-tickets`, `weekly-production-review`, `infra-scaling`, `linear-bug-triage` |
+| **AWS** (SSO) | preview seeding and `kubectl` in `langfuse-previews`, plus `infra-scaling`, `security-review` |
+| **incident.io** | `incident-alert-tickets`, `weekly-production-review`, `debug-issue-with-datadog` |
+| **PostHog** | `posthog-instrumentation`, and the usage half of `debug-issue-with-datadog` |
+| **Sentry** | `sentry-instrumentation` |
+| **Pylon** | `housekeeping` |
+| **Hex** | `analyze-cloud-costs` |
+| **Slack** | `weekly-production-review` |
+
+**Datadog is the one that fails quietly**, and it takes four skills with it.
+Prove each connector with a real read rather than trusting a status indicator —
+a remote server can report itself connected before it holds a token.
+
+Two prerequisites on the same checklist that are not connectors: the
+`langfuse-docs` checkout below, which four skills read the handbook from, and a
+working local Docker, without which the seeder cannot make test data.
+
+## Step 5 — the checkouts, especially the docs one
 
 A maintainer needs the app repo *and* the docs repo. The docs repo is the one
 people skip, and then documentation quietly stops happening because the

--- a/.agents/skills/langfuse-onboarding/SKILL.md
+++ b/.agents/skills/langfuse-onboarding/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: langfuse-onboarding
+description: |
+  Work out who the person in front of you is — outside contributor or Langfuse
+  maintainer, and which product areas they own — record it, and walk them
+  through onboarding. Use on "onboard me", "I'm new here", "what do I need to
+  set up", "am I set up correctly", and whenever you need to know someone's
+  role or focus and no identity file exists yet.
+---
+
+# Onboarding at Langfuse
+
+Two jobs. **Establish who you are talking to**, once, and record it so no later
+session has to ask again. Then **walk the onboarding path** for that person.
+
+Everything an agent needs to behave differently for a contributor than for a
+maintainer follows from the first job, so do it before anything else.
+
+## Step 1 — derive the role; do not ask what you can find out
+
+Two signals, in order. Both are read-only.
+
+```bash
+gh api repos/langfuse/langfuse --jq '.permissions | {push, maintain, admin}'
+git config user.email
+```
+
+- **`push: true`** → maintainer. They have write access to the app repo.
+- **`push: false`** or the call fails → treat as an outside contributor until they
+  say otherwise.
+- A `@clickhouse.com` git email plus reachable Linear tools is a second maintainer
+  signal, and the one that matters for the tracker layer: a maintainer with no
+  Linear connection is a *setup gap*, not a contributor.
+
+Say what you found and let them correct it. Never announce a role silently — a
+wrong guess sends someone down the wrong half of this file.
+
+## Step 2 — record it, so this happens once
+
+Write `~/.config/langfuse/me.md`. Machine-level on purpose: it has to answer the
+question in `langfuse`, in `langfuse-docs`, and in a scratch directory, so it
+cannot live in one repo. Create the directory if it does not exist.
+
+```markdown
+# Me, at Langfuse
+
+- **Name:** <name>
+- **Role:** maintainer | contributor
+- **GitHub:** <login>          # from `gh api user --jq .login`
+- **Tracker identity:** <name / email as Linear knows it, or "none">
+- **Focus:** <the areas they own or are learning — their own words>
+- **Checkouts:** <path to langfuse> · <path to langfuse-docs> · <others>
+- *Recorded <date> by an agent. Edit freely; delete to be asked again.*
+```
+
+**Never commit this file, and never put a secret in it.** It is notes, not
+config: no tokens, no keys. A repo `.env` is the wrong home — those are
+app configuration and one careless `git add` publishes them.
+
+Ask for **Focus** rather than deriving it. What someone owns on paper and what
+they are actually responsible for this quarter are different things, and only
+they know the second. Keep their phrasing.
+
+Do **not** record what they own project by project — that is derivable and it
+goes stale within a week. `linear-work-rhythm` reads it live from the tracker
+instead.
+
+## Step 3a — the contributor path
+
+Read `CONTRIBUTING.md` and walk it: setup, the four gating checks before opening
+a PR, and `## Maintainers` for what is not theirs to do. `.agents/AGENTS.md` →
+*Verification* is the honest bar, including which checks pass without running.
+
+Stop there. Do not describe the issue tracker, the label policy, the weekly
+rhythm, or the internal handbook — a contributor cannot open any of it, and
+offering it reads as a door that is locked.
+
+## Step 3b — the maintainer path
+
+**The handbook owns the content; you drive it.** It is `content/handbook/` in
+`langfuse/langfuse-docs`, published at `langfuse.com/handbook`. Read the pages,
+work through them with the person, and answer from what they actually say today —
+do not paraphrase them here, because this file would then be a second, stale copy
+of a document that changes without it.
+
+Start with:
+
+| Page | What it answers |
+| --- | --- |
+| `product-engineering/how-we-work/onboarding.mdx` | Day 1, Week 1, months 1–3, month 6 — the timeline and its outcomes |
+| `product-engineering/how-we-work/how-we-ship.mdx` | Prioritisation, specification, releases, issue states |
+| `tools-and-processes/using-linear.mdx` | How the tracker is used, and the working agreement |
+| `how-we-work/productivity-and-ai.mdx` | Agent tooling, and keeping `AGENTS.md` current |
+| `product-engineering/how-we-work/code-review.mdx` | What review is for here |
+
+Then, in the repos:
+
+- `.agents/AGENTS.md` — always loaded, and the two things it names that nothing
+  else does: what a green check really proves, and the context handover.
+- `linear-agent-writes` — read before the first agentic tracker write.
+- `pr-stack-workflow` — before the first change too large for one PR.
+
+**If a handbook page contradicts a skill or an `AGENTS.md`, say so.** That is a
+finding worth reporting, not something to smooth over: one of the two is wrong,
+and the person reading both will trust the wrong one.
+
+## Step 4 — the checkouts, especially the docs one
+
+A maintainer needs the app repo *and* the docs repo. The docs repo is the one
+people skip, and then documentation quietly stops happening because the
+alternative is a clone in the middle of a task.
+
+```bash
+git rev-parse --show-toplevel                        # where am I
+ls -d ../langfuse-docs ~/code/langfuse-docs 2>/dev/null   # is the docs repo here
+```
+
+If `langfuse-docs` is missing, say so plainly and give the command — do not
+carry on and hope:
+
+```bash
+git clone git@github.com:langfuse/langfuse-docs.git
+```
+
+It carries the handbook, the docs, and the changelog. Without it this skill
+cannot read step 3b, and no shipped change can get a docs page or a changelog
+entry without a separate detour.
+
+Record the paths you found in `me.md` so the next session does not search again.
+
+## What this skill does not do
+
+It does not decide what to work on — that is
+[`linear-work-rhythm`](../linear-work-rhythm/SKILL.md), which reads `me.md` and
+answers from the tracker. If someone asks "what should I do today" and no
+identity file exists, run step 1 and 2 first, then hand over.

--- a/.agents/skills/langfuse-onboarding/agents/openai.yaml
+++ b/.agents/skills/langfuse-onboarding/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Langfuse Onboarding"
+  short_description: "Establish who you are, then walk the onboarding path"
+  default_prompt: "Use $langfuse-onboarding to work out whether I am a contributor or a maintainer, record it, and walk me through setup."

--- a/.agents/skills/linear-work-rhythm/SKILL.md
+++ b/.agents/skills/linear-work-rhythm/SKILL.md
@@ -55,11 +55,18 @@ The heaviest recurring obligation and the easiest to miss, because nothing
 notifies you.
 
 ```
-get_status_updates(type: "project", user: "me", createdAt: "-P14D")
+get_status_updates(type: "project", user: "me")
 ```
 
+**Do not put a lower bound on that window.** A cutoff drops exactly the projects
+that need reporting: one last updated five weeks ago returns nothing, so you can
+say only "older than the window" — not how stale it is, and not what its last
+"next step" was. Take the newest update per project from an unbounded query
+instead, and page if you have to.
+
 Compare against the in-progress projects from above. Any project with no update
-since the last Monday owes one. Say how stale each is in days — "last update 11
+since the last Monday owes one, and a project with **no update at all** is the
+worst case, not an absent row. Say how stale each is in days — "last update 11
 days ago" lands, "stale" does not.
 
 An update carries health, progress since the last one, next step, blockers or

--- a/.agents/skills/linear-work-rhythm/SKILL.md
+++ b/.agents/skills/linear-work-rhythm/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: linear-work-rhythm
+description: |
+  Answer "what should I do today" for a Langfuse maintainer, from the tracker
+  rather than from memory: which projects you lead, which owe an update before
+  Monday planning, what shipped but is not finished, what is waiting on your
+  decision. Use on "what should I do today", "what's on my plate", "what should
+  I work on next", "prep my Monday update", "what did I say last week".
+---
+
+# The working rhythm, read live
+
+**Answer from the tracker, never from recall.** Ownership, health and dates
+change daily, and a plausible answer assembled from memory is worse than no
+answer because nobody can tell it is stale.
+
+Who the person is comes from `~/.config/langfuse/me.md`. If that file does not
+exist, run [`langfuse-onboarding`](../langfuse-onboarding/SKILL.md) first — do
+not guess, and do not answer this question for an outside contributor, who owns
+none of it.
+
+**The rules behind every check below are the working agreement**, published in
+`content/handbook/tools-and-processes/using-linear.mdx` in
+`langfuse/langfuse-docs`. Read it rather than trusting this file for *what* is
+required; this file is only the set of queries that reveal where you stand
+against it. When the two disagree, the handbook wins and this file is the bug.
+
+## Do not hand-maintain the responsibility zone
+
+Derive it. What someone owns is exactly "the projects where they are lead", and
+that answer is one call old:
+
+```
+list_projects(member: "me", state: "started",
+              fields: [name, status, lead, targetDate, priority, labels, teams, url])
+```
+
+A local list of someone's projects is stale within a week — this repo has been
+burned by exactly that. `me.md` holds only the durable half: name, role, and the
+focus they described in their own words.
+
+## The five checks
+
+Run them, then report as **a short ranked list with the reason attached**, not a
+status dump. Ranking beats completeness: the point is what to do next, and a
+40-row table answers nothing.
+
+### 1. Updates owed before Monday planning
+
+The heaviest recurring obligation and the easiest to miss, because nothing
+notifies you.
+
+```
+get_status_updates(type: "project", user: "me", createdAt: "-P14D")
+```
+
+Compare against the in-progress projects from above. Any project with no update
+since the last Monday owes one. Say how stale each is in days — "last update 11
+days ago" lands, "stale" does not.
+
+An update carries health, progress since the last one, next step, blockers or
+decisions needed, and any target-date change. **The previous update's "next step"
+is where this week's goal already is** — read it before writing the new one, and
+say whether it happened. That is the whole value of the sequence.
+
+### 2. Shipped but not finished
+
+Issues sitting in **Merged** are the staging area between a merged PR and `Done`,
+and they exist so follow-ups get captured before the work leaves your view.
+
+```
+list_issues(assignee: "me", state: "Merged",
+            fields: [title, status, project, labels, updatedAt, url])
+```
+
+For each, ask the three questions the agreement puts at this step, and ask them
+out loud rather than assuming the answer is no:
+
+- **Does this need a docs page or an edit?** User-visible behaviour usually does.
+  The docs live in `langfuse/langfuse-docs` under `content/docs/`. If that repo is
+  not checked out, say so and give the clone command — a missing checkout is why
+  documentation silently stops happening.
+- **Does it need a changelog entry?** `changelog-writing` owns the shape.
+- **Did a customer ask for this?** If a customer request is linked, they get told.
+
+Then it can move to `Done` — by a human. Moving tracker state is not an agent's
+to do; propose it.
+
+An issue that has been in `Merged` for weeks is the signal this step is not
+running. Count them and lead with the number.
+
+### 3. Waiting on your decision
+
+Triage normally gets a decision within one working day. Check the triage state on
+your teams, and your own inbox-shaped work: things assigned to you that you have
+not moved, and requests routed to you as a feature owner.
+
+### 4. Your open bugs
+
+A weekly look at your own bugs, to catch what is slipping.
+
+```
+list_issues(assignee: "me", label: "bug", state: "started")
+```
+
+Also check unstarted bugs assigned to you — a bug nobody has begun is the one
+that slips.
+
+### 5. Lifecycle compliance, but only where it changes what you do
+
+Report a gap only when fixing it is the next action. In-progress projects need a
+*specific* target date; planned ones need owner, priority, a quarter-level target
+date, and a pod or function label. Missing labels across every project is one
+finding, not eight.
+
+Do not turn this into an audit. One line naming the pattern is more useful than
+a per-project table, and the agreement is explicit that this system stays
+lightweight.
+
+## Writing anything back
+
+Every write follows [`linear-agent-writes`](../linear-agent-writes/SKILL.md) —
+read it first. Two things specific to this skill:
+
+- **A project update is a status update, not a description edit or a comment.**
+  It is the owner's voice on their own project. Draft it, show it, and let them
+  post it or tell you to. Do not post one as if it were theirs.
+- **State changes are theirs**: moving `Merged` to `Done`, re-prioritising,
+  changing a target date, reassigning. Surface them as the recommendation they
+  are.
+
+## What this does not cover
+
+Clearing the notification inbox, support queues and pull-request review load are
+[`housekeeping`](../housekeeping/SKILL.md); this skill is the project-lead layer
+above it. For the reasoning behind a specific piece of work rather than its
+status, use [`linear-context-handover`](../linear-context-handover/SKILL.md).

--- a/.agents/skills/linear-work-rhythm/SKILL.md
+++ b/.agents/skills/linear-work-rhythm/SKILL.md
@@ -25,6 +25,10 @@ none of it.
 required; this file is only the set of queries that reveal where you stand
 against it. When the two disagree, the handbook wins and this file is the bug.
 
+Read it from `origin/main` — `git fetch -q origin main` then
+`git show origin/main:<path>` — because a docs checkout is usually parked on an
+old branch, and quoting a stale agreement is worse than not quoting one.
+
 ## Do not hand-maintain the responsibility zone
 
 Derive it. What someone owns is exactly "the projects where they are lead", and

--- a/.agents/skills/linear-work-rhythm/agents/openai.yaml
+++ b/.agents/skills/linear-work-rhythm/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Linear Work Rhythm"
+  short_description: "What should I do today, answered from the tracker"
+  default_prompt: "Use $linear-work-rhythm to tell me what to do today: which of my projects owe an update, what shipped but is not finished, and what is waiting on my decision."


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17036 app preview](https://pr-17036.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Two skills so an agent knows **who it is working for** and **what that person should do next**. The role is derived, not asked. The responsibility zone is read from the tracker, not stored. Docs only, 6 files, +304.

**3/3 of a stack.** Based on #17017, which carries the tracker write policy these point at; that one is based on #17013. Base retargets when its parent lands.

## Why

An agent opening this repo did not know whether it was talking to an outside contributor or a maintainer, so it had to guess — and guessing wrong in either direction is bad in a different way. Offer the tracker workflow to a contributor and you have described a locked door. Withhold it from a maintainer and they never learn the practice exists.

"What should I do today" had no answer at all. The state that answers it — who leads which project, which ones owe an update, what shipped but is not finished — lives in the tracker and changes daily. Nothing read it, so the honest options were a stale guess or nothing.

## What

**`langfuse-onboarding`** — establishes the role once and records it.

- **Derived, not asked.** `gh api repos/langfuse/langfuse --jq .permissions` answers the binary; a work email plus reachable tracker tools is the second signal, and separates *maintainer without a connection* (a setup gap) from *contributor* (not one). Only the focus areas, which nobody can derive, come from the person — and their phrasing is kept.
- **One machine-level file**, `~/.config/langfuse/me.md`. The question has to be answerable in the docs repo and in a scratch directory too, so it cannot live in one repo; and a repo `.env` is app configuration that one careless `git add` publishes. Notes only, never a secret.
- **It stores no project list.** Ownership is derivable and a local copy is stale inside a week.
- **The handbook owns the content; the skill drives it.** Five pages, read rather than paraphrased, so this file cannot become a second stale copy of a document that changes without it. It is told to *report* contradictions between a handbook page and a skill rather than smooth them over.
- **It checks for the docs checkout.** That is the one people skip, and then documentation quietly stops happening because the alternative is cloning a repo in the middle of a task.

**`linear-work-rhythm`** — answers the daily question from the tracker.

Five checks: updates owed before Monday planning; issues sitting in `Merged` with docs, changelog and customer follow-ups unasked; work waiting on a decision; your open bugs; and lifecycle gaps, but only where fixing one is the next action. Reported as a short ranked list with reasons — the question is what to do next, and a forty-row table answers nothing.

It carries the queries, not the rules. The working agreement lives in the handbook, and a copy here would drift from it silently.

**`AGENTS.md`** gets the role check, because it always loads and a skill only loads once its description matches — by which point an agent has usually already assumed.

## Result

`onboard me` in a fresh clone now resolves the role, records it, walks the handbook and names what is missing from the setup. `what should I do today` returns ranked, sourced work instead of a guess.

<details>
<summary>The dry run, what it found, and what it does not prove</summary>

Run headless in a detached worktree with the shim sync applied and no identity file present, from the two-word prompt `onboard me`. It selected the skill unprompted and made 12 tool calls in this order: checked for a prior answer; derived the role from repository permissions; located the docs checkout; searched for and reached the tracker; read all five handbook pages; wrote the identity file. 14 turns, 113s, exit 0.

**It found three things it was not asked to look for. All three were re-verified by hand afterwards, and all three are real:**

1. Three handbook links point at a tracker workspace that no longer exists — the slug changed and the handbook did not follow. A new joiner following that page hits dead links on day one.
2. One handbook page credits a code-review vendor with no configuration anywhere in either repo, while the bots that actually run are unlisted. Someone reading both the handbook and `AGENTS.md` trusts the handbook and answers the wrong bots.
3. The docs checkout it read was **576 commits behind**, parked on an old branch.

**Finding 3 was a bug in the skill, and it is why the run was worth doing.** The instruction said *read the handbook*; it did not say *make sure it is today's*. A docs checkout normally sits on whatever branch its owner last shipped from, so a working-tree read quotes a document from weeks ago and says nothing about it. The run only caught it on its own initiative, which is not a property to rely on. Both skills now read `git show origin/main:<path>` after a fetch — no checkout switch, no way to get a stale answer quietly.

**Not proven by this run**, stated because a test record listing only passes is not one: the **contributor path never fired**, because the machine has write access — and that is the half where being wrong is worst; the missing-docs-clone branch never fired, because the docs repo was present; and a machine-global instruction file was loaded that a new joiner will not have, so the mechanical steps are trustworthy but the prose was not written from a blank slate. The first two are worth exercising against a repo without a write bit before anyone relies on them.

**Verified:** `skill-creator`'s validator reports *Skill is valid!* for both; `pnpm run agents:check` exits 0 and the shim sync links both; `prettier --check` and `turbo run lint` clean (`Tasks: 7 successful, 7 total`); spellcheck clean on the changed files; no dead relative links introduced.

**Deliberately not here:** the two handbook drifts above are a separate change to a separate repo, and the working agreement is still unpublished — that page needs a scrub before it can go into a public repo, because the draft carries internal links and a personal email address.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces persistent contributor-versus-maintainer onboarding and a tracker-driven daily work-rhythm skill, then routes relevant requests to those skills from the shared agent guidance.

- Derives and records the user’s role and focus at machine scope.
- Walks maintainers through current handbook content from the docs repository.
- Queries project updates, merged work, decisions, bugs, and lifecycle gaps to rank daily actions.
- The status-update window loses information required for long-overdue projects, and the decision check lacks operational tracker queries.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR is not ready to merge because projects overdue by more than 14 days lose the update history required by the core daily-planning workflow.

The fixed 14-day status-update filter prevents exact staleness and prior-goal comparison for the projects most in need of attention; the decision-work section also needs concrete tracker retrieval guidance.

**Files Needing Attention:** .agents/skills/linear-work-rhythm/SKILL.md
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Agent receives request] --> B{Identity file exists?}
  B -- No --> C[langfuse-onboarding]
  C --> D[Derive role and record me.md]
  D --> E{Role}
  E -- Contributor --> F[Walk CONTRIBUTING.md]
  E -- Maintainer --> G[Read handbook from origin/main]
  B -- Yes --> H{Daily work request?}
  D --> H
  H -- Yes, maintainer --> I[linear-work-rhythm]
  I --> J[Derive led projects]
  J --> K[Check updates and merged work]
  K --> L[Check decisions and bugs]
  L --> M[Rank next actions]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.agents/skills/linear-work-rhythm/SKILL.md:68
**Lookback Hides Overdue Updates**

The 14-day lower bound removes the previous update precisely for projects that have been neglected longer than two weeks. For those projects, this query can establish only that the update is more than 14 days old; it cannot report the exact staleness or read the previous update’s “next step,” both of which the following instructions require. Fetch each project’s latest update without a fixed lower bound, or add a fallback query when this window returns none.

### Issue 2
.agents/skills/linear-work-rhythm/SKILL.md:104-106
**Decision Check Lacks Queries**

The “Waiting on your decision” check is the only one without an executable tracker query or a source for team membership and feature-owner routing. Since `me.md` intentionally stores only identity and free-form focus, an agent cannot reliably determine which team triage queues and routed requests belong to the user. This category may therefore be omitted or inferred from memory even though the skill requires live tracker data. Add concrete retrieval and filtering instructions for each source named here.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): read the handbook from ori..."](https://github.com/langfuse/langfuse/commit/520218fc46b5d5cb3f11a6f9d52c09bdc4bd8a03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60319299)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->