### PR TITLE
test(assistant): Move sandbox image build outside test hook

### DIFF
--- a/packages/in-app-agent-sandbox-runtime/package.json
+++ b/packages/in-app-agent-sandbox-runtime/package.json
@@ -12,7 +12,7 @@
     "build:docker-image": "tsc && docker build . -t langfuse-in-app-agent-sandbox:latest && touch .local-image-built",
     "start": "node ./dist/server.js",
     "test": "vitest run src",
-    "test:e2e": "pnpm run build && vitest run tests",
+    "test:e2e": "pnpm run build && docker build . -t langfuse-in-app-agent-sandbox:e2e && vitest run tests",
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/packages/in-app-agent-sandbox-runtime/tests/sandbox.test.ts
+++ b/packages/in-app-agent-sandbox-runtime/tests/sandbox.test.ts
@@ -1,17 +1,10 @@
 // Never use fixed delays to establish operation ordering in these tests.
 // Synchronize through observable state; timeouts are failure bounds only.
-import { readdir } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 
 import Docker from "dockerode";
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-const PACKAGE_ROOT = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "..",
-);
 const IMAGE_TAG = "langfuse-in-app-agent-sandbox:e2e";
 const MICROVM_HOOKS_ROOT = "/aws/lambda-microvms/runtime/v1";
 const HEALTH_TIMEOUT_MS = 30_000;
@@ -25,10 +18,6 @@ describe("sandbox runtime docker container", () => {
   const docker = new Docker();
   let container: Docker.Container;
   let baseUrl = "";
-
-  beforeAll(async () => {
-    await buildSandboxImage(docker);
-  }, 300_000);
 
   beforeEach(async () => {
     container = await docker.createContainer({
@@ -434,54 +423,6 @@ describe("sandbox runtime docker container", () => {
     },
   );
 });
-
-async function buildSandboxImage(docker: Docker) {
-  const src = [
-    "Dockerfile",
-    "package.json",
-    ...(await listRelativeFiles(path.join(PACKAGE_ROOT, "dist"), "dist")),
-  ];
-  const stream = await docker.buildImage(
-    { context: PACKAGE_ROOT, src },
-    { t: IMAGE_TAG },
-  );
-
-  await new Promise<void>((resolve, reject) => {
-    docker.modem.followProgress(stream, (error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-
-      resolve();
-    });
-  });
-}
-
-async function listRelativeFiles(
-  absDir: string,
-  relativePrefix: string,
-): Promise<string[]> {
-  const entries = await readdir(absDir, { withFileTypes: true });
-  const files: string[] = [];
-
-  for (const entry of entries) {
-    const relativePath = `${relativePrefix}/${entry.name}`;
-    if (entry.isDirectory()) {
-      files.push(
-        ...(await listRelativeFiles(
-          path.join(absDir, entry.name),
-          relativePath,
-        )),
-      );
-      continue;
-    }
-
-    files.push(relativePath);
-  }
-
-  return files;
-}
 
 async function waitForHealth(baseUrl: string, container: Docker.Container) {
   const startedAt = Date.now();


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17047 app preview](https://pr-17047.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Moves the sandbox Docker image build out of Vitest's fixed five-minute `beforeAll` hook and into the package's e2e command. Slow base-image pulls or dependency installation can therefore use the CI job timeout, while Docker build progress remains visible in job logs.

The reported failures both expired at exactly 300 seconds before running either test. A neighboring successful run spent 222 seconds in setup and less than three seconds in assertions.

Impacted package: `@repo/in-app-agent-sandbox-runtime`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

- `pnpm run lint` (via commit hook): `Tasks: 7 successful, 7 total`
- `pnpm --filter @repo/in-app-agent-sandbox-runtime run typecheck`: passed
- `pnpm --filter @repo/in-app-agent-sandbox-runtime run test`: `Tests 3 passed (3)`
- `pnpm --filter @repo/in-app-agent-sandbox-runtime run test:e2e`: `Tests 2 passed (2)`; passed four consecutive executions
- `pnpm exec prettier --check packages/in-app-agent-sandbox-runtime/package.json packages/in-app-agent-sandbox-runtime/tests/sandbox.test.ts`: `All matched files use Prettier code style!`

The package-wide `format:check` also inspects generated `dist/**` files and reports their emitted formatting; generated artifacts were not edited or committed.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15983](https://linear.app/clickhouse/issue/LFE-15983/fix-flaky-tests-in-app-agent-sandbox-runtime)

<div><a href="https://cursor.com/agents/bc-18203655-0485-41da-b11c-208606360b23?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18203655-0485-41da-b11c-208606360b23&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR moves the sandbox Docker image build from Vitest’s timeout-bound `beforeAll` hook into the package’s `test:e2e` script.

- Builds TypeScript output before constructing the e2e image.
- Preserves the image tag consumed by the tests.
- Lets Docker build execution use the enclosing CI job timeout and expose progress directly in job logs.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because supported e2e invocations still build the expected image before creating test containers.

The new command preserves build ordering and image tagging while removing only the Vitest-managed image-build lifecycle; no actionable regression remains.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Script[test:e2e] --> Build[Compile TypeScript]
  Build --> Image[Build sandbox e2e image]
  Image --> Vitest[Run Vitest e2e suite]
  Vitest --> Container[Create containers from e2e image]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): move sandbox image build outsid..."](https://github.com/langfuse/langfuse/commit/62e2b322bfe7f83ba057ea743fc0683dd1306535) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60353966)</sub>

<!-- /greptile_comment -->