### PR TITLE
fix(auth): stop NextAuth email callback from consuming password-reset codes

### DIFF
--- a/web/src/__tests__/server/nextauth-email-callback.servertest.ts
+++ b/web/src/__tests__/server/nextauth-email-callback.servertest.ts
@@ -1,0 +1,174 @@
+import { createHash, randomInt, randomUUID } from "crypto";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { describe, expect, it, vi } from "vitest";
+
+// The EmailProvider is only registered when SMTP is configured, and the
+// provider list is built when `@/src/server/auth` is first imported. Set the
+// variables before any import so `GET /api/auth/callback/email` resolves to a
+// real provider instead of a "provider not found" redirect.
+vi.hoisted(() => {
+  process.env.SMTP_CONNECTION_URL = "smtp://localhost:1025";
+  process.env.EMAIL_FROM_ADDRESS = "noreply@example.com";
+});
+
+import { env } from "@/src/env.mjs";
+import {
+  hashPassword,
+  verifyPassword,
+} from "@/src/features/auth-credentials/lib/credentialsServerUtils";
+import auth from "@/src/pages/api/auth/[...nextauth]";
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import { getAuthOptions } from "@/src/server/auth";
+import { prisma } from "@langfuse/shared/src/db";
+
+const OLD_PASSWORD = "Oldpass1!";
+const NEW_PASSWORD = "Newpass1!";
+
+describe("GET /api/auth/callback/email", () => {
+  it("does not create a session or consume the code; the code still resets the password", async () => {
+    const { userId, email } = await createUser({ password: OLD_PASSWORD });
+    const token = uniqueOtp();
+    await insertOtp({ email, token });
+
+    const res = await callEmailCallback({ email, token });
+
+    expect(res.statusCode).toBe(302);
+    expect(getHeaderText(res, "Location")).toContain("error=Verification");
+    expect(getHeaderText(res, "Set-Cookie")).not.toMatch(
+      /session-token=[^;\s]+/,
+    );
+    await expect(findOtp({ email, token })).resolves.not.toBeNull();
+
+    const ctx = createInnerTRPCContext({ session: null, headers: {} });
+    const caller = appRouter.createCaller({ ...ctx, prisma });
+    await caller.credentials.resetPassword({
+      email,
+      token,
+      password: NEW_PASSWORD,
+    });
+
+    await expectPassword(userId, NEW_PASSWORD);
+    await expect(findOtp({ email, token })).resolves.toBeNull();
+  });
+
+  it("does not log in an account that never set a password", async () => {
+    const { email } = await createUser({ password: null });
+    const token = uniqueOtp();
+    await insertOtp({ email, token });
+
+    const res = await callEmailCallback({ email, token });
+
+    expect(res.statusCode).toBe(302);
+    expect(getHeaderText(res, "Location")).toContain("error=Verification");
+    expect(getHeaderText(res, "Set-Cookie")).not.toMatch(
+      /session-token=[^;\s]+/,
+    );
+    await expect(findOtp({ email, token })).resolves.not.toBeNull();
+  });
+
+  it("does not consume other outstanding codes on a wrong guess", async () => {
+    const { email } = await createUser({ password: OLD_PASSWORD });
+    const token = uniqueOtp();
+    await insertOtp({ email, token });
+
+    const res = await callEmailCallback({ email, token: "000000" });
+
+    expect(getHeaderText(res, "Location")).toContain("error=Verification");
+    await expect(findOtp({ email, token })).resolves.not.toBeNull();
+  });
+});
+
+describe("NextAuth signIn callback for the email provider", () => {
+  it("allows the send request but rejects the consume request", async () => {
+    const { email } = await createUser({ password: OLD_PASSWORD });
+    const authOptions = await getAuthOptions();
+    const signIn = authOptions.callbacks!.signIn!;
+    const user = { id: email, email };
+    const account = {
+      provider: "email",
+      type: "email" as const,
+      providerAccountId: email,
+    };
+
+    await expect(
+      signIn({ user, account, email: { verificationRequest: true } }),
+    ).resolves.toBe(true);
+    await expect(signIn({ user, account })).resolves.toBe(false);
+  });
+});
+
+function uniqueOtp() {
+  return randomInt(100000, 1000000).toString();
+}
+
+function hashEmailOtpToken(token: string) {
+  return createHash("sha256")
+    .update(`${token}${env.NEXTAUTH_SECRET ?? ""}`)
+    .digest("hex");
+}
+
+async function callEmailCallback({
+  email,
+  token,
+}: {
+  email: string;
+  token: string;
+}) {
+  const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+    method: "GET",
+    headers: { host: "localhost:3000" },
+    query: { nextauth: ["callback", "email"], token, email },
+  });
+  req.cookies = {};
+
+  await auth(req, res);
+
+  return res;
+}
+
+function getHeaderText(res: NextApiResponse, name: string) {
+  const value = res.getHeader(name);
+  return Array.isArray(value) ? value.join("\n") : String(value ?? "");
+}
+
+async function insertOtp({ email, token }: { email: string; token: string }) {
+  await prisma.verificationToken.create({
+    data: {
+      identifier: email,
+      token: hashEmailOtpToken(token),
+      expires: new Date(Date.now() + 3 * 60 * 1000),
+    },
+  });
+}
+
+function findOtp({ email, token }: { email: string; token: string }) {
+  return prisma.verificationToken.findUnique({
+    where: {
+      identifier_token: { identifier: email, token: hashEmailOtpToken(token) },
+    },
+  });
+}
+
+async function expectPassword(userId: string, password: string) {
+  const user = await prisma.user.findUniqueOrThrow({
+    where: { id: userId },
+    select: { password: true },
+  });
+  expect(await verifyPassword(password, user.password!)).toBe(true);
+}
+
+async function createUser({ password }: { password: string | null }) {
+  const id = randomUUID();
+  const email = `user-${id}@example.com`;
+  const user = await prisma.user.create({
+    data: {
+      id: `user-${id}`,
+      email,
+      name: "Email Callback Test User",
+      password: password === null ? null : await hashPassword(password),
+    },
+  });
+  return { userId: user.id, email };
+}

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -688,72 +688,15 @@ const createExtendedPrismaAdapter = (signupAttribution?: {
     }
   },
 
-  // Make email-OTP login that is used for password reset safer.
-  //
-  // Look the token up before consuming it. The upstream PrismaAdapter
-  // implements this as an unconditional `verificationToken.delete`, which
-  // rejects with Prisma P2025 whenever the token is missing — expired,
-  // already consumed (e.g. an email security scanner prefetching the magic
-  // link), or a bogus value from endpoint scanning. Every rejected query is
-  // surfaced by the global Prisma error handler (packages/shared/src/db.ts) as
-  // a `prisma:error` ERROR log, so a routine "invalid or expired token" spams
-  // error logs and error-rate dashboards. Reading first keeps the happy path
-  // identical while treating a missing token as the ordinary invalid-token
-  // outcome instead of a failed query.
-  async useVerificationToken(params) {
-    const identifier_token = {
-      identifier: params.identifier,
-      token: params.token,
-    };
-
-    const verificationToken = await prisma.verificationToken.findUnique({
-      where: { identifier_token },
-    });
-
-    if (!verificationToken) {
-      // Token invalid or expired-and-swept. Log the security event and clear
-      // any remaining tokens for this identifier to prevent enumeration.
-      logger.info("Failed OTP verification attempt", {
-        identifier: params.identifier,
-        token: params.token?.substring(0, 2) + "****", // partial token for debugging
-        timestamp: new Date().toISOString(),
-        reason: "invalid_or_expired",
-      });
-
-      await prisma.verificationToken.deleteMany({
-        where: { identifier: params.identifier },
-      });
-
-      return null;
-    }
-
-    try {
-      // Consume the token. NextAuth validates `expires` on the returned row.
-      await prisma.verificationToken.delete({ where: { identifier_token } });
-    } catch (error) {
-      // A concurrent request may have consumed the token between the read and
-      // the delete. Treat that race as an already-used token, not a 500.
-      if (
-        typeof error === "object" &&
-        error !== null &&
-        "code" in error &&
-        (error as { code?: unknown }).code === "P2025"
-      ) {
-        logger.info("OTP verification token already consumed", {
-          identifier: params.identifier,
-          timestamp: new Date().toISOString(),
-        });
-        return null;
-      }
-      throw error;
-    }
-
-    logger.info("OTP verification successful", {
-      identifier: params.identifier,
-      timestamp: new Date().toISOString(),
-    });
-
-    return verificationToken;
+  // Email one-time codes are consumed only by `credentials.resetPassword`
+  // (consumeEmailOtpAndUpdatePassword), which validates the code and writes
+  // the new password in one transaction. NextAuth calls this adapter method
+  // from GET /api/auth/callback/email before it consults `callbacks.signIn`,
+  // so returning null here is what keeps that route from logging a user in
+  // without a password. It also leaves the stored code untouched, so a
+  // prefetching mail scanner or a guessed request cannot burn a valid code.
+  async useVerificationToken() {
+    return null;
   },
 });
 
@@ -1021,7 +964,7 @@ export async function getAuthOptions(signupAttribution?: {
           };
         });
       },
-      async signIn({ user, account, profile }) {
+      async signIn({ user, account, profile, email: emailFlow }) {
         return instrumentAsync({ name: "next-auth-sign-in" }, async () => {
           // Block sign in without valid user.email
           const email = user.email?.toLowerCase();
@@ -1078,8 +1021,30 @@ export async function getAuthOptions(signupAttribution?: {
             }
           }
 
-          // Only allow sign in via email link if user is already in db as this is used for password reset
+          // The email provider only sends password-reset codes; it must never
+          // complete a login. NextAuth sets `email.verificationRequest` on the
+          // send request (POST /api/auth/signin/email) and omits it on the
+          // consume request (GET /api/auth/callback/email).
           if (account?.provider === "email") {
+            if (!emailFlow?.verificationRequest) {
+              logger.warn(
+                "Blocked email-OTP sign in via the NextAuth email callback",
+                { email },
+              );
+              return false;
+            }
+
+            // Codes only reset passwords, so there is nothing to send when
+            // password login is disabled.
+            if (env.AUTH_DISABLE_USERNAME_PASSWORD === "true") {
+              logger.info(
+                "Blocked email-OTP request because AUTH_DISABLE_USERNAME_PASSWORD is set",
+                { email },
+              );
+              return false;
+            }
+
+            // Only send a code if the user already exists, as this is used for password reset
             const blockedDomains = getSSOBlockedDomains();
             if (userDomain && blockedDomains.includes(userDomain)) {
               logger.info(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17039 app preview](https://pr-17039.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Password-reset one-time codes are meant to be spent only by the `credentials.resetPassword` mutation, which validates the code and writes the new password in one transaction. The NextAuth email provider still mounted `GET /api/auth/callback/email`, a second, unauthenticated consumer of the same codes:

- Anyone holding a valid code could open the callback URL and receive a full session without setting a password (for a fresh signup with `password: null` this yields a session that never completed setup).
- `AUTH_DISABLE_USERNAME_PASSWORD` was not honored on that path, so SSO-only deployments with SMTP configured still had an email-code login.
- NextAuth consumes the token *before* it asks `callbacks.signIn`, so any hit on the URL, including a wrong guess, burned the user's legitimate code (the old adapter override wiped every code for that email on a miss).
- The `useVerificationToken` adapter override existed only to make that callback safe; it also logged 2 of the 6 digits of failed guesses.

Changes in `web/src/server/auth.ts`:

- `useVerificationToken` now returns `null`. This is the actual gate: the callback route always fails verification and never touches the stored code.
- The `signIn` callback rejects email-provider requests that are not send requests (`email.verificationRequest` is set only on `POST /api/auth/signin/email`) as defense in depth, and refuses to send codes when `AUTH_DISABLE_USERNAME_PASSWORD=true`.
- The lookup-before-delete / wipe-on-miss / P2025 / partial-code-log override is removed.

The reset email contains only the 6-digit code (no magic link), so nothing user-facing links to the blocked route. Sending codes, the SSO-enforced-domain block, the user-must-exist check, and the timing jitter are unchanged.

New `web/src/__tests__/server/nextauth-email-callback.servertest.ts` drives the real `[...nextauth]` handler: a valid code on `GET /api/auth/callback/email` yields `error=Verification`, no session cookie, and the token row still exists; the same code then resets the password through `credentials.resetPassword`. It also covers a `password: null` account, a wrong guess not wiping the stored code, and the `signIn` callback allowing send but rejecting consume. All four tests fail on `main`. The test lives in its own file because it must set SMTP env vars before module load to register the `EmailProvider`, which `vitest.config.mts` routes into the isolated project; adding it to `credentials-reset-password.servertest.ts` would demote that whole suite to per-file isolation.

## Proof

Local dev server with SMTP pointed at Mailpit. Request a code, open the callback URL with that code: lands on `/auth/error?error=Verification`, `/api/auth/session` is `{}`. Then the same code completes the reset normally and signs in.

<a href="https://cursor.com/agents/bc-573a0078-fd27-4ff7-92fe-17440a9ec399/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fotp_callback_blocked_then_reset_succeeds.mp4"><img src="https://cursor.com/artifacts/c/art-d6cfa06c-d407-4b62-87bc-f23fc0aeeae5" alt="otp_callback_blocked_then_reset_succeeds.mp4" /></a>

Same flow via `curl`, including the DB-side check that the stored code survives both the valid-code callback hit and a wrong guess:

```text
== 2. open the callback URL directly with the valid code (the side door)
HTTP/1.1 302 Found
Location: http://localhost:3001/api/auth/error?error=Verification
session cookie set? 0
tokens still stored for demo@langfuse.com: 2

== 3. wrong guess on the callback must not wipe the real code
HTTP 302 -> http://localhost:3001/api/auth/error?error=Verification
tokens still stored for demo@langfuse.com: 2

== 4. the same code still resets the password via credentials.resetPassword
HTTP 200
tokens stored after reset: 0

== 5. sign in with the new password (POST /api/auth/callback/credentials)
HTTP/1.1 302 Found
Location: http://localhost:3001/
session cookie set? 1
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- `pnpm run lint`: `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck`: exit 0
- `pnpm --filter web run test src/__tests__/server/nextauth-email-callback.servertest.ts`: `Tests 4 passed (4)` (all 4 fail on `main`)
- `pnpm --filter web run test src/__tests__/server/credentials-reset-password.servertest.ts src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts`: `Test Files 2 passed (2)`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-573a0078-fd27-4ff7-92fe-17440a9ec399?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-573a0078-fd27-4ff7-92fe-17440a9ec399&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents NextAuth's email callback from consuming password-reset codes or creating sessions from them.

- Makes `useVerificationToken` reject callback consumption without modifying the stored code.
- Allows email-provider code requests only during verification-request handling and when username/password authentication is enabled.
- Adds integration coverage showing callback attempts preserve codes and cannot create sessions.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking test gap around the password-disabled email-send guard.

The callback gate and token-preservation behavior match the current NextAuth invocation sequence and reset flow; only the newly added configuration branch lacks direct regression coverage.

**Files Needing Attention:** web/src/server/auth.ts
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant B as Browser
    participant N as NextAuth
    participant DB as Verification tokens
    participant R as credentials.resetPassword

    B->>N: POST /api/auth/signin/email
    N->>N: "signIn(verificationRequest=true)"
    alt Password authentication enabled
        N->>DB: Store hashed one-time code
        N-->>B: Send code
    else Password authentication disabled
        N-->>B: Reject request
    end

    B->>N: GET /api/auth/callback/email
    N->>N: useVerificationToken() returns null
    N-->>B: Verification error, no session

    B->>R: Submit code and new password
    R->>DB: Validate and consume code transactionally
    R-->>B: Password updated
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/server/auth.ts:1039-1045
**Password-disabled guard lacks coverage**

The added tests do not exercise this branch with `AUTH_DISABLE_USERNAME_PASSWORD` enabled. Since this check enforces a deployment-level authentication restriction, add a test confirming that an email-provider send request is rejected when the flag is enabled; otherwise, a later regression could silently restore email-code issuance on password-disabled deployments.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): stop NextAuth email callback ..."](https://github.com/langfuse/langfuse/commit/a13af85af01b124264f612c6b9e51aede1153e2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60329319)</sub>

**Context used:**

- Knowledge Base — [Authentication and authorization](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/authentication-and-authorization.md)

<!-- /greptile_comment -->