### PR TITLE
docs(agents): make verification proportionate to risk

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -235,7 +235,9 @@ A check that passed is not always a check that ran:
   visual and your confidence is high, say what you changed, hand over the exact
   URL, and let the developer glance at it — that is faster for them than watching
   you automate a confirmation of something you already know. Offering is not
-  punting; silently skipping is.
+  punting; silently skipping is — so name what you did not check, and offer only
+  while somebody is there to take it. If nobody is around and the change is
+  user-visible, check it yourself.
 
 ## Generated Files
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -15,12 +15,16 @@ evaluating, and debugging AI applications.
 - Delegate exploratory or noisy work — broad code search, multi-file
   investigation, log or test-output trawls — to a subagent so the
   intermediate tool output stays out of the main context.
-- For bug fixes, first write the smallest failing test that proves the reported
-  behavior and confirm it fails against the buggy behavior before changing
-  production code. Add another test only when it exercises a distinct adapter,
-  contract, or execution path. Extend the closest existing test suite; do not
-  create a standalone constant test when an existing feature suite owns the
-  behavior. If the bug depends on a data shape, pause and ask: can
+- Match verification to risk, not to the fact that you changed something. A test
+  earns its place when it pins behavior that could regress without anyone
+  noticing. When the only assertion available restates the diff — that a spacing
+  value is now that value, that a label reads what it reads — it costs a file and
+  proves nothing. Skip it, and say in one line that you did and why.
+- When a bug fix does warrant a test, write the smallest failing one first and
+  confirm it fails against the buggy behavior before changing production code.
+  Add another only when it exercises a distinct adapter, contract, or execution
+  path. Extend the closest existing test suite; do not create a standalone
+  constant test when an existing feature suite owns the behavior. If the bug depends on a data shape, pause and ask: can
   `pnpm run seed` prefill that shape locally? If not, consider extending a
   seeder scenario so the bug stays cheaply reproducible
   (`packages/shared/scripts/seeder/AGENTS.md`), or note why a seed cannot
@@ -224,8 +228,14 @@ A check that passed is not always a check that ran:
 - `pnpm exec knip` is a required check in `pipeline.yml` with no `package.json`
   script, so it is easy to never run locally. Unused files and exports under
   `web/**`, `packages/shared/**` and `worker/**` fail it.
-- No check loads a page. A rendering change is not verified until somebody opens
-  the surface it touches and looks at it.
+- No check loads a page, so a rendering change is only verified once somebody
+  looks at it — but that somebody need not be you. Drive a browser when you are
+  genuinely uncertain: a layout that may reflow, a flow that carries state, an
+  interaction whose outcome you cannot predict. When the change is small and
+  visual and your confidence is high, say what you changed, hand over the exact
+  URL, and let the developer glance at it — that is faster for them than watching
+  you automate a confirmation of something you already know. Offering is not
+  punting; silently skipping is.
 
 ## Generated Files
 

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -35,7 +35,8 @@ Focus on:
 - performance issues with real impact
 - missing or weak tests for risky changes
 - Before calling coverage missing, identify the unique regression each proposed
-  test catches. Prefer merging into the closest existing suite. Flag repeated
+  test catches. Do not ask for one whose only assertion would restate the diff —
+  a spacing value, a label — because it costs a file and proves nothing. Prefer merging into the closest existing suite. Flag repeated
   tests of the same predicate across layers unless each proves a distinct
   transport, projection, or execution boundary.
 

--- a/.agents/skills/frontend-browser-review/SKILL.md
+++ b/.agents/skills/frontend-browser-review/SKILL.md
@@ -19,11 +19,26 @@ Use this skill when a change affects what users see or do in the browser.
 
 ## When To Use It
 
-- UI changes in `web/**`
-- Layout, styling, or responsive behavior changes
-- Changes to navigation or page flows
+Drive a browser when the outcome is uncertain:
+
+- Changes to navigation or page flows, or anything carrying state across steps
+- Layout or responsive behavior that could reflow in a way you cannot predict
 - Bug fixes where the failure mode is visible in the browser
-- Final signoff for user-visible frontend work
+- Final signoff for a substantial piece of user-visible work
+
+## When To Offer Instead
+
+A small, self-contained visual change you are confident in does not need an
+automated pass. Spacing, a colour token, a label, an icon swap: say what you
+changed, hand over the exact URL — a local port or the pull request's
+`pr-<N>.preview.langfuse.com` — and let the developer take the two-second look.
+It is faster for them than waiting while you confirm something you already know,
+and a screenshot in the pull request still carries the proof.
+
+Two conditions. **Be explicit** — name what you did not check and why, so the
+choice is visible and they can overrule it. And **do it while they are there**:
+offering is a handoff, not a way of ending your turn. If nobody is around to
+look, and the change is user-visible, check it yourself.
 
 ## Prefill Test Data First
 

--- a/.agents/skills/pr-stack-workflow/SKILL.md
+++ b/.agents/skills/pr-stack-workflow/SKILL.md
@@ -143,7 +143,9 @@ specifically:
   routinely produce an export whose only consumer lives in a later slice: dead
   code on this branch, fine on the tip, and `knip` is a required check. The fix
   is to move the export into the slice that uses it, not to widen an ignore list.
-- **A rendering change is not verified until somebody loads the screen.** Do it
-  once per slice, on that slice's branch and its own preview, not once on the
-  tip. Green checks and bot reviews have between them approved a branch that
-  rendered a blank page.
+- **Somebody has to load the screen, per slice.** Green checks and bot reviews
+  have between them approved a branch that rendered a blank page, and each slice
+  has its own branch and its own preview — so a look at the tip proves nothing
+  about slice 3. Who looks is a judgement call `.agents/AGENTS.md` covers: drive
+  it yourself where the outcome is uncertain, hand over the preview URL where it
+  is not.

--- a/.agents/skills/refactor-react-effects/SKILL.md
+++ b/.agents/skills/refactor-react-effects/SKILL.md
@@ -145,7 +145,8 @@ Run, at minimum:
 - ESLint on the migrated path, then `pnpm --filter web run lint`;
 - type checking when state or action interfaces changed;
 - a real-browser review for user-visible flows, using seeded data where
-  applicable;
+  applicable — yours where the outcome is uncertain, otherwise the developer's,
+  per `.agents/AGENTS.md`;
 - the effect inventory again to prove the intended scope is clean.
 
 Report the exact command summary lines and any retained effects with their


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17064 app preview](https://pr-17064.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Two instructions were written as absolutes where they should have been judgement calls, and agents followed them literally: unit tests for a padding change, and a browser session to confirm something already obvious. Both now scale with risk. Docs only, 5 files, off `main`.

## Why

**"For bug fixes, first write the smallest failing test."** Ask for a spacing change and you get a test asserting that the spacing value is now that value. Its only possible assertion restates the diff, so it costs a file, adds a thing to maintain, and catches nothing — but the rule said to write it, so it got written.

**"A rendering change is not verified until somebody opens the surface it touches."** True, and read as "open a browser for everything". For a colour token or a label, driving automation to confirm what you are already sure of is *slower for the developer* than handing them the URL: they wait while you prove a known result. The instruction never said the somebody had to be the agent.

Neither is a case for verifying less. Both are cases for spending the effort where the uncertainty actually is.

## What

**`AGENTS.md` leads with proportionality.** A test earns its place when it pins behavior that could regress unnoticed; where the only available assertion restates the diff, skip it and say so in a line. The smallest-failing-test recipe is intact and still applies once a fix warrants one.

**The browser rule now splits on certainty.** Drive it where the outcome is genuinely unpredictable — a layout that may reflow, a flow carrying state across steps, an interaction you cannot call. Where the change is small, visual and you are confident, say what you changed, hand over the exact URL, and let the developer take the two-second look.

Two conditions keep that from becoming an excuse, and they are the point:

- **Name what you did not check, and why.** The choice has to be visible so it can be overruled. Offering is not punting; silently skipping is.
- **Offer while someone is there.** It is a handoff, not a way to end a turn. If nobody is around and the change is user-visible, check it yourself.

**Applied everywhere the absolute form appeared** — `AGENTS.md`, `frontend-browser-review` (which gained a *When To Offer Instead* section beside its *When To Use It* list), `pr-stack-workflow`, and `refactor-react-effects` — with the rule stated once in `AGENTS.md` and the skills pointing at it rather than restating it.

**Plus the reviewer-side mirror.** `code-review` already asked reviewers to identify the unique regression a proposed test catches; it now also says not to demand one whose only assertion would restate the diff. Otherwise the author skips the pointless test correctly and a reviewer asks for it back.

## Result

Effort goes where the uncertainty is. A padding change ships with a preview link and an explicit note about what was not checked; a stateful flow still gets driven in a browser.

<details>
<summary>Scope: what was checked, and what was deliberately left alone</summary>

Swept all of `.agents/**`, `web/AGENTS.md` and `CONTRIBUTING.md` for test and browser mandates. Four sites carried the absolute form and are changed. The rest fall into three groups:

**Left alone because a browser genuinely is the only proof.** `sentry-instrumentation` requires reproducing a console error in a real browser, because a passing test does not show the error is gone. `posthog-instrumentation` requires Playwright to assert an event actually fired. Neither is a proportionality problem — there is no cheaper evidence.

**Left alone because it was already calibrated.** `code-review` asked for the unique regression before calling coverage missing, and flags the same predicate tested across layers. Only the one clause was added.

**Left alone because it is not agent guidance.** `CONTRIBUTING.md` tells a human contributor to open their own change in a browser, which is correct advice for a person looking at their own work.

One note on provenance: the browser sentence being softened here is one I added earlier this week, in the pull request that introduced the verification bar. It was right that no check loads a page and wrong to imply the agent must always be the one who does.

`skill-creator`'s validator passes, `pnpm run agents:check` exits 0, `prettier --check` and `turbo run lint` clean (`Tasks: 7 successful, 7 total`), spellcheck clean on all changed files.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR changes agent verification guidance so testing and browser validation scale with regression risk.

- Allows omission of tests whose only assertion restates the implementation change.
- Preserves test-first guidance for bug fixes that warrant regression coverage.
- Allows live developer handoff for small, predictable visual changes.
- Updates related review, browser, stacked-PR, and React-effect skills.
- The canonical browser rule is missing the live-recipient safeguard included in the specialized browser skill.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the canonical guidance requires agents to verify user-visible changes themselves whenever no developer is present to accept the handoff.

The specialized browser skill contains the necessary live-handoff safeguard, but the canonical rule and workflows that refer to it omit that condition, allowing visual changes to remain unverified.

**Files Needing Attention:** .agents/AGENTS.md
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.agents/AGENTS.md:236-238
**Visual handoff can go unchecked**

For a small visual change made while no developer is present, this canonical rule lets the agent provide a URL and finish. The specialized browser guidance says the agent must instead check the change itself in that situation. Without the same safeguard here, workflows that rely on this rule can leave a user-visible change unverified.

```suggestion
  URL, and let the developer glance at it — that is faster for them than watching
  you automate a confirmation of something you already know. Offering is not
  punting; silently skipping is. Offer only while the developer is there to look;
  if nobody is around and the change is user-visible, check it yourself.
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): make verification proporti..."](https://github.com/langfuse/langfuse/commit/f1d81e817f054678ea3fdf57903b0133ea0ee9ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60411605)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->