### PR TITLE
ci(assistant): Automate Langfuse skill sync

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 /web/src/components/design-system/ @bezbac
 /web/.storybook/ @bezbac
 
-# Langfuse skills
+# Skills for langfuse assistant
 /packages/langfuse-skills/ @LysanderKie @bezbac

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,6 @@
 # Design system
 /web/src/components/design-system/ @bezbac
 /web/.storybook/ @bezbac
+
+# Langfuse skills
+/packages/langfuse-skills/ @LysanderKie @bezbac

--- a/.github/workflows/langfuse-skills-sync.yml
+++ b/.github/workflows/langfuse-skills-sync.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "23 3 * * *"
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/langfuse-skills-sync.yml
 
 permissions:
   contents: read

--- a/.github/workflows/langfuse-skills-sync.yml
+++ b/.github/workflows/langfuse-skills-sync.yml
@@ -1,0 +1,251 @@
+name: Langfuse Skills Sync
+
+on:
+  schedule:
+    - cron: "23 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: langfuse-skills-sync
+  cancel-in-progress: true
+
+env:
+  BOT_BRANCH: langfuse-skills-sync-bot
+
+jobs:
+  sync:
+    if: github.repository == 'langfuse/langfuse'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+    outputs:
+      has_changes: ${{ steps.prepare.outputs.has_changes }}
+      branch_name: ${{ steps.prepare.outputs.branch_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Install skill sync dependencies
+        run: |
+          set -euo pipefail
+          corepack enable
+          pnpm --filter @repo/langfuse-skills install --frozen-lockfile
+
+      - name: Refresh embedded skills
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pnpm --filter @repo/langfuse-skills run sync
+
+      - name: Validate and prepare pull request artifact
+        id: prepare
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t changed_files < <(
+            {
+              git diff --name-only
+              git ls-files --others --exclude-standard
+            } | sort -u
+          )
+
+          if [ "${#changed_files[@]}" -eq 0 ]; then
+            echo "No skill changes detected."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "branch_name=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          allowed_file='packages/langfuse-skills/src/generated/skills.js'
+          for changed_file in "${changed_files[@]}"; do
+            if [ "$changed_file" != "$allowed_file" ]; then
+              echo "::error::Skill sync changed a file outside the generated catalog: $changed_file"
+              exit 1
+            fi
+          done
+
+          mapfile -t untracked_files < <(git ls-files --others --exclude-standard)
+          if [ "${#untracked_files[@]}" -gt 0 ]; then
+            git add -N -- "${untracked_files[@]}"
+          fi
+
+          pnpm --filter @repo/langfuse-skills run sync:check
+          git diff --check -- "${changed_files[@]}"
+
+          changed_line_count="$(
+            git diff --numstat -- "${changed_files[@]}" \
+              | awk '{ added += $1; deleted += $2 } END { print added + deleted + 0 }'
+          )"
+          if [ "$changed_line_count" -gt 10000 ]; then
+            echo "::error::Skill sync diff is unexpectedly large: ${changed_line_count} changed lines"
+            exit 1
+          fi
+
+          GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git \
+            -c core.hooksPath=/dev/null add -- "${changed_files[@]}"
+          mapfile -t staged_files < <(git diff --cached --name-only)
+          if [ "${#staged_files[@]}" -ne 1 ] || [ "${staged_files[0]}" != "$allowed_file" ]; then
+            echo "::error::Refusing to commit unexpected staged files"
+            exit 1
+          fi
+
+          staged_blob="$RUNNER_TEMP/langfuse-skills.js"
+          git show ":$allowed_file" > "$staged_blob"
+          if ! cmp -s "$allowed_file" "$staged_blob"; then
+            echo "::error::Staged skill catalog differs from the worktree"
+            exit 1
+          fi
+          node --check "$staged_blob"
+          git diff --cached --check -- "${staged_files[@]}"
+
+          git config user.name "langfuse-bot"
+          git config user.email "langfuse-bot@langfuse.com"
+          git -c core.hooksPath=/dev/null commit --no-verify \
+            -m "chore(skills): refresh embedded Langfuse skills"
+
+          pnpm --filter @repo/langfuse-skills run sync:check
+          git format-patch -1 --stdout HEAD > "$RUNNER_TEMP/langfuse-skills-sync.patch"
+          test -s "$RUNNER_TEMP/langfuse-skills-sync.patch"
+
+          {
+            echo "Automated refresh of the embedded Langfuse skill catalog."
+            echo
+            echo "## Scope"
+            echo
+            echo "- Refreshes \`packages/langfuse-skills/src/generated/skills.js\` from the upstream Langfuse skills repository."
+            echo
+            echo "## Validation"
+            echo
+            echo "- \`pnpm --filter @repo/langfuse-skills run sync:check\`"
+            echo "- \`node --check\` on the staged generated module"
+            echo "- \`git diff --check\`"
+            echo
+            echo "## Diff Stat"
+            echo
+            echo '```text'
+            git show --stat --oneline HEAD
+            echo '```'
+          } > "$RUNNER_TEMP/langfuse-skills-sync-pr-body.md"
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          echo "branch_name=$BOT_BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Upload pull request artifact
+        if: steps.prepare.outputs.has_changes == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: langfuse-skills-sync-pr
+          path: |
+            ${{ runner.temp }}/langfuse-skills-sync.patch
+            ${{ runner.temp }}/langfuse-skills-sync-pr-body.md
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs: sync
+    if: needs.sync.outputs.has_changes == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - name: Download pull request artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: langfuse-skills-sync-pr
+          path: ${{ runner.temp }}/langfuse-skills-sync-pr
+
+      - name: Push branch and create or update pull request
+        env:
+          BRANCH_NAME: ${{ needs.sync.outputs.branch_name }}
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          GIT_BIN="$(command -v git)"
+          GH_BIN="$(command -v gh)"
+          PATCH_PATH="$RUNNER_TEMP/langfuse-skills-sync-pr/langfuse-skills-sync.patch"
+          BODY_PATH="$RUNNER_TEMP/langfuse-skills-sync-pr/langfuse-skills-sync-pr-body.md"
+          PUSH_REPO="$RUNNER_TEMP/push-langfuse-skills-sync"
+          SOURCE_REPO_URL="https://github.com/${GITHUB_REPOSITORY}.git"
+
+          mkdir -p "$PUSH_REPO"
+          "$GIT_BIN" -C "$PUSH_REPO" init -q
+          "$GIT_BIN" -C "$PUSH_REPO" fetch --no-tags --depth=100 \
+            "$SOURCE_REPO_URL" "$GITHUB_REF"
+          if ! "$GIT_BIN" -C "$PUSH_REPO" cat-file -e "$GITHUB_SHA^{commit}"; then
+            echo "::error::Triggering commit $GITHUB_SHA was not found in $GITHUB_REF history"
+            exit 1
+          fi
+
+          "$GIT_BIN" -C "$PUSH_REPO" checkout -q -b "$BRANCH_NAME" "$GITHUB_SHA"
+          "$GIT_BIN" -C "$PUSH_REPO" config user.name "langfuse-bot"
+          "$GIT_BIN" -C "$PUSH_REPO" config user.email "langfuse-bot@langfuse.com"
+          GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null "$GIT_BIN" \
+            -C "$PUSH_REPO" -c core.hooksPath=/dev/null am --3way "$PATCH_PATH"
+
+          mapfile -t applied_files < <(
+            "$GIT_BIN" -C "$PUSH_REPO" diff-tree --no-commit-id --name-only -r HEAD
+          )
+          if [ "${#applied_files[@]}" -ne 1 ] || \
+            [ "${applied_files[0]}" != "packages/langfuse-skills/src/generated/skills.js" ]; then
+            echo "::error::Refusing to push a patch with unexpected files"
+            exit 1
+          fi
+          "$GIT_BIN" -C "$PUSH_REPO" diff --check HEAD^ HEAD
+
+          GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null "$GIT_BIN" \
+            -C "$PUSH_REPO" \
+            -c credential.helper= \
+            -c credential.https://github.com.helper= \
+            -c core.hooksPath=/dev/null \
+            push --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "$BRANCH_NAME"
+
+          pr_number="$(
+            "$GH_BIN" pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --head "$BRANCH_NAME" \
+              --state open \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+
+          if [ -n "$pr_number" ]; then
+            "$GH_BIN" pr edit \
+              --repo "$GITHUB_REPOSITORY" \
+              "$pr_number" \
+              --title "chore(skills): refresh embedded Langfuse skills" \
+              --body-file "$BODY_PATH"
+            pr_url="$(
+              "$GH_BIN" pr view \
+                --repo "$GITHUB_REPOSITORY" \
+                "$pr_number" \
+                --json url \
+                --jq '.url'
+            )"
+          else
+            pr_url="$(
+              "$GH_BIN" pr create \
+                --repo "$GITHUB_REPOSITORY" \
+                --head "$BRANCH_NAME" \
+                --base main \
+                --title "chore(skills): refresh embedded Langfuse skills" \
+                --body-file "$BODY_PATH"
+            )"
+          fi
+
+          echo "Created or updated Langfuse skill sync PR: $pr_url"
+          echo "## Pull request" >> "$GITHUB_STEP_SUMMARY"
+          echo "$pr_url" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/langfuse-skills-sync.yml
+++ b/.github/workflows/langfuse-skills-sync.yml
@@ -38,15 +38,26 @@ jobs:
           corepack enable
           pnpm --filter @repo/langfuse-skills install --frozen-lockfile
 
+      - name: Resolve upstream commit
+        id: upstream
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          commit="$(gh api repos/langfuse/skills/commits/main --jq .sha)"
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+          echo "short_commit=${commit:0:7}" >> "$GITHUB_OUTPUT"
+
       - name: Refresh embedded skills
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          LANGFUSE_SKILLS_REF: ${{ steps.upstream.outputs.commit }}
         run: pnpm --filter @repo/langfuse-skills run sync
 
       - name: Validate changes
         id: changes
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          LANGFUSE_SKILLS_REF: ${{ steps.upstream.outputs.commit }}
         run: |
           set -euo pipefail
 
@@ -87,6 +98,8 @@ jobs:
           title: "chore(skills): refresh embedded Langfuse skills"
           body: |
             Automated refresh of the embedded Langfuse skill catalog.
+
+            **Upstream commit:** [${{ steps.upstream.outputs.short_commit }}](https://github.com/langfuse/skills/commit/${{ steps.upstream.outputs.commit }})
 
             ## Validation
 

--- a/.github/workflows/langfuse-skills-sync.yml
+++ b/.github/workflows/langfuse-skills-sync.yml
@@ -14,20 +14,17 @@ concurrency:
 
 env:
   BOT_BRANCH: langfuse-skills-sync-bot
+  GENERATED_FILE: packages/langfuse-skills/src/generated/skills.js
 
 jobs:
   sync:
-    if: github.repository == 'langfuse/langfuse'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
-    outputs:
-      has_changes: ${{ steps.prepare.outputs.has_changes }}
-      branch_name: ${{ steps.prepare.outputs.branch_name }}
     steps:
-      - name: Checkout repository
+      - name: Checkout main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          ref: main
           persist-credentials: false
 
       - name: Setup Node.js
@@ -36,9 +33,8 @@ jobs:
           node-version: "24"
           package-manager-cache: false
 
-      - name: Install skill sync dependencies
+      - name: Install dependencies
         run: |
-          set -euo pipefail
           corepack enable
           pnpm --filter @repo/langfuse-skills install --frozen-lockfile
 
@@ -47,8 +43,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: pnpm --filter @repo/langfuse-skills run sync
 
-      - name: Validate and prepare pull request artifact
-        id: prepare
+      - name: Validate changes
+        id: changes
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -64,185 +60,77 @@ jobs:
           if [ "${#changed_files[@]}" -eq 0 ]; then
             echo "No skill changes detected."
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            echo "branch_name=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          allowed_file='packages/langfuse-skills/src/generated/skills.js'
-          for changed_file in "${changed_files[@]}"; do
-            if [ "$changed_file" != "$allowed_file" ]; then
-              echo "::error::Skill sync changed a file outside the generated catalog: $changed_file"
-              exit 1
-            fi
-          done
-
-          mapfile -t untracked_files < <(git ls-files --others --exclude-standard)
-          if [ "${#untracked_files[@]}" -gt 0 ]; then
-            git add -N -- "${untracked_files[@]}"
+          if [ "${#changed_files[@]}" -ne 1 ] || [ "${changed_files[0]}" != "$GENERATED_FILE" ]; then
+            printf "::error::Skill sync changed unexpected files: %s\n" "${changed_files[*]}"
+            exit 1
           fi
 
           pnpm --filter @repo/langfuse-skills run sync:check
-          git diff --check -- "${changed_files[@]}"
-
-          changed_line_count="$(
-            git diff --numstat -- "${changed_files[@]}" \
-              | awk '{ added += $1; deleted += $2 } END { print added + deleted + 0 }'
-          )"
-          if [ "$changed_line_count" -gt 10000 ]; then
-            echo "::error::Skill sync diff is unexpectedly large: ${changed_line_count} changed lines"
-            exit 1
-          fi
-
-          GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git \
-            -c core.hooksPath=/dev/null add -- "${changed_files[@]}"
-          mapfile -t staged_files < <(git diff --cached --name-only)
-          if [ "${#staged_files[@]}" -ne 1 ] || [ "${staged_files[0]}" != "$allowed_file" ]; then
-            echo "::error::Refusing to commit unexpected staged files"
-            exit 1
-          fi
-
-          staged_blob="$RUNNER_TEMP/langfuse-skills.js"
-          git show ":$allowed_file" > "$staged_blob"
-          if ! cmp -s "$allowed_file" "$staged_blob"; then
-            echo "::error::Staged skill catalog differs from the worktree"
-            exit 1
-          fi
-          node --check "$staged_blob"
-          git diff --cached --check -- "${staged_files[@]}"
-
-          git config user.name "langfuse-bot"
-          git config user.email "langfuse-bot@langfuse.com"
-          git -c core.hooksPath=/dev/null commit --no-verify \
-            -m "chore(skills): refresh embedded Langfuse skills"
-
-          pnpm --filter @repo/langfuse-skills run sync:check
-          git format-patch -1 --stdout HEAD > "$RUNNER_TEMP/langfuse-skills-sync.patch"
-          test -s "$RUNNER_TEMP/langfuse-skills-sync.patch"
-
-          {
-            echo "Automated refresh of the embedded Langfuse skill catalog."
-            echo
-            echo "## Scope"
-            echo
-            echo "- Refreshes \`packages/langfuse-skills/src/generated/skills.js\` from the upstream Langfuse skills repository."
-            echo
-            echo "## Validation"
-            echo
-            echo "- \`pnpm --filter @repo/langfuse-skills run sync:check\`"
-            echo "- \`node --check\` on the staged generated module"
-            echo "- \`git diff --check\`"
-            echo
-            echo "## Diff Stat"
-            echo
-            echo '```text'
-            git show --stat --oneline HEAD
-            echo '```'
-          } > "$RUNNER_TEMP/langfuse-skills-sync-pr-body.md"
-
+          node --check "$GENERATED_FILE"
+          git diff --check -- "$GENERATED_FILE"
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
-          echo "branch_name=$BOT_BRANCH" >> "$GITHUB_OUTPUT"
 
-      - name: Upload pull request artifact
-        if: steps.prepare.outputs.has_changes == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: langfuse-skills-sync-pr
-          path: |
-            ${{ runner.temp }}/langfuse-skills-sync.patch
-            ${{ runner.temp }}/langfuse-skills-sync-pr-body.md
-          if-no-files-found: error
-          retention-days: 1
-
-  publish:
-    needs: sync
-    if: needs.sync.outputs.has_changes == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 10
-    steps:
-      - name: Download pull request artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: langfuse-skills-sync-pr
-          path: ${{ runner.temp }}/langfuse-skills-sync-pr
-
-      - name: Push branch and create or update pull request
+      - name: Create or update pull request
+        if: steps.changes.outputs.has_changes == 'true'
         env:
-          BRANCH_NAME: ${{ needs.sync.outputs.branch_name }}
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: |
           set -euo pipefail
 
-          GIT_BIN="$(command -v git)"
-          GH_BIN="$(command -v gh)"
-          PATCH_PATH="$RUNNER_TEMP/langfuse-skills-sync-pr/langfuse-skills-sync.patch"
-          BODY_PATH="$RUNNER_TEMP/langfuse-skills-sync-pr/langfuse-skills-sync-pr-body.md"
-          PUSH_REPO="$RUNNER_TEMP/push-langfuse-skills-sync"
-          SOURCE_REPO_URL="https://github.com/${GITHUB_REPOSITORY}.git"
+          git config user.name "langfuse-bot"
+          git config user.email "langfuse-bot@langfuse.com"
+          git switch -c "$BOT_BRANCH"
+          git -c core.hooksPath=/dev/null add -- "$GENERATED_FILE"
 
-          mkdir -p "$PUSH_REPO"
-          "$GIT_BIN" -C "$PUSH_REPO" init -q
-          "$GIT_BIN" -C "$PUSH_REPO" fetch --no-tags --depth=100 \
-            "$SOURCE_REPO_URL" "$GITHUB_REF"
-          if ! "$GIT_BIN" -C "$PUSH_REPO" cat-file -e "$GITHUB_SHA^{commit}"; then
-            echo "::error::Triggering commit $GITHUB_SHA was not found in $GITHUB_REF history"
+          mapfile -t staged_files < <(git diff --cached --name-only)
+          if [ "${#staged_files[@]}" -ne 1 ] || [ "${staged_files[0]}" != "$GENERATED_FILE" ]; then
+            echo "::error::Refusing to publish unexpected staged files"
             exit 1
           fi
 
-          "$GIT_BIN" -C "$PUSH_REPO" checkout -q -b "$BRANCH_NAME" "$GITHUB_SHA"
-          "$GIT_BIN" -C "$PUSH_REPO" config user.name "langfuse-bot"
-          "$GIT_BIN" -C "$PUSH_REPO" config user.email "langfuse-bot@langfuse.com"
-          GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null "$GIT_BIN" \
-            -C "$PUSH_REPO" -c core.hooksPath=/dev/null am --3way "$PATCH_PATH"
-
-          mapfile -t applied_files < <(
-            "$GIT_BIN" -C "$PUSH_REPO" diff-tree --no-commit-id --name-only -r HEAD
-          )
-          if [ "${#applied_files[@]}" -ne 1 ] || \
-            [ "${applied_files[0]}" != "packages/langfuse-skills/src/generated/skills.js" ]; then
-            echo "::error::Refusing to push a patch with unexpected files"
-            exit 1
-          fi
-          "$GIT_BIN" -C "$PUSH_REPO" diff --check HEAD^ HEAD
-
-          GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null "$GIT_BIN" \
-            -C "$PUSH_REPO" \
-            -c credential.helper= \
-            -c credential.https://github.com.helper= \
-            -c core.hooksPath=/dev/null \
+          git diff --cached --check -- "$GENERATED_FILE"
+          git -c core.hooksPath=/dev/null commit --no-verify \
+            -m "chore(skills): refresh embedded Langfuse skills"
+          git -c credential.helper= \
             push --force \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-            "$BRANCH_NAME"
+            "$BOT_BRANCH"
+
+          body_file="$RUNNER_TEMP/langfuse-skills-sync-pr-body.md"
+          cat > "$body_file" <<'EOF'
+          Automated refresh of the embedded Langfuse skill catalog.
+
+          ## Validation
+
+          - `pnpm --filter @repo/langfuse-skills run sync:check`
+          - `node --check packages/langfuse-skills/src/generated/skills.js`
+          - `git diff --check`
+          EOF
 
           pr_number="$(
-            "$GH_BIN" pr list \
-              --repo "$GITHUB_REPOSITORY" \
-              --head "$BRANCH_NAME" \
+            gh pr list \
+              --head "$BOT_BRANCH" \
+              --base main \
               --state open \
               --json number \
               --jq '.[0].number // empty'
           )"
 
           if [ -n "$pr_number" ]; then
-            "$GH_BIN" pr edit \
-              --repo "$GITHUB_REPOSITORY" \
-              "$pr_number" \
+            gh pr edit "$pr_number" \
               --title "chore(skills): refresh embedded Langfuse skills" \
-              --body-file "$BODY_PATH"
-            pr_url="$(
-              "$GH_BIN" pr view \
-                --repo "$GITHUB_REPOSITORY" \
-                "$pr_number" \
-                --json url \
-                --jq '.url'
-            )"
+              --body-file "$body_file"
+            pr_url="$(gh pr view "$pr_number" --json url --jq '.url')"
           else
             pr_url="$(
-              "$GH_BIN" pr create \
-                --repo "$GITHUB_REPOSITORY" \
-                --head "$BRANCH_NAME" \
+              gh pr create \
+                --head "$BOT_BRANCH" \
                 --base main \
                 --title "chore(skills): refresh embedded Langfuse skills" \
-                --body-file "$BODY_PATH"
+                --body-file "$body_file"
             )"
           fi
 

--- a/.github/workflows/langfuse-skills-sync.yml
+++ b/.github/workflows/langfuse-skills-sync.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: "23 3 * * *"
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - .github/workflows/langfuse-skills-sync.yml
 
 permissions:
   contents: read

--- a/.github/workflows/langfuse-skills-sync.yml
+++ b/.github/workflows/langfuse-skills-sync.yml
@@ -83,8 +83,8 @@ jobs:
           branch: ${{ env.BOT_BRANCH }}
           base: main
           add-paths: ${{ env.GENERATED_FILE }}
-          commit-message: "chore(skills): refresh embedded Langfuse skills"
-          title: "chore(skills): refresh embedded Langfuse skills"
+          commit-message: "chore(assistant): refresh embedded Langfuse skills"
+          title: "chore(assistant): refresh embedded Langfuse skills"
           body: |
             Automated refresh of the embedded Langfuse skill catalog.
 

--- a/.github/workflows/langfuse-skills-sync.yml
+++ b/.github/workflows/langfuse-skills-sync.yml
@@ -81,6 +81,8 @@ jobs:
       - name: Create or update pull request
         if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        env:
+          HUSKY: "0"
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           branch: ${{ env.BOT_BRANCH }}

--- a/.github/workflows/langfuse-skills-sync.yml
+++ b/.github/workflows/langfuse-skills-sync.yml
@@ -75,65 +75,19 @@ jobs:
 
       - name: Create or update pull request
         if: steps.changes.outputs.has_changes == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: |
-          set -euo pipefail
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          branch: ${{ env.BOT_BRANCH }}
+          base: main
+          add-paths: ${{ env.GENERATED_FILE }}
+          commit-message: "chore(skills): refresh embedded Langfuse skills"
+          title: "chore(skills): refresh embedded Langfuse skills"
+          body: |
+            Automated refresh of the embedded Langfuse skill catalog.
 
-          git config user.name "langfuse-bot"
-          git config user.email "langfuse-bot@langfuse.com"
-          git switch -c "$BOT_BRANCH"
-          git -c core.hooksPath=/dev/null add -- "$GENERATED_FILE"
+            ## Validation
 
-          mapfile -t staged_files < <(git diff --cached --name-only)
-          if [ "${#staged_files[@]}" -ne 1 ] || [ "${staged_files[0]}" != "$GENERATED_FILE" ]; then
-            echo "::error::Refusing to publish unexpected staged files"
-            exit 1
-          fi
-
-          git diff --cached --check -- "$GENERATED_FILE"
-          git -c core.hooksPath=/dev/null commit --no-verify \
-            -m "chore(skills): refresh embedded Langfuse skills"
-          git -c credential.helper= \
-            push --force \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-            "$BOT_BRANCH"
-
-          body_file="$RUNNER_TEMP/langfuse-skills-sync-pr-body.md"
-          cat > "$body_file" <<'EOF'
-          Automated refresh of the embedded Langfuse skill catalog.
-
-          ## Validation
-
-          - `pnpm --filter @repo/langfuse-skills run sync:check`
-          - `node --check packages/langfuse-skills/src/generated/skills.js`
-          - `git diff --check`
-          EOF
-
-          pr_number="$(
-            gh pr list \
-              --head "$BOT_BRANCH" \
-              --base main \
-              --state open \
-              --json number \
-              --jq '.[0].number // empty'
-          )"
-
-          if [ -n "$pr_number" ]; then
-            gh pr edit "$pr_number" \
-              --title "chore(skills): refresh embedded Langfuse skills" \
-              --body-file "$body_file"
-            pr_url="$(gh pr view "$pr_number" --json url --jq '.url')"
-          else
-            pr_url="$(
-              gh pr create \
-                --head "$BOT_BRANCH" \
-                --base main \
-                --title "chore(skills): refresh embedded Langfuse skills" \
-                --body-file "$body_file"
-            )"
-          fi
-
-          echo "Created or updated Langfuse skill sync PR: $pr_url"
-          echo "## Pull request" >> "$GITHUB_STEP_SUMMARY"
-          echo "$pr_url" >> "$GITHUB_STEP_SUMMARY"
+            - `pnpm --filter @repo/langfuse-skills run sync:check`
+            - `node --check packages/langfuse-skills/src/generated/skills.js`
+            - `git diff --check`

--- a/packages/langfuse-skills/scripts/sync-skills.mjs
+++ b/packages/langfuse-skills/scripts/sync-skills.mjs
@@ -7,8 +7,9 @@ import { format as formatWithPrettier } from "prettier";
 
 const packageRoot = resolve(new URL("..", import.meta.url).pathname);
 const generatedPath = resolve(packageRoot, "src/generated/skills.js");
+const sourceRef = process.env.LANGFUSE_SKILLS_REF ?? "main";
 const sourceApiUrl =
-  "https://api.github.com/repos/langfuse/skills/contents/skills/langfuse/references?ref=main";
+  `https://api.github.com/repos/langfuse/skills/contents/skills/langfuse/references?ref=${encodeURIComponent(sourceRef)}`;
 const isCheckMode = process.argv.includes("--check");
 
 const getGitHubHeaders = () => ({


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17069 app preview](https://pr-17069.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds a daily and manually dispatchable workflow that refreshes the embedded Langfuse skill catalog and opens or updates a pull request when the generated catalog changes. Generated refresh PRs link the exact upstream `langfuse/skills` commit used for synchronization. Changes under `packages/langfuse-skills/` request review from `@LysanderKie` and `@bezbac` via CODEOWNERS.

The workflow always checks out `main`, including for manual dispatches. It resolves the upstream commit before synchronization and pins all content fetches to that SHA. Synchronization uses the read-only GitHub token; the pinned pull-request action receives the write-scoped bot credential only after validation and is restricted to staging the generated catalog.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Self-reviewed the workflow and its credential, diff-validation, and publishing boundaries.

## Verification

- End-to-end GitHub Actions test passed: [Langfuse Skills Sync run 33882594036](https://github.com/langfuse/langfuse/actions/runs/33882594036)
- The workflow created [skill refresh PR #17072](https://github.com/langfuse/langfuse/pull/17072), based on `main` and changing only `packages/langfuse-skills/src/generated/skills.js`
- Pinned sync test passed against upstream commit `fc574260e5530b217d94e06465a4da0c7d846888`: `sync`, `sync:check`, and `node --check`
- Commit hooks: Prettier and repository lint (`Tasks: 7 successful, 7 total`; `Cached: 5 cached, 7 total`)
- actionlint v1.7.12 passed (excluding the expected unknown-label warning for the repository's Blacksmith runner)

The temporary pull-request test trigger was removed after the successful run; the final workflow retains only the daily schedule and manual dispatch.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15996](https://linear.app/clickhouse/issue/LFE-15996/setup-ci-for-skill-sync)

<div><a href="https://cursor.com/agents/bc-6d546e65-d5bb-4570-82ed-0c7ab58d204f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d546e65-d5bb-4570-82ed-0c7ab58d204f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds scheduled and manually dispatchable automation for refreshing the embedded Langfuse skill catalog.

- Generates and validates the catalog under read-only repository permissions.
- Transfers a constrained patch artifact to a separate publishing job.
- Force-updates a dedicated bot branch and creates or updates its pull request.
- Manual dispatches currently allow the generated PR to inherit unrelated commits from a non-main branch.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until manual dispatches are prevented from basing the bot pull request on a non-main branch.

The generated patch itself is tightly constrained, but selecting a feature branch for manual dispatch makes the fixed bot branch inherit that branch's commits before it is opened against main.

**Files Needing Attention:** .github/workflows/langfuse-skills-sync.yml
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Trigger as Schedule / Manual Dispatch
  participant Sync as Read-only Sync Job
  participant Artifact as Patch Artifact
  participant Publish as Credentialed Publish Job
  participant GitHub as Bot Branch / Pull Request

  Trigger->>Sync: Run at selected GITHUB_REF and GITHUB_SHA
  Sync->>Sync: Install dependencies and regenerate skills.js
  Sync->>Sync: Validate path, size, syntax, and generated state
  Sync->>Artifact: Upload patch and PR body
  Artifact->>Publish: Download validated artifact
  Publish->>Publish: Check out triggering SHA and apply patch
  Publish->>GitHub: Force-update fixed bot branch
  Publish->>GitHub: Create or update PR against main
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/langfuse-skills-sync.yml:191
**Manual Runs Use Wrong Base**

A manual dispatch can target any branch, but this step bases the bot branch on that dispatch's `GITHUB_SHA` while the resulting pull request always targets `main`. If someone dispatches the workflow from a feature branch, the generated-catalog pull request will also contain that branch's unrelated commits. Restrict manual runs to `main` or explicitly build the publishing branch from `main`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ci): automate Langfuse skill sync"](https://github.com/langfuse/langfuse/commit/8cb37a00eb64830edf2b376fd790253e05a0014f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60414172)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->