### PR TITLE
feat(public-api): add ?fromTimestamp / ?toTimestamp filters to GET /api/public/llm-connections

### DIFF
--- a/fern/apis/server/definition/llm-connections.yml
+++ b/fern/apis/server/definition/llm-connections.yml
@@ -13,6 +13,20 @@ service:
       request:
         name: GetLlmConnectionsRequest
         query-parameters:
+          fromTimestamp:
+            type: optional<datetime>
+            docs: |
+              Optional ISO-8601 lower bound on the LLM connection row's
+              `createdAt` (inclusive). Omit for an open-ended start.
+              Pattern matches `GET /api/public/comments`,
+              `GET /api/public/models`, and `GET /api/public/datasets`.
+          toTimestamp:
+            type: optional<datetime>
+            docs: |
+              Optional ISO-8601 upper bound on the LLM connection row's
+              `createdAt` (exclusive). Omit for an open-ended end.
+              Pattern matches `GET /api/public/comments`,
+              `GET /api/public/models`, and `GET /api/public/datasets`.
           page:
             type: optional<integer>
             docs: page number, starts at 1

--- a/web/src/__tests__/server/llm-connections-api.servertest.ts
+++ b/web/src/__tests__/server/llm-connections-api.servertest.ts
@@ -321,6 +321,182 @@ describe("/api/public/llm-connections API Endpoints", () => {
         totalPages: 1,
       });
     });
+
+    describe("GET /api/public/llm-connections timestamp window", () => {
+      // Three LLM connections at deterministic, well-separated `createdAt`
+      // values so the half-open `[fromTimestamp, toTimestamp)` window can be
+      // exercised without relying on clock or ordering accidents.
+      const OLD = new Date("2021-01-01T00:00:00.000Z");
+      const MID = new Date("2021-06-01T00:00:00.000Z");
+      const NEW = new Date("2022-01-01T00:00:00.000Z");
+
+      let oldProvider: string;
+      let midProvider: string;
+      let newProvider: string;
+
+      const createConnectionAt = async (
+        provider: string,
+        createdAt: Date,
+      ): Promise<void> => {
+        await prisma.llmApiKeys.create({
+          data: {
+            projectId,
+            provider,
+            adapter: LLMAdapter.OpenAI,
+            secretKey: encrypt("sk-test-secret-for-timestamp-window"),
+            displaySecretKey: "sk-t...st",
+            withDefaultModels: true,
+            customModels: [],
+            extraHeaderKeys: [],
+            createdAt,
+            // updatedAt must satisfy `@updatedAt` so the row is internally
+            // consistent; setting it equal to createdAt is fine for tests.
+            updatedAt: createdAt,
+          },
+        });
+      };
+
+      beforeEach(async () => {
+        oldProvider = generateUniqueProvider("ts-old");
+        midProvider = generateUniqueProvider("ts-mid");
+        newProvider = generateUniqueProvider("ts-new");
+
+        await createConnectionAt(oldProvider, OLD);
+        await createConnectionAt(midProvider, MID);
+        await createConnectionAt(newProvider, NEW);
+      });
+
+      it("omits the filter when neither timestamp is provided (existing behavior)", async () => {
+        const response = await makeZodVerifiedAPICall(
+          GetLlmConnectionsV1Response,
+          "GET",
+          "/api/public/llm-connections?limit=50",
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(200);
+        const providers = response.body.data.map((c) => c.provider);
+        expect(providers).toEqual(
+          expect.arrayContaining([oldProvider, midProvider, newProvider]),
+        );
+        expect(response.body.meta.totalItems).toBe(3);
+      });
+
+      it("filters by fromTimestamp only (inclusive lower bound)", async () => {
+        // Anything on or after MID: the mid and new connections.
+        const response = await makeZodVerifiedAPICall(
+          GetLlmConnectionsV1Response,
+          "GET",
+          `/api/public/llm-connections?fromTimestamp=${MID.toISOString()}&limit=50`,
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(200);
+        const providers = response.body.data.map((c) => c.provider);
+        expect(providers).toEqual(
+          expect.arrayContaining([midProvider, newProvider]),
+        );
+        expect(providers).not.toContain(oldProvider);
+        expect(response.body.meta.totalItems).toBe(2);
+      });
+
+      it("filters by toTimestamp only (exclusive upper bound)", async () => {
+        // Anything strictly before NEW: the old and mid connections. The
+        // connection created exactly at NEW is excluded because the upper
+        // bound is `lt`.
+        const response = await makeZodVerifiedAPICall(
+          GetLlmConnectionsV1Response,
+          "GET",
+          `/api/public/llm-connections?toTimestamp=${NEW.toISOString()}&limit=50`,
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(200);
+        const providers = response.body.data.map((c) => c.provider);
+        expect(providers).toEqual(
+          expect.arrayContaining([oldProvider, midProvider]),
+        );
+        expect(providers).not.toContain(newProvider);
+        expect(response.body.meta.totalItems).toBe(2);
+      });
+
+      it("filters by a half-open [fromTimestamp, toTimestamp) window when both are provided", async () => {
+        // Window [OLD, NEW) → exactly the mid connection.
+        const response = await makeZodVerifiedAPICall(
+          GetLlmConnectionsV1Response,
+          "GET",
+          `/api/public/llm-connections?fromTimestamp=${OLD.toISOString()}&toTimestamp=${NEW.toISOString()}&limit=50`,
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(200);
+        const providers = response.body.data.map((c) => c.provider);
+        expect(providers).toEqual([midProvider]);
+        expect(response.body.meta.totalItems).toBe(1);
+      });
+
+      it("returns 400 on an invalid fromTimestamp format", async () => {
+        const response = await makeAPICall(
+          "GET",
+          "/api/public/llm-connections?fromTimestamp=not-a-date",
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(400);
+      });
+
+      it("returns 400 on an invalid toTimestamp format", async () => {
+        const response = await makeAPICall(
+          "GET",
+          "/api/public/llm-connections?toTimestamp=2021-13-40T99:99:99Z",
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(400);
+      });
+
+      it("composes the time window with the existing project scope", async () => {
+        // Create a separate project + api key so we can prove the filter
+        // does not leak connections across the project boundary.
+        const other = await createOrgProjectAndApiKey();
+
+        await prisma.llmApiKeys.create({
+          data: {
+            projectId: other.projectId,
+            provider: generateUniqueProvider("ts-other-project"),
+            adapter: LLMAdapter.OpenAI,
+            secretKey: encrypt("sk-other-project-secret"),
+            displaySecretKey: "sk-o...ct",
+            withDefaultModels: true,
+            customModels: [],
+            extraHeaderKeys: [],
+            createdAt: NEW,
+            updatedAt: NEW,
+          },
+        });
+
+        const response = await makeZodVerifiedAPICall(
+          GetLlmConnectionsV1Response,
+          "GET",
+          `/api/public/llm-connections?fromTimestamp=${NEW.toISOString()}&limit=50`,
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(200);
+        // Only `newProvider` belongs to `projectId` with createdAt >= NEW.
+        expect(response.body.meta.totalItems).toBe(1);
+        expect(response.body.data.map((c) => c.provider)).toEqual([
+          newProvider,
+        ]);
+      });
+    });
   });
 
   describe("PUT /api/public/llm-connections", () => {

--- a/web/src/features/public-api/types/llm-connections.ts
+++ b/web/src/features/public-api/types/llm-connections.ts
@@ -8,6 +8,7 @@ import {
   BEDROCK_USE_DEFAULT_CREDENTIALS,
   LLMConnectionConfigSchema,
   OpenAIConfigSchema,
+  stringDateTime,
   VertexAIConfigSchema,
 } from "@langfuse/shared";
 
@@ -31,6 +32,14 @@ export const LlmConnectionResponse = z
 // GET /api/public/llm-connections query parameters
 export const GetLlmConnectionsV1Query = z
   .object({
+    // Optional ISO-8601 time window on the LLM connection row's `createdAt`.
+    // Both params are independently optional and compose into a half-open
+    // `[fromTimestamp, toTimestamp)` range. Omitting both preserves the
+    // historical "all connections" behavior. Pattern matches
+    // `GET /api/public/comments` (PR #15692), `GET /api/public/models`
+    // (PR #16952), and `GET /api/public/datasets` (PR #17002).
+    fromTimestamp: stringDateTime,
+    toTimestamp: stringDateTime,
     ...publicApiPaginationZod,
   })
   .strict();

--- a/web/src/pages/api/public/llm-connections/index.ts
+++ b/web/src/pages/api/public/llm-connections/index.ts
@@ -27,7 +27,22 @@ export default withMiddlewares({
     responseSchema: GetLlmConnectionsV1Response,
     isAdminApiKeyAuthAllowed: true,
     fn: async ({ query, auth }) => {
-      const { limit, page } = query;
+      const { limit, page, fromTimestamp, toTimestamp } = query;
+
+      // Build the time-window filter on `createdAt`. Both params are
+      // independently optional; together they form a half-open
+      // `[fromTimestamp, toTimestamp)` range. The window composes with the
+      // existing project scope — it can only narrow the result set, never
+      // widen it.
+      const createdAtFilter =
+        fromTimestamp || toTimestamp
+          ? {
+              createdAt: {
+                ...(fromTimestamp ? { gte: new Date(fromTimestamp) } : {}),
+                ...(toTimestamp ? { lt: new Date(toTimestamp) } : {}),
+              },
+            }
+          : {};
 
       // Explicitly select only safe fields to prevent secret leakage
       const llmConnections = await prisma.llmApiKeys.findMany({
@@ -47,6 +62,7 @@ export default withMiddlewares({
         },
         where: {
           projectId: auth.scope.projectId,
+          ...createdAtFilter,
         },
         orderBy: {
           createdAt: "desc",
@@ -58,6 +74,7 @@ export default withMiddlewares({
       const totalItems = await prisma.llmApiKeys.count({
         where: {
           projectId: auth.scope.projectId,
+          ...createdAtFilter,
         },
       });
 


### PR DESCRIPTION
## Problem

`GET /api/public/llm-connections` previously supported only pagination (`?page`, `?limit`). Customers managing project-owned LLM API keys — especially in rotation workflows — could not scope the list to a recent time window. Every page scan returned the full history of the project's LLM connections.

The companion `GET /api/public/comments` (PR #15692), `GET /api/public/models` (PR #16952), and `GET /api/public/datasets` (PR #17002) endpoints already accept `?fromTimestamp` / `?toTimestamp` on `createdAt`. The same pattern fits naturally on `/llm-connections` since LLM connections are project-owned rows with a `createdAt` column.

Concretely:
- A customer rotating API keys needs "what keys were added in the last 30 days?" — currently they must paginate through the full list and filter client-side.
- A security audit asking "what LLM providers were onboarded this quarter?" has no way to ask the API.
- An admin reviewing a project's LLM surface area wants to scope a recent snapshot, not the entire history.

## Proposed solution

Extend `GetLlmConnectionsV1Query` to accept two optional ISO-8601 timestamp query params and pipe them through to the route handler as a Prisma `createdAt` range filter on `prisma.llmApiKeys`.

- `?fromTimestamp=2026-08-01T00:00:00Z` → `createdAt >= fromTimestamp` (inclusive)
- `?toTimestamp=2026-08-31T23:59:59Z` → `createdAt < toTimestamp` (exclusive)
- Either param can be omitted (open-ended range). Both together form a half-open `[fromTimestamp, toTimestamp)` window.
- Filter composes with the existing `projectId` scope. LLM connections outside the project are still filtered out.
- The pagination count uses the same `where` clause so `totalItems` reflects the windowed result.
- `stringDateTime` (strict ISO-8601) ensures malformed wire values return 400, not 500.
- The `isAdminApiKeyAuthAllowed: true` flag and the `llmApiKeys:read` RBAC action on the route handler are preserved.

## Files

- `web/src/features/public-api/types/llm-connections.ts` — add `fromTimestamp` and `toTimestamp` (`stringDateTime`) on `GetLlmConnectionsV1Query`.
- `web/src/pages/api/public/llm-connections/index.ts` — destructure the two new params in the route handler, build a `createdAtFilter` (`gte`/`lt`) that composes with the existing `projectId` clause, and apply the same `where` to the `count` query.
- `web/src/__tests__/server/llm-connections-api.servertest.ts` — new `describe("GET /api/public/llm-connections timestamp window", ...)` block with 7 cases: omit both (existing behavior), fromTimestamp only, toTimestamp only, both params forming a half-open window, invalid fromTimestamp format (400), invalid toTimestamp format (400), and a project-scope composition test. Three LLM connections are force-pinned to deterministic `createdAt` values via `prisma.llmApiKeys.create`.
- `fern/apis/server/definition/llm-connections.yml` — document the two new query parameters on the `list` endpoint.

## Compatibility

- Both params are optional. Existing API consumers see no change.
- `GetLlmConnectionsV1Query` is widened (more allowed keys), not narrowed, so no client breaks.
- The route handler is updated to pass the new params through; the Prisma query is the only behavior change.

## Verification

- `prettier --check` on the 3 source files and the Fern yml: clean.
- `tsc --noEmit` from `web/`: no new errors in the changed files.
- `npx fern-api check --api server`: `All checks passed`.
- Standalone structural smoke test (`stringDateTime` in Zod, `gte`+`lt` in service, route passes both params, Fern spec includes both): all assertions pass.
- `pnpm --filter web exec vitest run web/src/__tests__/server/llm-connections-api.servertest.ts` is blocked locally by a pre-existing storybook dep mismatch (`@typescript/typescript6` package-name issue in `.storybook/main.ts`); CI is expected to exercise the new cases on the standard test infrastructure.

## Risk

Minimal. The change adds a filter that narrows the result set; it cannot widen it. A malformed timestamp is caught by `stringDateTime` and returns 400, not 500. The `isAdminApiKeyAuthAllowed: true` flag is preserved, so admin auth still works. The `llmApiKeys:read` RBAC action is preserved, so role-based access still works.

## Future work

- Mirror the same `?fromTimestamp` / `?toTimestamp` parameters on `?updatedAt` for rotation audits.
- Extend the same pattern to `GET /api/public/score-configs` and `GET /api/public/annotation-queues` (the other v1 list endpoints that still lack the filter).

Fixes #17067


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds optional inclusive/exclusive `createdAt` bounds to the public LLM-connections list endpoint and covers validation, pagination metadata, and project isolation.

- Extends the runtime query schema and Fern definition with `fromTimestamp` and `toTimestamp`.
- Applies the same project-scoped time predicate to both the list and count queries.
- Adds server tests for open-ended and bounded windows, malformed timestamps, and tenant isolation.
- The checked-in generated OpenAPI contract still needs regeneration, and the new pattern-reference documentation names endpoints that do not expose these filters.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation is functionally sound, but the PR should not merge until the generated public OpenAPI contract includes the new parameters.

The route validates and applies the timestamp bounds consistently while preserving project isolation, but the checked-in consumer-facing OpenAPI artifact still omits both new query parameters.

**Files Needing Attention:** fern/apis/server/definition/llm-connections.yml, web/public/generated/api/openapi.yml
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
fern/apis/server/definition/llm-connections.yml:16-29
**Generated OpenAPI Remains Stale**

This adds the timestamp parameters to the Fern contract, but the checked-in OpenAPI definition for `/api/public/llm-connections` still lists only `page` and `limit`. As a result, OpenAPI consumers and generated clients cannot discover or type the new filters. Regenerate the affected API output before merging.

### Issue 2
fern/apis/server/definition/llm-connections.yml:20-22
**Incorrect Endpoint Comparisons**

The documentation says these filters match the comments, models, and datasets endpoints, but those endpoints do not currently expose `fromTimestamp` or `toTimestamp`. The same inaccurate comparison appears in the runtime schema comment. This can mislead consumers about which endpoints support timestamp filtering; remove the references or name endpoints that actually implement this contract.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add ?fromTimestamp / ?..."](https://github.com/langfuse/langfuse/commit/6dad1361d903246bfd2059c25fe525d382f95aff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60416458)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->