### PR TITLE
docs(agents): rank by the handbook, and stop inventing staleness

### DIFF
--- a/.agents/skills/langfuse-onboarding/SKILL.md
+++ b/.agents/skills/langfuse-onboarding/SKILL.md
@@ -121,11 +121,11 @@ Start with:
 
 | Page | What it answers |
 | --- | --- |
-| `product-engineering/how-we-work/onboarding.mdx` | Day 1, Week 1, months 1–3, month 6 — the timeline and its outcomes |
-| `product-engineering/how-we-work/how-we-ship.mdx` | Prioritisation, specification, releases, issue states |
-| `tools-and-processes/using-linear.mdx` | How the tracker is used, and the working agreement |
-| `how-we-work/productivity-and-ai.mdx` | Agent tooling, and keeping `AGENTS.md` current |
-| `product-engineering/how-we-work/code-review.mdx` | What review is for here |
+| `content/handbook/product-engineering/how-we-work/onboarding.mdx` | Day 1, Week 1, months 1–3, month 6 — the timeline and its outcomes |
+| `content/handbook/product-engineering/how-we-work/how-we-ship.mdx` | Prioritisation, specification, releases, issue states |
+| `content/handbook/tools-and-processes/using-linear.mdx` | How the tracker is used, and the working agreement |
+| `content/handbook/how-we-work/productivity-and-ai.mdx` | Agent tooling, and keeping `AGENTS.md` current |
+| `content/handbook/product-engineering/how-we-work/code-review.mdx` | What review is for here |
 
 Then, in the repos:
 

--- a/.agents/skills/linear-work-rhythm/SKILL.md
+++ b/.agents/skills/linear-work-rhythm/SKILL.md
@@ -39,10 +39,10 @@ work on, and this file deliberately does not restate them:
 
 | Page | What you need from it |
 | --- | --- |
-| `product-engineering/how-we-work/how-we-ship.mdx` | Prioritisation, the P0–P3 levels and their timelines, daily response times, the project-update rhythm |
-| `product-engineering/principles.mdx` | What product engineers do and explicitly do not do |
-| `how-we-work/ownership.mdx` | That product areas are split between engineers by direct ownership |
-| `tools-and-processes/using-linear.mdx` | The working agreement: primitives, project lifecycle, definition of done |
+| `content/handbook/product-engineering/how-we-work/how-we-ship.mdx` | Prioritisation, the P0–P3 levels and their timelines, daily response times, the project-update rhythm |
+| `content/handbook/product-engineering/principles.mdx` | What product engineers do and explicitly do not do |
+| `content/handbook/how-we-work/ownership.mdx` | That product areas are split between engineers by direct ownership |
+| `content/handbook/tools-and-processes/using-linear.mdx` | The working agreement: primitives, project lifecycle, definition of done |
 
 If what you are about to say contradicts one of them, the handbook wins.
 

--- a/.agents/skills/linear-work-rhythm/SKILL.md
+++ b/.agents/skills/linear-work-rhythm/SKILL.md
@@ -3,8 +3,8 @@ name: linear-work-rhythm
 description: |
   Answer "what should I do today" for a Langfuse maintainer, from the tracker
   rather than from memory: which projects you lead, which owe an update before
-  Monday planning, what shipped but is not finished, what is waiting on your
-  decision, and what colleagues are working on that overlaps. Use on "what
+  the Monday engineering weekly, what shipped but is not finished, what waits
+  on your decision, and what colleagues are working on that overlaps. Use on "what
   should I do today", "what's on my plate", "what should I work on next", "prep
   my Monday update", "what did I say last week", "who else is working on this",
   "who should review this", and whenever someone hands over a bare link — a
@@ -34,6 +34,18 @@ Read it from `origin/main` — `git fetch -q origin main` then
 `git show origin/main:<path>` — because a docs checkout is usually parked on an
 old branch, and quoting a stale agreement is worse than not quoting one.
 
+**Read these before ranking anything.** They say how the team decides what to
+work on, and this file deliberately does not restate them:
+
+| Page | What you need from it |
+| --- | --- |
+| `product-engineering/how-we-work/how-we-ship.mdx` | Prioritisation, the P0–P3 levels and their timelines, daily response times, the project-update rhythm |
+| `product-engineering/principles.mdx` | What product engineers do and explicitly do not do |
+| `how-we-work/ownership.mdx` | That product areas are split between engineers by direct ownership |
+| `tools-and-processes/using-linear.mdx` | The working agreement: primitives, project lifecycle, definition of done |
+
+If what you are about to say contradicts one of them, the handbook wins.
+
 ## Do not hand-maintain the responsibility zone
 
 Derive it. What someone owns is exactly "the projects where they are lead", and
@@ -48,16 +60,43 @@ A local list of someone's projects is stale within a week — this repo has been
 burned by exactly that. `me.md` holds only the durable half: name, role, and the
 focus they described in their own words.
 
+## What ranking actually means here
+
+Product engineers set their own priorities. The handbook is explicit — *"everyone
+manages their own priorities and escalates to their lead when work piles up"* —
+so you are not issuing a to-do list. You are making the state of the week
+visible so somebody else can decide.
+
+Rank by the handbook's own balance: *"we balance busy work with making progress
+on the most important project we're driving forward."* In that order:
+
+1. **What moves the project they are driving.** A blocked review, a decision
+   waiting on someone else, work sitting one approval away from shipping.
+2. **What is genuinely urgent**, in the priority language the handbook defines —
+   P0 drop-everything, P1 same-week — not in adjectives you invent.
+3. **Busy work, bounded.** Bug fixes and support are capped at roughly two hours
+   a day by the same page. Reviews turn around inside 24 hours. Present these as
+   the budget they are, not as the plan.
+
+**Never present admin as the work.** Drafting an update, merging `main` into a
+stale branch, clearing a queue: those are chores you can offer to take off
+someone, and offering is useful. Ranking them as what to do today is not — it
+reads as though you did not find the real work. If the honest answer is that
+nothing is blocked and the week is clear, say that in one line.
+
 ## The six checks
 
-Run them, then report as **a short ranked list with the reason attached**, not a
-status dump. Ranking beats completeness: the point is what to do next, and a
-40-row table answers nothing.
+### 1. Updates the engineering weekly will read
 
-### 1. Updates owed before Monday planning
+**Monday is the engineering weekly**, and the team reads project updates
+together in it and plans the week from them. So an update has to exist *before*
+Monday — written Friday or Monday morning, it does not matter which. An
+out-of-date project is a gap in that plan, which is why this is the heaviest
+recurring obligation and the easiest to miss: nothing notifies you.
 
-The heaviest recurring obligation and the easiest to miss, because nothing
-notifies you.
+Today's date decides how you say it. Before Monday, this is a deadline
+approaching. On Monday, it is late. Mid-week, it is a commitment nobody has
+closed out — see below.
 
 ```
 get_status_updates(type: "project", user: "me")
@@ -69,15 +108,26 @@ say only "older than the window" — not how stale it is, and not what its last
 "next step" was. Take the newest update per project from an unbounded query
 instead, and page if you have to.
 
-Compare against the in-progress projects from above. Any project with no update
-since the last Monday owes one, and a project with **no update at all** is the
-worst case, not an absent row. Say how stale each is in days — "last update 11
-days ago" lands, "stale" does not.
+Compare against the in-progress projects from above. A project with **no update
+at all** is the worst case, not an absent row.
+
+**Do not report this as staleness.** "Five updates are 11 days stale" is a
+number nobody committed to and a word that means nothing — it sounds like a
+metric and carries no information about the work. What is real is the *last thing
+they said they would do*. Every update ends with a next step, so quote it back
+and ask about that:
+
+> On 24 Aug you said Front End Perf's next step was checking whether we should
+> use react-compiler. Did that happen, or has it been overtaken?
+
+That is a question they can answer in five seconds, and the answer *is* the new
+update. An age in days is not. If several projects are in the same position,
+give one line each in that shape — the commitment, then the question — rather
+than a list of dates.
 
 An update carries health, progress since the last one, next step, blockers or
-decisions needed, and any target-date change. **The previous update's "next step"
-is where this week's goal already is** — read it before writing the new one, and
-say whether it happened. That is the whole value of the sequence.
+decisions needed, and any target-date change. The previous next step is where
+this week's goal already is, so read it before writing anything new.
 
 ### 2. Shipped but not finished
 
@@ -159,7 +209,10 @@ not moved, and requests routed to you as a feature owner.
 
 ### 5. Your open bugs
 
-A weekly look at your own bugs, to catch what is slipping.
+A weekly look at your own bugs, to catch what is slipping. **Bounded**: bug
+fixes and support are capped at roughly two hours a day, so this is a budget
+check, not a backlog to work through. If it consistently needs more than that,
+the handbook says to escalate rather than absorb it — say so.
 
 ```
 list_issues(assignee: "me", label: "bug", state: "started")

--- a/.agents/skills/linear-work-rhythm/SKILL.md
+++ b/.agents/skills/linear-work-rhythm/SKILL.md
@@ -67,13 +67,18 @@ manages their own priorities and escalates to their lead when work piles up"* �
 so you are not issuing a to-do list. You are making the state of the week
 visible so somebody else can decide.
 
-Rank by the handbook's own balance: *"we balance busy work with making progress
-on the most important project we're driving forward."* In that order:
+**A P0 outranks everything, including this ordering.** The handbook defines it
+as drop-everything — a security incident, ingestion delay, the traces table not
+loading. If one exists, it is the answer and the rest of the list can wait; do
+not bury it under a blocked review.
+
+With no P0 open, rank by the handbook's own balance: *"we balance busy work with
+making progress on the most important project we're driving forward."*
 
 1. **What moves the project they are driving.** A blocked review, a decision
    waiting on someone else, work sitting one approval away from shipping.
-2. **What is genuinely urgent**, in the priority language the handbook defines —
-   P0 drop-everything, P1 same-week — not in adjectives you invent.
+2. **P1** — same-week by definition, so it competes with the project rather than
+   deferring behind it. Use the handbook's levels, not adjectives you invent.
 3. **Busy work, bounded.** Bug fixes and support are capped at roughly two hours
    a day by the same page. Reviews turn around inside 24 hours. Present these as
    the budget they are, not as the plan.
@@ -108,8 +113,14 @@ say only "older than the window" — not how stale it is, and not what its last
 "next step" was. Take the newest update per project from an unbounded query
 instead, and page if you have to.
 
-Compare against the in-progress projects from above. A project with **no update
-at all** is the worst case, not an absent row.
+**Which projects owe one:** every in-progress project they lead whose newest
+update predates the last Monday. That is the cutoff — the weekly reads what is
+there, so anything that missed the previous round is still outstanding. A project
+with **no update at all** is the worst case, not an absent row.
+
+Use the cutoff to *select*, then use the framing below to *say it*. The two are
+not in tension: which projects are outstanding is a date question, and what to
+say about each one is not.
 
 **Do not report this as staleness.** "Five updates are 11 days stale" is a
 number nobody committed to and a word that means nothing — it sounds like a


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17075 app preview](https://pr-17075.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

A real run of `linear-work-rhythm` got the day wrong, invented a metric, and finished by offering two chores as if they were the work. Three fixes, all grounded in handbook text this skill was paraphrasing instead of reading. Docs only, 1 file.

## What went wrong

**It did not know when updates are due.** Monday is the engineering weekly; the team reads project updates in it and plans the week from them, so an update has to exist *before* Monday. The skill said "before Monday planning" without naming the meeting, and a session read that as *Friday* being the day the handbook nominates — and said so out loud, on a Friday.

**It invented staleness.** "Five project updates are 11 days stale" is a number nobody committed to and a word that carries no information about the work. It sounds like a metric, which is worse than saying nothing.

**It handed out chores.** After the ranking it offered to draft the five updates and to merge `main` into a dirty branch. Both are admin. Product engineers manage their own priorities, so a list of admin reads as having failed to find the real work.

## What changed

**Name the meeting, and let the day decide the wording.** Monday is the engineering weekly; the update is written Friday or Monday morning. Before Monday it is a deadline approaching, on Monday it is late, mid-week it is a commitment nobody closed out.

**Quote the commitment instead of counting days.** Every update ends with a next step, so ask about *that*:

> On 24 Aug you said Front End Perf's next step was checking whether we should use react-compiler. Did that happen, or has it been overtaken?

Answerable in five seconds, and the answer *is* the new update. An age in days is not, so the skill is now told not to report one.

**Rank by the handbook's own balance, not by what is easiest to list.** It quotes the two lines that govern this — *"everyone manages their own priorities and escalates to their lead when work piles up"* and *"we balance busy work with making progress on the most important project we're driving forward"* — and orders accordingly: what moves the project someone is driving, then what is genuinely urgent in the P0–P3 language the handbook defines, then busy work presented as the budget it is. Bug and support time is named as the roughly two hours a day the handbook caps it at, with escalation rather than absorption when it overruns.

**And explicitly: never present admin as the work.** Offering to take a chore off someone is useful; ranking chores as today's plan is not. If nothing is blocked and the week is clear, say that in one line.

**Four handbook pages are now listed as required reading** — `how-we-ship`, `product-engineering/principles`, `ownership`, `using-linear` — with a note that the handbook wins on any disagreement. The skill was reconstructing their content from memory, which is how both the Monday error and the invented metric got in.

## Result

The output becomes a picture of the week that a product engineer can act on independently, in the team's own vocabulary, instead of a chore list with a fabricated metric at the top of it.

<details>
<summary>What was kept, and one thing to still doubt</summary>

The run was not all wrong, and the parts that worked are untouched. It correctly found that eight pull requests were frozen behind two unapproved ones, named the specific bottoms to get reviewed, and identified from the tracker who was inside that surface and worth asking. That is the shape the skill is for — a name and a blocked path, not a status dump — and this change only alters what surrounds it.

Grounded in text read from `origin/main` of `langfuse-docs` rather than a local checkout, for the reason the skill itself gives: a docs checkout is usually parked on an old branch, and the one on this machine was 576 commits behind earlier today.

**Still worth doubting:** the ranking order is now stated as a rule, but it has been tested exactly once, in the run that prompted this. The next honest check is another live run, ideally on a Monday, when the update section should read as "late" rather than "approaching" — that branch of the wording has not been exercised at all.

`skill-creator`'s validator passes, `pnpm run agents:check` exits 0, `prettier --check` and `turbo run lint` clean (`Tasks: 7 successful, 7 total`), spellcheck clean.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR revises the `linear-work-rhythm` skill to ground recommendations in handbook guidance, phrase weekly-update follow-ups around prior commitments, prioritize project progress over administrative work, and bound bug/support work. The revised instructions currently lose the concrete weekly-update cutoff, rank drop-everything P0 work below ordinary project progress, and ambiguously specify mandatory handbook paths.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until weekly-update eligibility is defined again and P0 work is ranked ahead of ordinary project progress.

The skill removes the only concrete cutoff used to identify owed updates and explicitly puts drop-everything work second, so realistic runs can omit required updates or recommend lower-priority work first; the handbook path format should also be clarified.

**Files Needing Attention:** .agents/skills/linear-work-rhythm/SKILL.md
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.agents/skills/linear-work-rhythm/SKILL.md:111-112
**Update cutoff is undefined**

The update check no longer defines which projects owe an update. The query retrieves up to 14 days of history, but removing the “no update since last Monday” cutoff leaves “out-of-date” undefined. The agent may therefore omit updates required for the Monday engineering weekly or select projects inconsistently.

### Issue 2
.agents/skills/linear-work-rhythm/SKILL.md:73-76
**P0 work ranks second**

This order puts ordinary project progress ahead of P0 work, even though the same instruction defines P0 as “drop-everything.” When both exist, the generated ranking will recommend a blocked review or near-shipping task before the emergency, contradicting the stated priority semantics.

### Issue 3
.agents/skills/linear-work-rhythm/SKILL.md:42-45
**Handbook paths are ambiguous**

The required-reading table gives handbook-root-relative paths, while the preceding command passes `<path>` directly to `git show origin/main:<path>` and its example uses the repository-relative `content/handbook/...` form. An agent substituting these new paths literally may fail to load the mandatory pages, so clarify the prefix or include it in each path.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): rank by the handbook, and ..."](https://github.com/langfuse/langfuse/commit/a14f0ad67cd0e2f7bf490152699bfbe057911702) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60438608)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->