### PR TITLE
feat(shared): tag ClickHouse query outcome metric by table and label events routes

### DIFF
--- a/packages/shared/src/server/clickhouse/queryOutcome.test.ts
+++ b/packages/shared/src/server/clickhouse/queryOutcome.test.ts
@@ -92,6 +92,22 @@ describe("ClickHouse query outcome metric", () => {
       ).toBe("events_full");
     });
 
+    // The Scores UI reads FROM scores and LEFT JOINs traces; the label must
+    // follow the table under load, not the join partner.
+    it("labels a FROM table over its join partner", () => {
+      expect(
+        clickHouseQueryTableLabel(
+          "SELECT * FROM scores s FINAL LEFT JOIN traces t ON s.trace_id = t.id",
+        ),
+      ).toBe("scores");
+    });
+
+    it("matches a schema-qualified FROM table", () => {
+      expect(
+        clickHouseQueryTableLabel("SELECT * FROM default.events_full"),
+      ).toBe("events_full");
+    });
+
     it("does not match a table name inside a longer identifier", () => {
       expect(
         clickHouseQueryTableLabel("SELECT * FROM observations_batch_staging"),

--- a/packages/shared/src/server/clickhouse/queryOutcome.test.ts
+++ b/packages/shared/src/server/clickhouse/queryOutcome.test.ts
@@ -4,6 +4,7 @@ import {
   CLICKHOUSE_QUERY_OUTCOME_METRIC,
   CLICKHOUSE_RESOURCE_ERROR_OUTCOMES,
   clickHouseQueryOutcomeRouteLabel,
+  clickHouseQueryTableLabel,
   recordClickHouseQueryOutcome,
 } from "./queryOutcome";
 
@@ -51,6 +52,58 @@ describe("ClickHouse query outcome metric", () => {
         expect(clickHouseQueryOutcomeRouteLabel(route)).toBe("other");
       },
     );
+
+    // tRPC procedure paths and MCP tool names carry no method prefix and are
+    // code-defined, so they are matched verbatim against the bare allowlist.
+    it.each([
+      ["events.all", "events.all"],
+      ["listObservations", "listObservations"],
+    ])("labels the bare route %s verbatim", (route, expected) => {
+      expect(clickHouseQueryOutcomeRouteLabel(route)).toBe(expected);
+    });
+
+    it("counts an unlisted bare route under the catch-all label", () => {
+      expect(clickHouseQueryOutcomeRouteLabel("traces.byId")).toBe("other");
+    });
+  });
+
+  describe("table labels", () => {
+    it.each([
+      [
+        "SELECT * FROM events_full WHERE project_id = {p:String}",
+        "events_full",
+      ],
+      ["SELECT count() FROM events_core FINAL", "events_core"],
+      [
+        "SELECT * FROM observations o WHERE o.project_id = {p:String}",
+        "observations",
+      ],
+      ["SELECT * FROM traces WHERE id = {id:String}", "traces"],
+      ["SELECT * FROM scores WHERE project_id = {p:String}", "scores"],
+    ])("labels %s as %s", (query, expected) => {
+      expect(clickHouseQueryTableLabel(query)).toBe(expected);
+    });
+
+    it("prefers the events tables when several tables appear", () => {
+      expect(
+        clickHouseQueryTableLabel(
+          "SELECT * FROM events_full LEFT JOIN traces USING (id)",
+        ),
+      ).toBe("events_full");
+    });
+
+    it("does not match a table name inside a longer identifier", () => {
+      expect(
+        clickHouseQueryTableLabel("SELECT * FROM observations_batch_staging"),
+      ).toBe("other");
+      expect(clickHouseQueryTableLabel("SELECT * FROM traces_null")).toBe(
+        "other",
+      );
+    });
+
+    it("falls back to other for an unrecognised table", () => {
+      expect(clickHouseQueryTableLabel("SELECT 1")).toBe("other");
+    });
   });
 
   it("maps every ClickHouse resource error type to an outcome", () => {
@@ -62,15 +115,19 @@ describe("ClickHouse query outcome metric", () => {
   });
 
   it("emits the outcome with bounded tags", () => {
-    recordClickHouseQueryOutcome("timeout", {
-      tag_schema_version: "1",
-      surface: "publicapi",
-      route: "GET /api/public/v2/observations",
-      projectId: "project-1",
-      sdkName: "python",
-      sdkVersion: "3.12.0",
-      userAgent: "python-httpx/0.28.1",
-    });
+    recordClickHouseQueryOutcome(
+      "timeout",
+      {
+        tag_schema_version: "1",
+        surface: "publicapi",
+        route: "GET /api/public/v2/observations",
+        projectId: "project-1",
+        sdkName: "python",
+        sdkVersion: "3.12.0",
+        userAgent: "python-httpx/0.28.1",
+      },
+      "events_full",
+    );
 
     expect(recordIncrement).toHaveBeenCalledTimes(1);
     expect(recordIncrement).toHaveBeenCalledWith(
@@ -80,20 +137,30 @@ describe("ClickHouse query outcome metric", () => {
         outcome: "timeout",
         surface: "publicapi",
         route: "get_/api/public/v2/observations",
+        table: "events_full",
       },
     );
   });
 
   it("keeps unknown surfaces and unlabelled routes queryable", () => {
-    recordClickHouseQueryOutcome("success", {
-      tag_schema_version: "1",
-      surface: "unknown",
-    });
+    recordClickHouseQueryOutcome(
+      "success",
+      {
+        tag_schema_version: "1",
+        surface: "unknown",
+      },
+      "other",
+    );
 
     expect(recordIncrement).toHaveBeenCalledWith(
       CLICKHOUSE_QUERY_OUTCOME_METRIC,
       1,
-      { outcome: "success", surface: "unknown", route: "other" },
+      {
+        outcome: "success",
+        surface: "unknown",
+        route: "other",
+        table: "other",
+      },
     );
   });
 });

--- a/packages/shared/src/server/clickhouse/queryOutcome.ts
+++ b/packages/shared/src/server/clickhouse/queryOutcome.ts
@@ -99,16 +99,20 @@ export type ClickHouseQueryTable =
 
 /**
  * Derived from the query text because threading a table through every call site
- * is impractical. The events tables are checked first and never co-occur with
- * the v3 tables, so `events_full`/`events_core` are exact; the v3 labels are
- * best-effort for multi-table joins (the first match in this order wins).
+ * is impractical. Anchored to the `FROM` table (with an optional `db.` prefix)
+ * so a lightweight join partner never outranks the table under load — the Scores
+ * UI reads `FROM scores ... LEFT JOIN traces`, and a bare `traces` scan would
+ * otherwise steal the label. Still best-effort: a subquery/CTE reading a
+ * different table in its own `FROM` can win by priority order (first match
+ * wins). The events read path is single-table (`FROM events_full`/`events_core`,
+ * no v3 joins), so those labels are reliable.
  */
 const TABLE_LABEL_PATTERNS: ReadonlyArray<[ClickHouseQueryTable, RegExp]> = [
-  ["events_full", /\bevents_full\b/i],
-  ["events_core", /\bevents_core\b/i],
-  ["observations", /\bobservations\b/i],
-  ["traces", /\btraces\b/i],
-  ["scores", /\bscores\b/i],
+  ["events_full", /\bfrom\s+(?:\w+\.)?events_full\b/i],
+  ["events_core", /\bfrom\s+(?:\w+\.)?events_core\b/i],
+  ["observations", /\bfrom\s+(?:\w+\.)?observations\b/i],
+  ["traces", /\bfrom\s+(?:\w+\.)?traces\b/i],
+  ["scores", /\bfrom\s+(?:\w+\.)?scores\b/i],
 ];
 
 const OTHER_TABLE_LABEL = "other" as const;

--- a/packages/shared/src/server/clickhouse/queryOutcome.ts
+++ b/packages/shared/src/server/clickhouse/queryOutcome.ts
@@ -33,8 +33,8 @@ export const CLICKHOUSE_RESOURCE_ERROR_OUTCOMES = {
 } as const satisfies Record<string, ClickHouseQueryOutcome>;
 
 /**
- * Routes whose outcomes are reported under their own `route` tag. Everything
- * else is counted under `other`.
+ * REST routes whose outcomes are reported under their own `route` tag.
+ * Everything else is counted under `other`.
  *
  * `route` on the query tags is derived from the request path, so it carries
  * caller-controlled segments (trace ids, prompt names) and is unbounded. Metric
@@ -46,6 +46,14 @@ const LABELLED_ROUTES = new Set([
   "GET /api/public/v2/metrics",
   "GET /api/public/v3/scores",
 ]);
+
+/**
+ * Non-REST routes matched verbatim: tRPC procedure paths (`events.all`) and MCP
+ * tool names (`listObservations`) are code-defined and already bounded, so they
+ * do not need the method/path parsing REST routes get. Add one when it gains an
+ * SLO or drives a meaningful share of timeouts.
+ */
+const LABELLED_BARE_ROUTES = new Set(["events.all", "listObservations"]);
 
 const OTHER_ROUTE_LABEL = "other";
 
@@ -60,7 +68,9 @@ export function clickHouseQueryOutcomeRouteLabel(route?: string): string {
 
   const collapsed = route.trim();
   const separatorIndex = collapsed.indexOf(" ");
-  if (separatorIndex === -1) return OTHER_ROUTE_LABEL;
+  if (separatorIndex === -1) {
+    return LABELLED_BARE_ROUTES.has(collapsed) ? collapsed : OTHER_ROUTE_LABEL;
+  }
 
   const method = collapsed.slice(0, separatorIndex);
   const path = collapsed.slice(separatorIndex + 1);
@@ -74,13 +84,51 @@ export function clickHouseQueryOutcomeRouteLabel(route?: string): string {
   return `${method.toLowerCase()}_${normalizedPath}`;
 }
 
+/**
+ * Bounded table label so timeouts can be isolated to the table under load — the
+ * events read path (`events_full`/`events_core`) is the current driver, and the
+ * counter is blind to it without this tag.
+ */
+export type ClickHouseQueryTable =
+  | "events_full"
+  | "events_core"
+  | "traces"
+  | "observations"
+  | "scores"
+  | "other";
+
+/**
+ * Derived from the query text because threading a table through every call site
+ * is impractical. The events tables are checked first and never co-occur with
+ * the v3 tables, so `events_full`/`events_core` are exact; the v3 labels are
+ * best-effort for multi-table joins (the first match in this order wins).
+ */
+const TABLE_LABEL_PATTERNS: ReadonlyArray<[ClickHouseQueryTable, RegExp]> = [
+  ["events_full", /\bevents_full\b/i],
+  ["events_core", /\bevents_core\b/i],
+  ["observations", /\bobservations\b/i],
+  ["traces", /\btraces\b/i],
+  ["scores", /\bscores\b/i],
+];
+
+const OTHER_TABLE_LABEL = "other" as const;
+
+export function clickHouseQueryTableLabel(query: string): ClickHouseQueryTable {
+  for (const [label, pattern] of TABLE_LABEL_PATTERNS) {
+    if (pattern.test(query)) return label;
+  }
+  return OTHER_TABLE_LABEL;
+}
+
 export function recordClickHouseQueryOutcome(
   outcome: ClickHouseQueryOutcome,
   tags: NormalizedClickHouseQueryTags,
+  table: ClickHouseQueryTable,
 ): void {
   recordIncrement(CLICKHOUSE_QUERY_OUTCOME_METRIC, 1, {
     outcome,
     surface: tags.surface,
     route: clickHouseQueryOutcomeRouteLabel(tags.route),
+    table,
   });
 }

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -33,6 +33,7 @@ import {
 } from "../clickhouse/queryTags";
 import {
   CLICKHOUSE_RESOURCE_ERROR_OUTCOMES,
+  clickHouseQueryTableLabel,
   recordClickHouseQueryOutcome,
 } from "../clickhouse/queryOutcome";
 
@@ -684,6 +685,7 @@ export async function queryClickhouse<T>(
 ): Promise<T[]> {
   if (!opts.allowLegacyEventsRead) assertNoLegacyEventsRead(opts.query);
   const normalizedTags = normalizeClickHouseQueryTags(opts.tags);
+  const table = clickHouseQueryTableLabel(opts.query);
   return await instrumentAsync(
     { name: "clickhouse-query", spanKind: SpanKind.CLIENT },
     async (span) => {
@@ -745,11 +747,12 @@ export async function queryClickhouse<T>(
             ? CLICKHOUSE_RESOURCE_ERROR_OUTCOMES[wrapped.errorType]
             : "error",
           normalizedTags,
+          table,
         );
         throw wrapped;
       });
 
-      recordClickHouseQueryOutcome("success", normalizedTags);
+      recordClickHouseQueryOutcome("success", normalizedTags, table);
       return rows;
     },
   );


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17073 app preview](https://pr-17073.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

The `langfuse.clickhouse.query.outcome` counter already records ClickHouse query
timeouts (`outcome:timeout`) once per logical query — a dogstatsd increment, so it
is unsampled and fires wherever the ClickHouse call throws, independent of the HTTP
layer swallowing a timeout as a 200/422. But it could not answer the two questions
we actually have when a table is under load:

- **Which table timed out?** Added a bounded `table` tag
  (`events_full` / `events_core` / `traces` / `observations` / `scores` / `other`),
  derived from the query text. The events tables are matched first and never co-occur
  with the v3 tables, so their labels are exact; the v3 labels are best-effort for
  multi-table joins.
- **Which surface/route?** The events read routes previously collapsed into
  `route:other` because the label parser only understood REST `METHOD /path` strings.
  Added a small verbatim allowlist for code-defined bare routes so `events.all`
  (tRPC UI list) and `listObservations` (MCP) get their own label.

With both, `query.outcome{outcome:timeout, table:events_full}` split by
`surface`/`route` is an exact, alertable signal for the events read-path timeouts —
no project id (kept out on purpose for cardinality; per-tenant stays a query_log job).

Note the counter measures the client-side ~30s request timeout, which fires just
before the server-side `max_execution_time` (~35s, exception code 159 in query_log);
the two clocks track closely.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Tests added/updated (`queryOutcome.test.ts`: table classifier, bare-route labels, tag payload)
- [x] `pnpm turbo run lint typecheck --filter=@langfuse/shared` — 4 successful, 4 total
- [x] `pnpm --filter @langfuse/shared run test queryOutcome` — 27 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds bounded ClickHouse table tags to terminal query-outcome metrics and dedicated labels for the `events.all` and `listObservations` routes.

- Computes one table label from each logical query and includes it on success and error metrics.
- Extends route labeling for bounded, code-defined tRPC and MCP route names.
- Adds tests for route labels, table classification, identifier boundaries, and emitted metric tags.
- The textual table classifier can misattribute real multi-table and CTE-based queries, reducing the reliability of table-specific alerts.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking observability accuracy issue in table attribution that should be addressed to make table-specific alerts dependable.

Route propagation and metric emission are consistent, but scanning the entire SQL for the first tracked word demonstrably labels some scores and split-event queries by a CTE or precedence choice rather than by their physical workload.

**Files Needing Attention:** packages/shared/src/server/clickhouse/queryOutcome.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[queryClickhouse SQL] --> B[Classify table from query text]
  C[Normalized query tags] --> D[Normalize route label]
  B --> E[Execute ClickHouse query with retries]
  E --> F{Terminal outcome}
  F -->|Success| G[Increment query outcome metric]
  F -->|Timeout or error| G
  D --> G
  G --> H[Bounded outcome, surface, route, and table tags]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/clickhouse/queryOutcome.ts:106-111
**Table labels can be wrong**

The classifier returns the first tracked word anywhere in the SQL instead of identifying physical table references. For example, the scores UI query defines `WITH traces AS (...)` but reads from `scores`, so it is labeled `traces`. Observation split queries contain both `events_core` and `events_full`, so they are always labeled `events_full` even when the core scan is the stage under load. This makes table-specific timeout alerts unreliable. Restrict matching to actual table references or pass the intended workload label explicitly.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(shared): tag ClickHouse query outco..."](https://github.com/langfuse/langfuse/commit/3d129d493305327e98b3d5d20bc1f126e9904784) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60426701)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Observability data platform](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/observability-data-platform.md)

<!-- /greptile_comment -->