### PR TITLE
fix(web): Truncate `SelectInput` text

### DIFF
--- a/web/src/components/design-system/SelectInput/SelectInput.stories.tsx
+++ b/web/src/components/design-system/SelectInput/SelectInput.stories.tsx
@@ -3,6 +3,9 @@ import { expect, fn, userEvent, within } from "storybook/test";
 import preview from "../../../../.storybook/preview";
 import { SelectInput } from "./SelectInput";
 
+const longOptionLabel =
+  "This is a very long option label that should remain on a single line without wrapping";
+
 const meta = preview.meta({
   component: SelectInput,
 });
@@ -67,6 +70,25 @@ export const Default = meta.story({
       />
     );
   },
+});
+
+export const WithLongText = meta.story({
+  args: {
+    value: "long-option",
+    placeholder: "Select an option",
+    options: [
+      {
+        value: "long-option",
+        label: longOptionLabel,
+      },
+    ],
+    onValueChange: fn(),
+  },
+  render: (args) => (
+    <div className="w-64">
+      <SelectInput {...args} />
+    </div>
+  ),
 });
 
 export const TestKeyboardSelection = meta.story({

--- a/web/src/components/design-system/SelectInput/SelectInput.tsx
+++ b/web/src/components/design-system/SelectInput/SelectInput.tsx
@@ -69,6 +69,9 @@ function SelectInputInner<V extends string>(
     useScrollGradients<React.ComponentRef<typeof SelectPrimitive.Viewport>>(
       true,
     );
+  const selectedOption = options
+    .flatMap((node) => (isSelectGroup(node) ? node.options : [node]))
+    .find((option) => option.value === value);
   const renderNode = useCallback(
     (
       node: SelectInputNode<V>,
@@ -101,7 +104,9 @@ function SelectInputInner<V extends string>(
               hasPreviousGroup ? "mt-4" : "",
             )}
           >
-            <SelectPrimitive.ItemText>{node.label}</SelectPrimitive.ItemText>
+            <span className="min-w-0 flex-1 truncate" title={node.label}>
+              <SelectPrimitive.ItemText>{node.label}</SelectPrimitive.ItemText>
+            </span>
             <SelectPrimitive.ItemIndicator className="ml-auto flex size-3.5 shrink-0 items-center justify-center">
               <Check className="size-4" />
             </SelectPrimitive.ItemIndicator>
@@ -141,11 +146,17 @@ function SelectInputInner<V extends string>(
       <SelectPrimitive.Trigger
         ref={ref}
         className="border-input bg-background ring-offset-background placeholder:text-foreground-tertiary focus:ring-ring disabled:bg-muted/50 flex h-8 w-full items-center justify-between gap-1 rounded-md border px-3 py-2 text-sm focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
+        title={selectedOption?.label}
         {...triggerProps}
       >
-        <SelectPrimitive.SelectValue placeholder={placeholder} />
+        <span
+          className="min-w-0 flex-1 truncate text-left"
+          title={selectedOption?.label}
+        >
+          <SelectPrimitive.SelectValue placeholder={placeholder} />
+        </span>
         <SelectPrimitive.Icon asChild>
-          <ChevronDown className="h-4 w-4 opacity-50" />
+          <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
         </SelectPrimitive.Icon>
       </SelectPrimitive.Trigger>
       <SelectPrimitive.Portal container={container}>


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17077 app preview](https://pr-17077.preview.langfuse.com)**
<!-- aws-preview-pin:end -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR constrains selected and menu option labels so long text truncates without displacing the dropdown icon, adds native title tooltips, and introduces a long-label Storybook example.

- Flattens grouped options to find the selected label for trigger tooltips.
- Adds flex sizing and truncation to trigger and menu labels.
- Keeps the dropdown icon and selection indicator from shrinking.
- Adds a Storybook state demonstrating a long selected label.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge, with a non-blocking gap in automated regression coverage for the new truncation behavior.

The flex and overflow changes align with the component’s supported option types and current callers; the only finding is that the added story does not assert the visual behavior it is intended to protect.

**Files Needing Attention:** web/src/components/design-system/SelectInput/SelectInput.stories.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/design-system/SelectInput/SelectInput.stories.tsx:75-92
**Truncation remains untested**

This story renders the long-text state but makes no assertions, and the Storybook setup has no automated visual snapshot coverage. The test suite can therefore pass if single-line truncation or menu layout regresses. Please add an interaction assertion that verifies the trigger and option text remain on one line and overflow their containers.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): truncate SelectInput text"](https://github.com/langfuse/langfuse/commit/634bfcfe3d0e0419707c96c62cd4d811ae2c55cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60454911)</sub>

<!-- /greptile_comment -->