### PR TITLE
feat(evals): track filter analytics

### DIFF
--- a/web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialogContainer/EvaluatorSavedDialogContainer.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialogContainer/EvaluatorSavedDialogContainer.tsx
@@ -24,6 +24,7 @@ import { api, type RouterOutputs } from "@/src/utils/api";
 import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
 import { cn } from "@/src/utils/tailwind";
 import { classifySampleFiltersForRule } from "@/src/features/evals/v2/fns/rules/classifySampleFiltersForRule";
+import { getFilterAnalyticsProperties } from "@/src/features/evals/v2/fns/getFilterAnalyticsProperties";
 import { EvaluatorSavedRuleFilterPreview } from "@/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialog/EvaluatorSavedRuleFilterPreview";
 
 type Rule = RouterOutputs["evalsV2"]["rules"]["list"]["rules"][number];
@@ -162,7 +163,7 @@ export function EvaluatorSavedDialogContainer({
     if (result.action === "created") {
       capture("evaluation_rules:create", {
         assignmentCount: 1,
-        filterCount: supportedRuleFilters.length,
+        ...getFilterAnalyticsProperties(supportedRuleFilters),
         samplingPercent: Math.round(sampling * 100),
         isEnabled: true,
         source: "evaluator_create_test_filters",

--- a/web/src/features/evals/v2/components/Rules/CreateRuleDialog/components/CreateRuleDialogContent/CreateRuleDialogContent.tsx
+++ b/web/src/features/evals/v2/components/Rules/CreateRuleDialog/components/CreateRuleDialogContent/CreateRuleDialogContent.tsx
@@ -22,6 +22,7 @@ import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useProject } from "@/src/features/projects/hooks";
 import { prepareNameForSave } from "@/src/features/evals/v2/fns/prepareNameForSave";
+import { getFilterAnalyticsProperties } from "@/src/features/evals/v2/fns/getFilterAnalyticsProperties";
 import { resolveInitialRuleFilters } from "./resolveInitialRuleFilters";
 
 export function CreateRuleDialogContent({
@@ -113,7 +114,7 @@ export function CreateRuleDialogContent({
     });
     capture("evaluation_rules:create", {
       assignmentCount: draft.assignments.length,
-      filterCount: draft.filter.length,
+      ...getFilterAnalyticsProperties(draft.filter),
       samplingPercent: Math.round(draft.sampling * 100),
       isEnabled: true,
     });

--- a/web/src/features/evals/v2/components/Rules/EditRuleDialog/components/EditRuleDialogContent/EditRuleDialogContent.tsx
+++ b/web/src/features/evals/v2/components/Rules/EditRuleDialog/components/EditRuleDialogContent/EditRuleDialogContent.tsx
@@ -14,6 +14,7 @@ import type { RuleEvaluatorOption } from "@/src/features/evals/v2/types/rules";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics";
 import { api, type RouterOutputs } from "@/src/utils/api";
 import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
+import { getFilterAnalyticsProperties } from "@/src/features/evals/v2/fns/getFilterAnalyticsProperties";
 
 type Rule = RouterOutputs["evalsV2"]["rules"]["get"];
 
@@ -93,7 +94,7 @@ export function EditRuleDialogContent({
     });
     capture("evaluation_rules:update", {
       assignmentCount: draft.assignments.length,
-      filterCount: draft.filter.length,
+      ...getFilterAnalyticsProperties(draft.filter),
       samplingPercent: Math.round(draft.sampling * 100),
       isEnabled: rule.enabled,
     });

--- a/web/src/features/evals/v2/fns/getFilterAnalyticsProperties.clienttest.ts
+++ b/web/src/features/evals/v2/fns/getFilterAnalyticsProperties.clienttest.ts
@@ -1,0 +1,58 @@
+import type { FilterState } from "@langfuse/shared";
+import { describe, expect, it } from "vitest";
+
+import { getFilterAnalyticsProperties } from "./getFilterAnalyticsProperties";
+
+describe("getFilterAnalyticsProperties", () => {
+  it("reports filter columns without filter values", () => {
+    const filters = [
+      {
+        column: "type",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["GENERATION"],
+      },
+      {
+        column: "type",
+        type: "stringOptions",
+        operator: "none of",
+        value: ["SPAN"],
+      },
+      {
+        column: "metadata",
+        key: "customerId",
+        type: "stringObject",
+        operator: "=",
+        value: "private-customer-id",
+      },
+    ] satisfies FilterState;
+
+    expect(getFilterAnalyticsProperties(filters)).toEqual({
+      filterCount: 3,
+      filterColumns: ["type", "metadata"],
+      usesExperimentFilter: false,
+    });
+  });
+
+  it.each([
+    "experimentId",
+    "experimentName",
+    "experimentDatasetId",
+    "isExperimentItemRootSpan",
+  ])("identifies the %s experiment filter", (column) => {
+    const filters = [
+      {
+        column,
+        type: "string",
+        operator: "=",
+        value: "value",
+      },
+    ] satisfies FilterState;
+
+    expect(getFilterAnalyticsProperties(filters)).toEqual({
+      filterCount: 1,
+      filterColumns: [column],
+      usesExperimentFilter: true,
+    });
+  });
+});

--- a/web/src/features/evals/v2/fns/getFilterAnalyticsProperties.ts
+++ b/web/src/features/evals/v2/fns/getFilterAnalyticsProperties.ts
@@ -1,0 +1,20 @@
+import type { FilterState } from "@langfuse/shared";
+
+const EXPERIMENT_FILTER_COLUMNS = new Set([
+  "experimentId",
+  "experimentName",
+  "experimentDatasetId",
+  "isExperimentItemRootSpan",
+]);
+
+export function getFilterAnalyticsProperties(filters: FilterState) {
+  const filterColumns = [...new Set(filters.map(({ column }) => column))];
+
+  return {
+    filterCount: filters.length,
+    filterColumns,
+    usesExperimentFilter: filterColumns.some((column) =>
+      EXPERIMENT_FILTER_COLUMNS.has(column),
+    ),
+  };
+}

--- a/web/src/features/evals/v2/pages/EvaluatorSetupPage.tsx
+++ b/web/src/features/evals/v2/pages/EvaluatorSetupPage.tsx
@@ -63,6 +63,7 @@ import {
   getJudgePromptAnalyticsProperties,
   type EvaluatorCreationSource,
 } from "@/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties";
+import { getFilterAnalyticsProperties } from "@/src/features/evals/v2/fns/getFilterAnalyticsProperties";
 
 type InitialEvaluator = {
   id: string;
@@ -503,6 +504,7 @@ export function EvaluatorSetupPage(
         capture("evaluators:update", {
           evaluatorType: state.type,
           filterExperience,
+          ...getFilterAnalyticsProperties(state.sampleFilter),
           ...(definition.type === "LLM_AS_JUDGE"
             ? getJudgePromptAnalyticsProperties(definition.promptMessages)
             : {}),
@@ -550,6 +552,7 @@ export function EvaluatorSetupPage(
               : undefined,
         }),
         filterExperience,
+        ...getFilterAnalyticsProperties(state.sampleFilter),
       });
       initialSnapshot.current = getCurrentSnapshot(state);
       await utils.evalsV2.filterOptions.invalidate({ projectId });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17066 app preview](https://pr-17066.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What this does

Tracks the filters people use when creating or updating evaluators and evaluation rules.

The events now include:
- `filterCount`
- `filterColumns`
- `usesExperimentFilter`

This also covers rules created from evaluator test filters.

## Privacy

Only filter column names are captured. Filter values and metadata keys are not sent to PostHog.

## Verification

- `pnpm --filter web run test-client getFilterAnalyticsProperties.clienttest.ts`
- `pnpm --filter web run typecheck`
- `pnpm exec turbo run lint --force`
- `pnpm exec knip`


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds reusable filter analytics properties to evaluator and evaluation-rule create/update events without transmitting filter values or metadata keys.
- Reports the total filter count and unique filter columns.
- Identifies whether experiment-specific filters are used.
- Covers evaluator test filters that are subsequently converted into rules.
- Adds tests for deduplication, privacy-sensitive metadata handling, and experiment-filter classification.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, privacy, or repository-rule issues identified.

The helper reports only counts, known filter-column identifiers, and an experiment-filter boolean; all changed capture paths accept these property types and preserve existing event behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evals): track filter analytics"](https://github.com/langfuse/langfuse/commit/19eada17c0a055e425e12468935fe06da87282e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60412561)</sub>

<!-- /greptile_comment -->