### PR TITLE
fix(web): seo title for cloud sign in page

### DIFF
--- a/web/src/features/auth/pageMetadata.ts
+++ b/web/src/features/auth/pageMetadata.ts
@@ -15,7 +15,7 @@
  * and gets `DEFAULT_PAGE_TITLE`.
  */
 
-export const DEFAULT_PAGE_TITLE = "Langfuse";
+const DEFAULT_PAGE_TITLE = "Langfuse";
 
 export const SIGN_IN_PAGE_TITLE = "Sign in | Langfuse";
 export const SIGN_UP_PAGE_TITLE = "Sign up | Langfuse";

--- a/web/src/features/auth/pageMetadata.ts
+++ b/web/src/features/auth/pageMetadata.ts
@@ -1,0 +1,44 @@
+/**
+ * Document titles rendered during server-side rendering.
+ *
+ * `AppLayout` gates every page behind `useSession()`, which is always
+ * `"loading"` on the server, so the layout returns a spinner and the page
+ * component — including its `next/head` block — never renders server-side.
+ * The served HTML therefore carried no `<title>` at all.
+ *
+ * `_app` renders outside that gate, so it supplies the title from this map
+ * before the session resolves. Page-level `next/head` blocks still win once
+ * they mount on the client, and they read their strings from here so there is
+ * one source of truth.
+ *
+ * Only public, crawlable routes need an entry; everything else is behind auth
+ * and gets `DEFAULT_PAGE_TITLE`.
+ */
+
+export const DEFAULT_PAGE_TITLE = "Langfuse";
+
+export const SIGN_IN_PAGE_TITLE = "Sign in | Langfuse";
+export const SIGN_UP_PAGE_TITLE = "Sign up | Langfuse";
+
+type PageMetadata = {
+  title: string;
+  description?: string;
+};
+
+/** Keyed by `router.pathname`, so the values are route patterns, not URLs. */
+const PUBLIC_PAGE_METADATA: Record<string, PageMetadata> = {
+  "/auth/sign-in": {
+    title: SIGN_IN_PAGE_TITLE,
+    description:
+      "Sign in to Langfuse to trace, evaluate, and debug your LLM applications.",
+  },
+  "/auth/sign-up": {
+    title: SIGN_UP_PAGE_TITLE,
+    description:
+      "Create a free Langfuse account to trace, evaluate, and debug your LLM applications.",
+  },
+};
+
+export function getPageMetadata(pathname: string): PageMetadata {
+  return PUBLIC_PAGE_METADATA[pathname] ?? { title: DEFAULT_PAGE_TITLE };
+}

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -16,6 +16,7 @@ import { TooltipProvider } from "@/src/components/ui/tooltip";
 import { CommandMenuProvider } from "@/src/features/command-k-menu/CommandMenuProvider";
 
 import { api } from "@/src/utils/api";
+import { getPageMetadata } from "@/src/features/auth/pageMetadata";
 
 import { NextAdapterPagesWithReadyGuard } from "@/src/utils/nextAdapterPagesWithReadyGuard";
 import { QueryParamProvider } from "use-query-params";
@@ -169,6 +170,12 @@ const MyApp: AppType<{ session: Session | null }> = ({
     </>
   );
 
+  // AppLayout gates every page behind `useSession()`, which is always
+  // "loading" on the server, so it renders a spinner and the page's own
+  // `next/head` block is absent from the served HTML. This <Head> sits outside
+  // that gate; page-level blocks still take over once they mount client-side.
+  const pageMetadata = getPageMetadata(router.pathname);
+
   return (
     <>
       {/* Replaces Next's default `width=device-width` (next/head dedupes by
@@ -183,6 +190,10 @@ const MyApp: AppType<{ session: Session | null }> = ({
           name="viewport"
           content="width=device-width, height=device-height, initial-scale=1, maximum-scale=1, user-scalable=no, shrink-to-fit=no, viewport-fit=cover"
         />
+        <title>{pageMetadata.title}</title>
+        {pageMetadata.description ? (
+          <meta name="description" content={pageMetadata.description} />
+        ) : null}
       </Head>
       <QueryParamProvider
         adapter={NextAdapterPagesWithReadyGuard}

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -1,3 +1,4 @@
+import { SIGN_IN_PAGE_TITLE } from "@/src/features/auth/pageMetadata";
 import { type GetServerSideProps } from "next";
 import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import { Button } from "@/src/components/ui/button";
@@ -861,7 +862,7 @@ export default function SignIn({
     return (
       <>
         <Head>
-          <title>Sign in | Langfuse</title>
+          <title>{SIGN_IN_PAGE_TITLE}</title>
         </Head>
         <Spinner message={`Signing in as ${PREVIEW_DEMO_USER_EMAIL}`} />
       </>

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -1,3 +1,4 @@
+import { SIGN_UP_PAGE_TITLE } from "@/src/features/auth/pageMetadata";
 import { Button } from "@/src/components/ui/button";
 import {
   Form,
@@ -454,7 +455,7 @@ function SignupPageShell({ children }: { children: React.ReactNode }) {
   return (
     <>
       <Head>
-        <title>Sign up | Langfuse</title>
+        <title>{SIGN_UP_PAGE_TITLE}</title>
         <meta
           name="description"
           content="Create an account, no credit card required."


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17057 app preview](https://pr-17057.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## The problem

The served HTML for every route on `cloud.langfuse.com` has no `<title>`, and a body that reads `Loading ...`:

```
$ curl -s https://cloud.langfuse.com/auth/sign-in -o /tmp/si.html -w "%{http_code} %{size_download}b\n"
200 7821b
$ grep -o '<title>[^<]*</title>' /tmp/si.html
(nothing)
$ grep -c "Sign in to your account" /tmp/si.html
0
```

`sign-in.tsx` *does* set a title, and has since #1223 in Feb 2024. It never reaches the response because `AppLayout` gates every page behind `useSession()`:

```ts
// useAuthGuard.ts
if (session.status === "loading") {
  return { action: "loading", message: "Loading" };
}

// app-layout/index.tsx
if (authGuard.action === "loading" || ...) {
  return <LoadingLayout message={authGuard.message} />;   // children discarded
}
```

`session.status` is always `"loading"` during SSR, so the layout returns the spinner and the page component — including its `next/head` block — is never rendered on the server. `__NEXT_DATA__` confirms the right page and props were resolved; only the render is skipped.

## Why it matters outside the app

`/auth/sign-in` is the one route here that search engines care about. It ranks at **position 2.0 for "langfuse login" with 291,318 impressions and 11,410 clicks** over the last 90 days (Search Console). Crawlers that do not execute JavaScript — including the one used for our own site audit, which reports it under "Title tag missing or empty" — see an untitled page with two words on it.

## The fix

`_app` renders outside the session gate and already has a `<Head>` for the viewport meta, so the title goes there:

```tsx
<Head>
  <meta name="viewport" content="..." />
  <title>{pageMetadata.title}</title>
  {pageMetadata.description ? (
    <meta name="description" content={pageMetadata.description} />
  ) : null}
</Head>
```

- `web/src/features/auth/pageMetadata.ts` holds the strings, and `sign-in.tsx` / `sign-up.tsx` now import from it, so the SSR fallback and the page-level `next/head` blocks cannot drift apart.
- `next/head` dedupes by tag, and the page-level block renders later, so behaviour on the client is unchanged — the tab title is still whatever the page sets.
- Only public routes get a specific title. Everything behind auth is not crawlable and gets a plain `"Langfuse"`, which is still better than nothing for a browser tab or a bookmark.

## Deliberately not changed

Moving the `variant === "unauthenticated"` branch above the loading check in `AppLayout` would render the real sign-in page server-side — title, form and all — which is the more complete fix. I did not do it here: a signed-in user landing on `/auth/sign-in` currently gets `authGuard.action === "redirect"`, and rendering the form before that guard resolves would flash the sign-in form at them before the redirect fires. That is a UX call for whoever owns this layout, and it belongs in its own PR.

## Verification

- **Typecheck**: `tsc -p web/tsconfig.json --noEmit` reports **no errors in any of the four files** this PR touches. (My local run shows pre-existing errors elsewhere from an out-of-sync Prisma client in my environment, not from this change — CI is authoritative.)
- **Prettier**: no-op on all four files.
- **Not verified in a browser.** AGENTS.md asks for a real-browser review of `web/**` changes; running the app needs Postgres, ClickHouse and Redis, which I did not have here. The change is a `next/head` addition with no conditional logic beyond a pathname lookup, but a reviewer should confirm on a preview deploy that `/auth/sign-in` now has `<title>Sign in | Langfuse</title>` in `view-source` and that the tab title is unchanged while navigating the app.

Found while triaging the Ahrefs site audit for langfuse.com, which crawls in subdomains mode and so includes `cloud.langfuse.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds server-rendered document metadata outside the session-dependent application layout, ensuring authentication routes provide useful titles and descriptions in initial HTML.

- Adds a pathname-based metadata map for sign-in and sign-up.
- Emits fallback metadata from `_app` before the guarded page component renders.
- Reuses shared title constants in portions of the authentication pages.
- Leaves minor metadata consistency and regression-coverage gaps.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with non-blocking metadata consistency and regression-coverage improvements recommended.

The server-side title lookup matches the canonical authentication routes and no behavioral or security failure remains, but page-level metadata can drift from the new fallback and the SSR regression is not automatically tested.

**Files Needing Attention:** web/src/pages/_app.tsx, web/src/pages/auth/sign-in.tsx, web/src/pages/auth/sign-up.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/pages/auth/sign-in.tsx:865
**Metadata Sources Still Drift**

The metadata refactor does not fully create one source of truth. The normal sign-in branch still hardcodes `Sign in | Langfuse` at line 875, while the sign-up page retains a description that differs from the new server-side value. A later metadata update could therefore change the server-rendered output without changing the hydrated page metadata. Please use the shared metadata values in every page-level `Head`.

### Issue 2
web/src/pages/_app.tsx:193-196
**SSR Metadata Lacks Coverage**

The new server-rendered metadata has no automated assertion, even though this regression is specifically visible in HTML generated before JavaScript runs and was not verified in a browser. Add a server-rendering or preview-level test that requests an authentication route and checks its title and description. This would catch future changes that move the `Head` behind the session gate or break the pathname lookup.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): render a document title in the..."](https://github.com/langfuse/langfuse/commit/1f3131f75ef2e7a4ad474bfb9e41db5807c6ae0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60396353)</sub>

**Context used:**

- Knowledge Base — [Authentication and authorization](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/authentication-and-authorization.md)

<!-- /greptile_comment -->