### PR TITLE
feat(web): persistent trace summary strip and simplified detail headers

### DIFF
--- a/web/src/components/ItemBadge.tsx
+++ b/web/src/components/ItemBadge.tsx
@@ -102,15 +102,41 @@ export function renderFilterIcon(value: string): React.ReactNode {
   );
 }
 
+/**
+ * Bare type icon without the badge chrome (background/border) — for rows where
+ * an opaque box would fight the row's own hover/selection highlight.
+ */
+export function ItemIcon({
+  type,
+  className,
+}: {
+  type: LangfuseItemType;
+  className?: string;
+}) {
+  const Icon = iconMap[type] || ListTree;
+  const label =
+    String(type).charAt(0).toUpperCase() + String(type).slice(1).toLowerCase();
+  return (
+    <Icon
+      aria-label={label}
+      className={cn("shrink-0", iconVariants({ type }), className)}
+    />
+  );
+}
+
 export function ItemBadge({
   type,
   showLabel = false,
   isSmall = false,
+  hideIcon = false,
   className,
 }: {
   type: LangfuseItemType;
   showLabel?: boolean;
   isSmall?: boolean;
+  /** Label-only chip (page headers): the label names the type, so the icon
+      repeats it. */
+  hideIcon?: boolean;
   className?: string;
 }) {
   const Icon = iconMap[type] || ListTree; // Default to ListTree if unknown type
@@ -133,7 +159,11 @@ export function ItemBadge({
       variant="outline"
       title={label}
       className={cn(
-        "bg-background flex max-w-fit items-center gap-1 overflow-hidden border-2 whitespace-nowrap",
+        hideIcon
+          ? // Label-only mode (page/peek headers): quiet chip — no fill, muted
+            // text — so the type label doesn't compete with the title.
+            "text-muted-foreground border-border flex max-w-fit items-center gap-1 overflow-hidden border bg-transparent whitespace-nowrap"
+          : "bg-background flex max-w-fit items-center gap-1 overflow-hidden border-2 whitespace-nowrap",
         // With a label the horizontal padding is what separates the icon from the
         // text. Without one there is nothing to separate, and the padding only
         // made a square icon sit in a rectangle. `max-w-none` is what lets it be
@@ -145,7 +175,7 @@ export function ItemBadge({
         isSmall && showLabel && "h-4",
       )}
     >
-      <Icon className={iconClass} />
+      {!hideIcon && <Icon className={iconClass} />}
       {showLabel && (
         <span className="truncate" title={displayLabel}>
           {displayLabel}

--- a/web/src/components/ItemBadge.tsx
+++ b/web/src/components/ItemBadge.tsx
@@ -102,28 +102,6 @@ export function renderFilterIcon(value: string): React.ReactNode {
   );
 }
 
-/**
- * Bare type icon without the badge chrome (background/border) — for rows where
- * an opaque box would fight the row's own hover/selection highlight.
- */
-export function ItemIcon({
-  type,
-  className,
-}: {
-  type: LangfuseItemType;
-  className?: string;
-}) {
-  const Icon = iconMap[type] || ListTree;
-  const label =
-    String(type).charAt(0).toUpperCase() + String(type).slice(1).toLowerCase();
-  return (
-    <Icon
-      aria-label={label}
-      className={cn("shrink-0", iconVariants({ type }), className)}
-    />
-  );
-}
-
 export function ItemBadge({
   type,
   showLabel = false,

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -163,7 +163,7 @@ const PageHeader = ({
               <div className="mr-2 flex items-center gap-1">
                 {itemType && (
                   <div className="flex items-center">
-                    <ItemBadge type={itemType} showLabel />
+                    <ItemBadge type={itemType} showLabel hideIcon />
                   </div>
                 )}
                 <div className="relative inline-block max-w-md md:max-w-none">

--- a/web/src/components/session/ModernSessionHeaderPill.tsx
+++ b/web/src/components/session/ModernSessionHeaderPill.tsx
@@ -14,6 +14,9 @@ type ModernSessionHeaderPillProps = {
   | {
       variant: "link";
       href: ComponentPropsWithoutRef<typeof Link>["href"];
+      /** Set for pills that render customer data (session/user/trace ids)
+          as visible text, so PostHog session recordings mask it. */
+      maskFromSessionReplay?: boolean;
     }
   | ({
       variant: "button";
@@ -49,7 +52,7 @@ export function ModernSessionHeaderPill(props: ModernSessionHeaderPillProps) {
       <Link
         href={props.href}
         data-session-header-pill="true"
-        className={`${PILL_CLASS_NAME} hover:border-link hover:text-link group max-w-[280px] min-w-0 gap-1.5`}
+        className={`${PILL_CLASS_NAME} hover:border-link hover:text-link group max-w-[280px] min-w-0 gap-1.5 ${props.maskFromSessionReplay ? "ph-no-capture" : ""}`}
       >
         {props.children}
       </Link>

--- a/web/src/components/table/peek/PeekHeader.tsx
+++ b/web/src/components/table/peek/PeekHeader.tsx
@@ -209,9 +209,10 @@ export function PeekHeader({
         className="bg-muted flex min-h-11 shrink-0 flex-row flex-nowrap items-center justify-between gap-2 overflow-hidden px-2 py-1"
       >
         <div className="flex min-w-0 flex-row items-center gap-2">
-          {/* Badge never truncates: it shows the full label or just the icon. */}
+          {/* Label-only chip, matching the full-page header (the label names
+              the type; short enough to keep on any width). */}
           <div ref={badgeRef} className="shrink-0">
-            <ItemBadge type={itemType} showLabel={plan.badgeShowLabel} />
+            <ItemBadge type={itemType} showLabel hideIcon />
           </div>
           <span
             className="truncate text-sm font-bold focus:outline-hidden"

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -34,6 +34,8 @@ export function JSONView(props: {
   json?: unknown;
   title?: string;
   hideTitle?: boolean;
+  /** Header controls (copy, expand) reveal on section hover instead of always. */
+  hoverControls?: boolean;
   className?: string;
   isLoading?: boolean;
   codeClassName?: string;
@@ -180,6 +182,7 @@ export function JSONView(props: {
     >
       {props.title && !props.hideTitle ? (
         <MarkdownJsonViewHeader
+          hoverRevealControls={props.hoverControls}
           title={props.title}
           handleOnCopy={handleOnCopy}
           controlButtons={

--- a/web/src/components/ui/MarkdownJsonView.tsx
+++ b/web/src/components/ui/MarkdownJsonView.tsx
@@ -19,12 +19,20 @@ type MarkdownJsonViewHeaderProps = {
   handleOnCopy: (event?: React.MouseEvent<HTMLButtonElement>) => void;
   controlButtons?: React.ReactNode;
   /** When set, the header hosts expand/collapse so a long body is not the
-      only place to find the control. */
+      only place to find the control. `subject` names what collapses in the
+      accessible labels (defaults to "system prompt", its original use). */
   collapseControl?: {
     isCollapsed: boolean;
     onToggle: () => void;
+    subject?: string;
   };
   inset?: boolean;
+  /** Hosts that render their own copy control (e.g. inside the content box)
+      suppress the header's. */
+  hideCopyButton?: boolean;
+  /** Reveal the right-side controls only while hovering the hosting section
+      (requires a `group/iosection` ancestor). */
+  hoverRevealControls?: boolean;
 };
 
 export function MarkdownJsonViewHeader({
@@ -34,12 +42,15 @@ export function MarkdownJsonViewHeader({
   controlButtons,
   collapseControl,
   inset = false,
+  hideCopyButton = false,
+  hoverRevealControls = false,
 }: MarkdownJsonViewHeaderProps) {
   const [isCopied, setIsCopied] = useState(false);
+  const collapseSubject = collapseControl?.subject ?? "system prompt";
   const collapseLabel = collapseControl
     ? collapseControl.isCollapsed
-      ? "Expand system prompt"
-      : "Collapse system prompt"
+      ? `Expand ${collapseSubject}`
+      : `Collapse ${collapseSubject}`
     : undefined;
   // Keep the visible title in the title-button name (WCAG 2.5.3). A generic
   // aria-label would hide message `name`s from assistive tech.
@@ -88,7 +99,13 @@ export function MarkdownJsonViewHeader({
           titleContent
         )}
       </div>
-      <div className="mr-1 flex min-w-0 shrink flex-row items-center gap-1">
+      <div
+        className={cn(
+          "mr-1 flex min-w-0 shrink flex-row items-center gap-1",
+          hoverRevealControls &&
+            "opacity-0 transition-opacity group-hover/iosection:opacity-100 focus-within:opacity-100",
+        )}
+      >
         {collapseControl ? (
           <Button
             variant="ghost"
@@ -102,24 +119,26 @@ export function MarkdownJsonViewHeader({
           </Button>
         ) : null}
         {controlButtons}
-        <Button
-          title="Copy to clipboard"
-          variant="ghost"
-          size="icon-xs"
-          type="button"
-          onClick={(event) => {
-            setIsCopied(true);
-            handleOnCopy(event);
-            setTimeout(() => setIsCopied(false), 1000);
-          }}
-          className="hover:bg-border -mr-2"
-        >
-          {isCopied ? (
-            <Check className="h-3 w-3" />
-          ) : (
-            <Copy className="h-3 w-3" />
-          )}
-        </Button>
+        {!hideCopyButton && (
+          <Button
+            title="Copy to clipboard"
+            variant="ghost"
+            size="icon-xs"
+            type="button"
+            onClick={(event) => {
+              setIsCopied(true);
+              handleOnCopy(event);
+              setTimeout(() => setIsCopied(false), 1000);
+            }}
+            className="hover:bg-border -mr-2"
+          >
+            {isCopied ? (
+              <Check className="h-3 w-3" />
+            ) : (
+              <Copy className="h-3 w-3" />
+            )}
+          </Button>
+        )}
       </div>
     </div>
   );
@@ -155,6 +174,7 @@ export function MarkdownJsonView({
   controlButtons,
   afterHeader,
   isSystemPrompt,
+  hoverControls,
 }: {
   content?: unknown;
   title?: string;
@@ -168,6 +188,8 @@ export function MarkdownJsonView({
   /** Collapse long content to a preview (from raw `role === "system"`, since
       the title can carry a message `name` instead of the role). */
   isSystemPrompt?: boolean;
+  /** Header controls reveal on section hover instead of rendering always. */
+  hoverControls?: boolean;
 }) {
   const characterLimit = useMarkdownRenderCharacterLimit();
   // Boxed so a renderable `null` content stays distinguishable from
@@ -192,6 +214,7 @@ export function MarkdownJsonView({
           controlButtons={controlButtons}
           afterHeader={afterHeader}
           isSystemPrompt={isSystemPrompt}
+          hoverControls={hoverControls}
         />
       ) : (
         <PrettyJsonView
@@ -199,6 +222,7 @@ export function MarkdownJsonView({
           title={title}
           titleIcon={titleIcon}
           className={className}
+          hoverControls={hoverControls}
           media={media}
           currentView="pretty"
           controlButtons={controlButtons}

--- a/web/src/components/ui/MarkdownJsonView.tsx
+++ b/web/src/components/ui/MarkdownJsonView.tsx
@@ -102,8 +102,10 @@ export function MarkdownJsonViewHeader({
       <div
         className={cn(
           "mr-1 flex min-w-0 shrink flex-row items-center gap-1",
+          // pointer-coarse: touch devices have no hover, so the controls
+          // stay visible there instead of being unreachable.
           hoverRevealControls &&
-            "opacity-0 transition-opacity group-hover/iosection:opacity-100 focus-within:opacity-100",
+            "opacity-0 transition-opacity group-hover/iosection:opacity-100 focus-within:opacity-100 pointer-coarse:opacity-100",
         )}
       >
         {collapseControl ? (

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -488,6 +488,7 @@ export function MarkdownView({
   controlButtons,
   afterHeader,
   isSystemPrompt,
+  hoverControls = false,
 }: {
   /** The UNPARSED content shape — see `canRenderContentAsMarkdown`. Media
       reference strings must still be strings when they reach the part guards. */
@@ -504,6 +505,8 @@ export function MarkdownView({
       (`role === "system"`) — the title can be a message `name` instead of the
       role. Falls back to matching the title for callers without role data. */
   isSystemPrompt?: boolean;
+  /** Header controls (copy, ...) reveal on section hover instead of always. */
+  hoverControls?: boolean;
 }) {
   const { forcedTheme, resolvedTheme } = useTheme();
   const theme = forcedTheme ?? resolvedTheme;
@@ -558,13 +561,17 @@ export function MarkdownView({
   ) : null;
 
   return (
-    <div className="overflow-hidden" key={theme}>
+    <div
+      className={cn("overflow-hidden", hoverControls && "group/iosection")}
+      key={theme}
+    >
       {title ? (
         <>
           <MarkdownJsonViewHeader
             title={title}
             titleIcon={titleIcon}
             handleOnCopy={handleOnCopy}
+            hoverRevealControls={hoverControls}
             controlButtons={controlButtons}
             collapseControl={
               shouldBeCollapsible

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -770,6 +770,9 @@ export function PrettyJsonView(props: {
   inset?: boolean;
   /** Content to render between header and main content (e.g., thinking blocks) */
   afterHeader?: React.ReactNode;
+  /** Titled sections (Input/Output/Metadata): header controls (copy,
+      expand-all) reveal on section hover instead of rendering always. */
+  hoverControls?: boolean;
   /** When set, rows show an actions menu with copy + add-to-filter shortcuts
       (metadata views only). */
   metadataActions?: MetadataFilterActions;
@@ -1408,10 +1411,46 @@ export function PrettyJsonView(props: {
     </>
   );
 
+  const expandCollapseButton = (
+    <>
+      {shouldUseTableView && (
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          onClick={() => expandAllRef.current?.()}
+          className="hover:bg-border -mr-2"
+          title={allRowsExpanded ? "Collapse all rows" : "Expand all rows"}
+        >
+          {allRowsExpanded ? (
+            <FoldVertical className="h-3 w-3" />
+          ) : (
+            <UnfoldVertical className="h-3 w-3" />
+          )}
+        </Button>
+      )}
+      {!shouldUseTableView && !isMarkdownMode && !largeStringValue && (
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          onClick={handleJsonToggleCollapse}
+          className="hover:bg-border -mr-2"
+          title={jsonIsCollapsed ? "Expand all" : "Collapse all"}
+        >
+          {jsonIsCollapsed ? (
+            <UnfoldVertical className="h-3 w-3" />
+          ) : (
+            <FoldVertical className="h-3 w-3" />
+          )}
+        </Button>
+      )}
+    </>
+  );
+
   return (
     <div
       className={cn(
         "flex max-h-full min-h-0 flex-col",
+        props.hoverControls && "group/iosection",
         props.inset && "[&_.io-message-content]:px-2",
         props.className,
         props.scrollable ? "overflow-hidden" : "",
@@ -1433,62 +1472,34 @@ export function PrettyJsonView(props: {
               : undefined
           }
           inset={props.inset}
+          hoverRevealControls={props.hoverControls}
           controlButtons={
             <>
-              {shouldUseTableView && (
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={() => expandAllRef.current?.()}
-                  className="hover:bg-border -mr-2"
-                  title={
-                    allRowsExpanded ? "Collapse all rows" : "Expand all rows"
-                  }
-                >
-                  {allRowsExpanded ? (
-                    <FoldVertical className="h-3 w-3" />
-                  ) : (
-                    <UnfoldVertical className="h-3 w-3" />
-                  )}
-                </Button>
-              )}
-              {!shouldUseTableView && !isMarkdownMode && !largeStringValue && (
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={handleJsonToggleCollapse}
-                  className="hover:bg-border -mr-2"
-                  title={jsonIsCollapsed ? "Expand all" : "Collapse all"}
-                >
-                  {jsonIsCollapsed ? (
-                    <UnfoldVertical className="h-3 w-3" />
-                  ) : (
-                    <FoldVertical className="h-3 w-3" />
-                  )}
-                </Button>
-              )}
+              {expandCollapseButton}
               {props.controlButtons}
             </>
           }
         />
       ) : null}
-      {props.afterHeader}
-      {props.scrollable ? (
-        <div
-          className={cn(
-            "flex h-full min-h-0 overflow-hidden",
-            isMarkdownMode ? getBackgroundColorClass() : "rounded-sm border",
-          )}
-        >
-          <div className="max-h-full min-h-0 w-full overflow-y-auto">
-            {body}
+      <div>
+        {props.afterHeader}
+        {props.scrollable ? (
+          <div
+            className={cn(
+              "flex h-full min-h-0 overflow-hidden",
+              isMarkdownMode ? getBackgroundColorClass() : "rounded-sm border",
+            )}
+          >
+            <div className="max-h-full min-h-0 w-full overflow-y-auto">
+              {body}
+            </div>
           </div>
-        </div>
-      ) : isMarkdownMode ? (
-        <div className={getBackgroundColorClass()}>{body}</div>
-      ) : (
-        body
-      )}
+        ) : isMarkdownMode ? (
+          <div className={getBackgroundColorClass()}>{body}</div>
+        ) : (
+          body
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/components/ui/action-button-count-badge.tsx
+++ b/web/src/components/ui/action-button-count-badge.tsx
@@ -1,6 +1,22 @@
-export function ActionButtonCountBadge({ count }: { count: number }) {
+import { cn } from "@/src/utils/tailwind";
+
+export function ActionButtonCountBadge({
+  count,
+  variant = "default",
+}: {
+  count: number;
+  /** "muted" for quiet contexts (e.g. tab labels) where the primary fill shouts. */
+  variant?: "default" | "muted";
+}) {
   return (
-    <span className="bg-primary/50 text-primary-foreground flex h-3.5 w-fit items-center justify-center rounded-sm px-1 text-xs shadow-xs">
+    <span
+      className={cn(
+        "flex h-3.5 w-fit items-center justify-center rounded-sm px-1 text-xs",
+        variant === "muted"
+          ? "bg-muted text-muted-foreground"
+          : "bg-primary/50 text-primary-foreground shadow-xs",
+      )}
+    >
       {count > 99 ? "99+" : count}
     </span>
   );

--- a/web/src/features/models/components/UpsertModelFormDialog/UpsertModelFormDialog.clienttest.tsx
+++ b/web/src/features/models/components/UpsertModelFormDialog/UpsertModelFormDialog.clienttest.tsx
@@ -167,22 +167,22 @@ describe("UpsertModelFormDialog price editor", () => {
     upsertMutateAsync.mockClear();
   });
 
-  it("keeps an unlinked model badge intact as the dialog trigger", () => {
+  it("renders an unlinked model as a link to model settings (no inline dialog)", () => {
     render(
       <ModelBadge
         model="claude-sonnet-4-5"
         internalModelId={null}
         projectId="p1"
-        usageDetails={undefined}
       />,
     );
 
-    const trigger = screen.getByTitle("Create model definition");
-    const label = within(trigger).getByText("claude-sonnet-4-5");
+    const link = screen.getByTitle(
+      "Model has no pricing definition — view model settings",
+    );
+    within(link).getByText("claude-sonnet-4-5");
 
-    expect(trigger.tagName).toBe("BUTTON");
-    expect(label.parentElement).toHaveClass("bg-tertiary");
-    expect(label.parentElement?.querySelector("svg")).not.toBeNull();
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("href", "/project/p1/settings/models");
   });
 
   it("keeps every keystroke of a usage type that extends an existing one", () => {

--- a/web/src/features/playground/page/components/JumpToPlaygroundDropdownMenuController.tsx
+++ b/web/src/features/playground/page/components/JumpToPlaygroundDropdownMenuController.tsx
@@ -40,7 +40,7 @@ import {
   type JumpToPlaygroundAction,
 } from "./JumpToPlaygroundMenu";
 
-type JumpToPlaygroundDropdownMenuControllerProps = (
+type JumpToPlaygroundSourceProps =
   | {
       source: "prompt";
       prompt: Prompt & { resolvedPrompt?: Prisma.JsonValue };
@@ -56,22 +56,27 @@ type JumpToPlaygroundDropdownMenuControllerProps = (
         output: string | null;
       };
       analyticsEventName: "trace_detail:test_in_playground_button_click";
-    }
-) & {
-  children: (control: {
-    disabled: boolean;
-    title: string;
-    Trigger: Parameters<
-      NonNullable<
-        React.ComponentProps<typeof DropdownMenuController>["children"]
-      >
-    >[0]["Trigger"];
-  }) => React.ReactNode;
-};
+    };
 
-export const JumpToPlaygroundDropdownMenuController = (
-  props: JumpToPlaygroundDropdownMenuControllerProps,
-) => {
+type JumpToPlaygroundDropdownMenuControllerProps =
+  JumpToPlaygroundSourceProps & {
+    children: (control: {
+      disabled: boolean;
+      title: string;
+      Trigger: Parameters<
+        NonNullable<
+          React.ComponentProps<typeof DropdownMenuController>["children"]
+        >
+      >[0]["Trigger"];
+    }) => React.ReactNode;
+  };
+
+/**
+ * The jump-to-playground logic without any trigger UI, so hosts can embed the
+ * playground actions in their own menus (e.g. the observation header's
+ * combined "Add to" menu) as well as behind the standalone controller below.
+ */
+export const useJumpToPlayground = (props: JumpToPlaygroundSourceProps) => {
   const router = useRouter();
   const capture = usePostHogClientCapture();
   const projectId = useProjectIdFromURL();
@@ -174,11 +179,32 @@ export const JumpToPlaygroundDropdownMenuController = (
     ? "Test in LLM playground"
     : "Test in LLM playground is not available since messages are not in valid ChatML format or tool calls have been used. If you think this is not correct, please open a GitHub issue.";
 
+  return {
+    isAvailable,
+    tooltipMessage,
+    includeOutput,
+    setIncludeOutput,
+    handlePlaygroundAction,
+  };
+};
+
+export const JumpToPlaygroundDropdownMenuController = (
+  props: JumpToPlaygroundDropdownMenuControllerProps,
+) => {
+  const { children, ...sourceProps } = props;
+  const {
+    isAvailable,
+    tooltipMessage,
+    includeOutput,
+    setIncludeOutput,
+    handlePlaygroundAction,
+  } = useJumpToPlayground(sourceProps);
+
   return (
     <DropdownMenuController
       align="end"
       renderMenu={() =>
-        props.source === "prompt" ? (
+        sourceProps.source === "prompt" ? (
           <JumpToPlaygroundMenu
             source="prompt"
             onPlaygroundAction={handlePlaygroundAction}
@@ -194,7 +220,7 @@ export const JumpToPlaygroundDropdownMenuController = (
       }
     >
       {({ Trigger }) =>
-        props.children({
+        children({
           Trigger,
           disabled: !isAvailable,
           title: tooltipMessage,

--- a/web/src/features/playground/page/components/JumpToPlaygroundDropdownMenuController.tsx
+++ b/web/src/features/playground/page/components/JumpToPlaygroundDropdownMenuController.tsx
@@ -75,8 +75,16 @@ type JumpToPlaygroundDropdownMenuControllerProps =
  * The jump-to-playground logic without any trigger UI, so hosts can embed the
  * playground actions in their own menus (e.g. the observation header's
  * combined "Add to" menu) as well as behind the standalone controller below.
+ *
+ * The hook itself must always be called unconditionally (rules of hooks) —
+ * callers that only offer the Playground entry for some observation types
+ * (e.g. generation-like ones) pass `enabled: false` for the rest so the
+ * internal API key query doesn't fire for every span/event.
  */
-export const useJumpToPlayground = (props: JumpToPlaygroundSourceProps) => {
+export const useJumpToPlayground = (
+  props: JumpToPlaygroundSourceProps,
+  { enabled = true }: { enabled?: boolean } = {},
+) => {
   const router = useRouter();
   const capture = usePostHogClientCapture();
   const projectId = useProjectIdFromURL();
@@ -95,7 +103,7 @@ export const useJumpToPlayground = (props: JumpToPlaygroundSourceProps) => {
     {
       projectId: projectId as string,
     },
-    { enabled: Boolean(projectId) },
+    { enabled: enabled && Boolean(projectId) },
   );
 
   const modelToProviderMap = useMemo(() => {

--- a/web/src/features/tag/components/TagPill.tsx
+++ b/web/src/features/tag/components/TagPill.tsx
@@ -1,0 +1,17 @@
+/**
+ * Read-only tag chip: thin outlined pill, muted text. The quiet counterpart to
+ * the interactive TagButton — for surfaces that display tags without editing
+ * them (trace summary strip, detail headers).
+ */
+export function TagPill({ tag }: { tag: string }) {
+  return (
+    <span
+      title={tag}
+      className="border-border text-muted-foreground inline-flex max-w-40 items-center rounded-sm border px-1.5 text-xs leading-4"
+    >
+      <span className="truncate" title={tag}>
+        {tag}
+      </span>
+    </span>
+  );
+}

--- a/web/src/features/tag/components/TagPill.tsx
+++ b/web/src/features/tag/components/TagPill.tsx
@@ -1,17 +1,16 @@
+import { ModernSessionHeaderPill } from "@/src/components/session/ModernSessionHeaderPill";
+
 /**
- * Read-only tag chip: thin outlined pill, muted text. The quiet counterpart to
- * the interactive TagButton — for surfaces that display tags without editing
- * them (trace summary strip, detail headers).
+ * Read-only tag chip for surfaces that display tags without editing them
+ * (trace summary strip, detail headers). Renders through the session
+ * header's pill primitive so trace and session chips share one style.
  */
 export function TagPill({ tag }: { tag: string }) {
   return (
-    <span
-      title={tag}
-      className="border-border text-muted-foreground inline-flex max-w-40 items-center rounded-sm border px-1.5 text-xs leading-4"
-    >
-      <span className="truncate" title={tag}>
+    <ModernSessionHeaderPill variant="display" title={tag}>
+      <span className="max-w-40 truncate" title={tag}>
         {tag}
       </span>
-    </span>
+    </ModernSessionHeaderPill>
   );
 }

--- a/web/src/features/traces/components/CollapsibleBadgeRow.tsx
+++ b/web/src/features/traces/components/CollapsibleBadgeRow.tsx
@@ -25,10 +25,13 @@ export function CollapsibleBadgeRow({
   const isMobile = useIsMobile();
   const [expanded, setExpanded] = useState(false);
 
-  // Desktop: unchanged full wrapped badge row.
+  // Desktop: full wrapped row. gap-x-3: the row holds muted TEXT metadata now
+  // (not chips), and text items need breathing room to scan as separate facts.
   if (!isMobile) {
     return (
-      <div className={cn("flex flex-wrap items-center gap-1", className)}>
+      <div
+        className={cn("flex flex-wrap items-center gap-x-3 gap-y-1", className)}
+      >
         {children}
       </div>
     );
@@ -39,7 +42,7 @@ export function CollapsibleBadgeRow({
     <div className="flex items-start gap-1">
       <div
         className={cn(
-          "flex min-w-0 flex-1 items-center gap-1",
+          "flex min-w-0 flex-1 items-center gap-x-3",
           // Collapsed: one clipped line. `[&>*]:shrink-0` stops flex from
           // squeezing badges below their content width (which made long ones
           // like "Time to first token" wrap vertically into a multi-line row);

--- a/web/src/features/traces/components/IOPreview/IOPreviewJSONSimple.tsx
+++ b/web/src/features/traces/components/IOPreview/IOPreviewJSONSimple.tsx
@@ -148,6 +148,7 @@ export function IOPreviewJSONSimple({
         ) : (
           <PrettyJsonView
             title="Input"
+            hoverControls
             json={input}
             parsedJson={effectiveInput}
             isLoading={isLoading}
@@ -175,6 +176,7 @@ export function IOPreviewJSONSimple({
         ) : (
           <PrettyJsonView
             title="Output"
+            hoverControls
             json={output}
             parsedJson={effectiveOutput}
             isLoading={isLoading}
@@ -217,6 +219,7 @@ export function IOPreviewJSONSimple({
         ) : (
           <PrettyJsonView
             title="Metadata"
+            hoverControls
             json={metadata}
             parsedJson={effectiveMetadata}
             isLoading={isLoading}

--- a/web/src/features/traces/components/IOPreview/IOPreviewPretty.tsx
+++ b/web/src/features/traces/components/IOPreview/IOPreviewPretty.tsx
@@ -57,7 +57,7 @@ function JsonInputOutputView({
   const showOutput = !hideOutput && !(hideIfNull && !parsedOutput);
 
   return (
-    <div className="[&_.io-message-content]:px-2 [&_.io-message-header]:px-2">
+    <div className="space-y-4 [&_.io-message-content]:px-3 [&_.io-message-header]:px-3">
       {showInput && (
         <PrettyJsonView
           title="Input"
@@ -68,6 +68,7 @@ function JsonInputOutputView({
           currentView="pretty"
           externalExpansionState={inputExpansionState}
           onExternalExpansionChange={onInputExpansionChange}
+          hoverControls
         />
       )}
       {showOutput && (
@@ -80,6 +81,7 @@ function JsonInputOutputView({
           currentView="pretty"
           externalExpansionState={outputExpansionState}
           onExternalExpansionChange={onOutputExpansionChange}
+          hoverControls
         />
       )}
     </div>
@@ -297,7 +299,7 @@ export function IOPreviewPretty({
       ) : null}
 
       {shouldRenderMessages ? (
-        <div className="[&_.io-message-content]:px-2 [&_.io-message-header]:px-2">
+        <div className="mt-4 [&_.io-message-content]:px-3 [&_.io-message-header]:px-3">
           <ChatMessageList
             messages={allMessages}
             shouldRenderMarkdown={shouldRenderMarkdown}
@@ -351,6 +353,7 @@ export function IOPreviewPretty({
             externalExpansionState={metadataExpansionState}
             onExternalExpansionChange={onMetadataExpansionChange}
             metadataActions={metadataActions}
+            hoverControls
           />
         </div>
       )}

--- a/web/src/features/traces/components/IOPreview/components/ChatMessage.tsx
+++ b/web/src/features/traces/components/IOPreview/components/ChatMessage.tsx
@@ -92,6 +92,7 @@ export function ChatMessage({
       <div className="hover:bg-muted transition-colors">
         <div style={{ display: shouldRenderMarkdown ? "block" : "none" }}>
           <MarkdownJsonView
+            hoverControls
             title="Placeholder"
             content={message.name || "Unnamed placeholder"}
           />
@@ -191,6 +192,7 @@ export function ChatMessage({
         {/* Markdown view */}
         <div style={{ display: shouldRenderMarkdown ? "block" : "none" }}>
           <MarkdownJsonView
+            hoverControls
             title={title}
             content={message.content || ""}
             audio={message.audio}

--- a/web/src/features/traces/components/IOPreview/components/CorrectedOutputField.tsx
+++ b/web/src/features/traces/components/IOPreview/components/CorrectedOutputField.tsx
@@ -8,6 +8,7 @@ import { useCorrectionEditor } from "../hooks/useCorrectionEditor";
 import { useMemo, useState } from "react";
 import { CodeMirrorEditor } from "@/src/components/editor/CodeMirrorEditor";
 import { useHasProjectAccess } from "@/src/features/rbac";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics";
 import { Switch } from "@/src/components/design-system/Switch/Switch";
 import useLocalStorage from "@/src/components/useLocalStorage";
 import { CorrectedOutputDiffDialog } from "./CorrectedOutputDiffDialog";
@@ -46,6 +47,7 @@ export function CorrectedOutputField({
   compact = false,
 }: CorrectedOutputFieldProps) {
   const hasAccess = useHasProjectAccess({ projectId, scope: "scores:CUD" });
+  const capture = usePostHogClientCapture();
 
   // JSON validation toggle (persisted in localStorage)
   const [strictJsonMode, setStrictJsonMode] = useLocalStorage(
@@ -55,6 +57,9 @@ export function CorrectedOutputField({
 
   // Diff dialog state
   const [isDiffDialogOpen, setIsDiffDialogOpen] = useState(false);
+
+  // One-line link by default; the full section renders on demand.
+  const [isExpanded, setIsExpanded] = useState(false);
 
   // Merge cache + server data
   const { effectiveCorrection, correctionValue } = useCorrectionData(
@@ -155,6 +160,29 @@ export function CorrectedOutputField({
     setIsEditing(false);
   };
 
+  // Collapsed to a one-line link by default: corrections are used by a small
+  // share of users, so the full editor UI only takes space once asked for.
+  if (!isExpanded) {
+    return (
+      <div className="px-3 py-2">
+        <button
+          type="button"
+          onClick={() => {
+            capture("trace_detail:io_section_collapse_toggle", {
+              section: "corrected_output",
+              collapsed: false,
+            });
+            setIsExpanded(true);
+          }}
+          className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs hover:underline"
+        >
+          <Pencil className="size-3 shrink-0" aria-hidden />
+          {hasContent ? "Corrected output" : "Add corrected output"}
+        </button>
+      </div>
+    );
+  }
+
   return (
     <>
       <CorrectedOutputDiffDialog
@@ -165,7 +193,7 @@ export function CorrectedOutputField({
         correctedOutput={value}
         strictJsonMode={strictJsonMode}
       />
-      <div className="px-2">
+      <div className="px-3">
         <div className="group relative rounded-md">
           <div className="flex items-center justify-between py-1.5">
             <div className="flex items-center gap-1">

--- a/web/src/features/traces/components/ObservationDetailView/ConnectedObservationDetailView.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/ConnectedObservationDetailView.tsx
@@ -27,6 +27,7 @@ import {
   HoverCardTrigger,
 } from "@/src/components/ui/hover-card";
 import { Tabs } from "@/src/components/design-system/Tabs/Tabs";
+import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-badge";
 import {
   TabsBar,
   TabsBarContent,
@@ -366,7 +367,20 @@ export function ConnectedObservationDetailView({
             <TabsBarList>
               <TabsBarTrigger value="preview">Preview</TabsBarTrigger>
               {showScoresTab ? (
-                <TabsBarTrigger value="scores">Scores</TabsBarTrigger>
+                <TabsBarTrigger value="scores" className="gap-1">
+                  Scores
+                  {/* Match the tab's table: observation scores, plus the
+                      trace-level ones when this node stands in for the trace. */}
+                  <ActionButtonCountBadge
+                    count={
+                      observationScores.length +
+                      (ownsTraceLevelScores
+                        ? scores.filter((score) => !score.observationId).length
+                        : 0)
+                    }
+                    variant="muted"
+                  />
+                </TabsBarTrigger>
               ) : null}
               {showLogViewTab ? (
                 <TabsBarTrigger value="log">
@@ -480,7 +494,6 @@ export function ConnectedObservationDetailView({
         >
           <ObservationPreview
             currentView={currentView}
-            tags={isRoot ? observation.traceTags : undefined}
             previewKey={observation.id}
             onPrettyViewAvailabilityChange={setIsPrettyViewAvailable}
             previewProps={{

--- a/web/src/features/traces/components/ObservationDetailView/ObservationPreview.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/ObservationPreview.tsx
@@ -1,11 +1,9 @@
 import { useState, type ComponentProps, type Key } from "react";
 
 import { IOPreview } from "@/src/features/traces/components/IOPreview/IOPreview";
-import TagList from "@/src/features/tag/components/TagList";
 
 export interface ObservationPreviewProps {
   currentView?: ComponentProps<typeof IOPreview>["currentView"];
-  tags?: string[] | null;
   previewKey: Key;
   previewProps: Omit<
     ComponentProps<typeof IOPreview>,
@@ -16,7 +14,6 @@ export interface ObservationPreviewProps {
 
 export function ObservationPreview({
   currentView,
-  tags,
   previewKey,
   previewProps,
   onPrettyViewAvailabilityChange,
@@ -31,20 +28,7 @@ export function ObservationPreview({
           : "overflow-auto pb-4"
       }`}
     >
-      {tags && tags.length > 0 ? (
-        <>
-          <div
-            className={`px-2 pt-2 text-sm font-bold ${currentView && currentView !== "pretty" && currentView !== "pretty-beta" ? "shrink-0" : ""}`}
-          >
-            Tags
-          </div>
-          <div
-            className={`flex flex-wrap gap-x-1 gap-y-1 px-2 pb-2 ${currentView && currentView !== "pretty" && currentView !== "pretty-beta" ? "shrink-0" : ""}`}
-          >
-            <TagList selectedTags={tags} isLoading={false} />
-          </div>
-        </>
-      ) : null}
+      {/* Trace tags render in the persistent TraceSummaryStrip, not per observation. */}
       <IOPreview
         key={previewKey}
         {...previewProps}

--- a/web/src/features/traces/components/ObservationDetailView/components/ModelBadge.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ModelBadge.tsx
@@ -1,64 +1,43 @@
 /* eslint-disable @repo/no-null-render */
 /**
- * Model badge for ObservationDetailView
- * Handles linked models (with external link) and unlinked models (with create form)
+ * Model text for ObservationDetailView. Always a quiet external link: linked
+ * models go to their model definition, unlinked models to the model-settings
+ * list (which owns "create a definition" — the inline create dialog that used
+ * to open from here was a surprising click target in the header).
  */
 
-import { Badge } from "@/src/components/design-system/Badge/Badge";
-import { ExternalLinkIcon, PlusCircle } from "lucide-react";
+import { ExternalLinkIcon } from "lucide-react";
 import Link from "next/link";
-import { UpsertModelFormDialog } from "@/src/features/models/components/UpsertModelFormDialog/UpsertModelFormDialog";
 
 export function ModelBadge({
   model,
   internalModelId,
   projectId,
-  usageDetails,
 }: {
   model: string | null;
   internalModelId: string | null;
   projectId: string;
-  usageDetails: Record<string, number> | undefined;
 }) {
   if (!model) return null;
 
-  // Linked model - show link to model settings
-  if (internalModelId) {
-    return (
-      <Link
-        href={`/project/${projectId}/settings/models/${internalModelId}`}
-        className="inline-flex"
-        title="View model details"
-      >
-        <Badge text={model} trailingIcon={ExternalLinkIcon} />
-      </Link>
-    );
-  }
+  const href = internalModelId
+    ? `/project/${projectId}/settings/models/${internalModelId}`
+    : `/project/${projectId}/settings/models`;
 
-  // Unlinked model - show create form dialog
   return (
-    <UpsertModelFormDialog
-      action="create"
-      projectId={projectId}
-      prefilledModelData={{
-        modelName: model,
-        prices:
-          usageDetails && Object.keys(usageDetails).length > 0
-            ? Object.keys(usageDetails)
-                .filter((key) => key !== "total")
-                .reduce(
-                  (acc, key) => {
-                    acc[key] = 0.000001;
-                    return acc;
-                  },
-                  {} as Record<string, number>,
-                )
-            : undefined,
-      }}
+    <Link
+      href={href}
+      className="text-muted-foreground hover:text-foreground inline-flex max-w-48 items-center gap-1 text-xs hover:underline"
+      title={
+        internalModelId
+          ? "View model details"
+          : "Model has no pricing definition — view model settings"
+      }
     >
-      <button type="button" className="inline-flex cursor-pointer">
-        <Badge text={model} trailingIcon={PlusCircle} />
-      </button>
-    </UpsertModelFormDialog>
+      <span className="truncate" title={model}>
+        {model}
+      </span>
+      <ExternalLinkIcon className="size-3 shrink-0" aria-hidden />
+    </Link>
   );
 }

--- a/web/src/features/traces/components/ObservationDetailView/components/ModelParametersBadges.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ModelParametersBadges.tsx
@@ -5,7 +5,6 @@
  */
 
 import { type JsonNested } from "@langfuse/shared";
-import { Badge } from "@/src/components/design-system/Badge/Badge";
 
 export function ModelParametersBadges({
   modelParameters,
@@ -37,8 +36,15 @@ export function ModelParametersBadges({
 
         const text = `${key}: ${valueString}`;
         return (
-          <span key={key} className="inline-flex max-w-md">
-            <Badge text={text} title={text} />
+          <span
+            key={key}
+            title={text}
+            className="text-muted-foreground inline-flex max-w-md truncate text-xs"
+          >
+            {key}:{" "}
+            <span className="text-foreground/80 truncate" title={text}>
+              {valueString}
+            </span>
           </span>
         );
       })}

--- a/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx
@@ -27,7 +27,20 @@ import { AnnotateDrawerController } from "@/src/features/scores/components/Annot
 import { CommentDrawerController } from "@/src/features/comments/CommentDrawerController";
 import { AnnotationQueueItemDropdownMenuController } from "@/src/features/annotation-queues/components/AnnotationQueueItemDropdownMenuController";
 import { AnnotationQueueItemCountBadge } from "@/src/features/annotation-queues/components/AnnotationQueueItemCountBadge";
-import { JumpToPlaygroundDropdownMenuController } from "@/src/features/playground/page/components/JumpToPlaygroundDropdownMenuController";
+import {
+  JumpToPlaygroundDropdownMenuController,
+  useJumpToPlayground,
+} from "@/src/features/playground/page/components/JumpToPlaygroundDropdownMenuController";
+import { JumpToPlaygroundMenu } from "@/src/features/playground/page/components/JumpToPlaygroundMenu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/src/components/ui/dropdown-menu";
 import { PromptBadge } from "@/src/features/traces/components/PromptBadge";
 import {
   LatencyBadge,
@@ -37,13 +50,10 @@ import {
   VersionBadge,
 } from "@/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple";
 import { ObservationLevelBadge } from "@/src/features/traces/components/ObservationLevelBadge";
-import {
-  SessionBadge,
-  UserIdBadge,
-} from "@/src/features/traces/components/TraceMetadataBadges";
 import { EvaluatorBadge } from "@/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/components/EvaluatorBadge/EvaluatorBadge";
 import {
   CostBadge,
+  hasRenderableUsage,
   UsageBadge,
 } from "@/src/features/traces/components/ObservationMetadataBadgesTooltip";
 import { ModelBadge } from "@/src/features/traces/components/ObservationDetailView/components/ModelBadge";
@@ -62,6 +72,7 @@ import { Button } from "@/src/components/ui/button";
 import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-badge";
 import {
   ChevronDown,
+  Database,
   EllipsisVertical,
   ListPlus,
   LockIcon,
@@ -160,6 +171,23 @@ export const ObservationDetailViewHeader = memo(
     const datasetCount = existingDatasetItems.length;
     const hasExistingDatasetItems = datasetCount > 0;
 
+    // Playground availability for the combined "Add to" menu. The hook must
+    // run unconditionally; without IO it resolves to unavailable.
+    const playground = useJumpToPlayground({
+      source: "generation",
+      generation: observationWithIO ?? {
+        ...observation,
+        traceId: observation.traceId ?? null,
+        input: null,
+        output: null,
+        metadata: null,
+      },
+      analyticsEventName: "trace_detail:test_in_playground_button_click",
+    });
+    const showPlaygroundEntry = Boolean(
+      observationWithIO && isGenerationLike(observationWithIO.type),
+    );
+
     // Format cost and usage values
     const totalCost = observation.totalCost;
     const totalUsage = observation.totalUsage;
@@ -193,14 +221,14 @@ export const ObservationDetailViewHeader = memo(
       subtreeMetrics?.costDetails ?? observation.costDetails;
 
     return (
-      <div className="@container shrink-0 space-y-2 border-b p-2">
+      <div className="@container shrink-0 space-y-2 p-3">
         {/* Title row with actions */}
         <div className="grid w-full grid-cols-1 items-start gap-2 @2xl:grid-cols-[auto_auto] @2xl:justify-between">
           <div className="flex w-full flex-row items-center gap-1">
-            <ItemBadge type={observation.type as ObservationType} isSmall />
+            <ItemBadge type={observation.type as ObservationType} />
             <span
               className={cn(
-                "mb-0 line-clamp-2 min-w-0 font-bold break-all md:break-normal md:wrap-break-word",
+                "mb-0 line-clamp-2 min-w-0 text-base font-bold break-all md:break-normal md:wrap-break-word",
                 isMobile && "flex-1",
               )}
             >
@@ -462,7 +490,7 @@ export const ObservationDetailViewHeader = memo(
                         ) : (
                           <MessageSquare className="h-4 w-4" />
                         )}
-                        <span className="text-sm">Add comment</span>
+                        <span className="text-sm">Comment</span>
                         {!disabled && commentCount ? (
                           <ActionButtonCountBadge count={commentCount} />
                         ) : null}
@@ -495,38 +523,64 @@ export const ObservationDetailViewHeader = memo(
                     >
                       {({ Anchor, openDropdown }) => (
                         <Anchor>
-                          <Button
-                            variant="secondary"
-                            size="sm"
-                            disabled={!hasDatasetAccess}
-                            onClick={() => {
-                              if (hasExistingDatasetItems) {
-                                openDropdown();
-                                return;
-                              }
-
-                              captureNewDatasetItemFormOpen();
-                              openDialog();
-                            }}
-                          >
-                            {!hasExistingDatasetItems && hasDatasetAccess ? (
-                              <PlusIcon
-                                className="mr-1.5 -ml-0.5 h-3.5 w-3.5"
-                                aria-hidden="true"
-                              />
-                            ) : null}
-                            {hasExistingDatasetItems
-                              ? `In ${datasetCount} dataset(s)`
-                              : "Add to datasets"}
-                            {hasExistingDatasetItems ? (
-                              <ChevronDown className="ml-2 h-3 w-3" />
-                            ) : !hasDatasetAccess ? (
-                              <LockIcon
-                                className="ml-1.5 h-3 w-3"
-                                aria-hidden="true"
-                              />
-                            ) : null}
-                          </Button>
+                          {/* One "Add to" menu for the send-this-somewhere verbs
+                              (dataset, playground). */}
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button variant="secondary" size="sm">
+                                <PlusIcon
+                                  className="mr-1.5 -ml-0.5 h-3.5 w-3.5"
+                                  aria-hidden="true"
+                                />
+                                Add to
+                                <ChevronDown className="ml-2 h-3 w-3" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              <DropdownMenuItem
+                                disabled={!hasDatasetAccess}
+                                onSelect={() => {
+                                  if (hasExistingDatasetItems) {
+                                    openDropdown();
+                                    return;
+                                  }
+                                  captureNewDatasetItemFormOpen();
+                                  openDialog();
+                                }}
+                              >
+                                <Database className="mr-2 h-4 w-4" />
+                                {hasExistingDatasetItems
+                                  ? `Dataset — in ${datasetCount}`
+                                  : "Dataset"}
+                                {!hasDatasetAccess && (
+                                  <LockIcon className="ml-auto h-3 w-3" />
+                                )}
+                              </DropdownMenuItem>
+                              {showPlaygroundEntry && (
+                                <DropdownMenuSub>
+                                  <DropdownMenuSubTrigger
+                                    disabled={!playground.isAvailable}
+                                    title={playground.tooltipMessage}
+                                  >
+                                    <Terminal className="mr-2 h-4 w-4" />
+                                    Playground
+                                  </DropdownMenuSubTrigger>
+                                  <DropdownMenuSubContent>
+                                    <JumpToPlaygroundMenu
+                                      source="generation"
+                                      includeOutput={playground.includeOutput}
+                                      onIncludeOutputChange={
+                                        playground.setIncludeOutput
+                                      }
+                                      onPlaygroundAction={
+                                        playground.handlePlaygroundAction
+                                      }
+                                    />
+                                  </DropdownMenuSubContent>
+                                </DropdownMenuSub>
+                              )}
+                            </DropdownMenuContent>
+                          </DropdownMenu>
                         </Anchor>
                       )}
                     </ExistingDatasetItemsDropdownMenuController>
@@ -608,9 +662,9 @@ export const ObservationDetailViewHeader = memo(
                         variant="secondary"
                         size="sm"
                         disabled={disabled !== undefined}
-                        className="rounded-l-none rounded-r-md border-l-2"
+                        className="rounded-l-none rounded-r-md border-l px-1.5"
                       >
-                        <span className="relative mr-1 text-xs">
+                        <span className="relative text-xs">
                           <ChevronDown className="h-3 w-3" />
                           {totalCount > 0 && (
                             <AnnotationQueueItemCountBadge
@@ -624,35 +678,6 @@ export const ObservationDetailViewHeader = memo(
                   </AnnotationQueueItemDropdownMenuController>
                 </div>
               )}
-              {observationWithIO &&
-                isGenerationLike(observationWithIO.type) && (
-                  <JumpToPlaygroundDropdownMenuController
-                    source="generation"
-                    generation={observationWithIO}
-                    analyticsEventName="trace_detail:test_in_playground_button_click"
-                  >
-                    {({ Trigger, disabled, title }) => (
-                      <Trigger asChild>
-                        <Button
-                          variant="secondary"
-                          size="sm"
-                          disabled={disabled}
-                          title={title}
-                          className={cn(
-                            "flex items-center gap-1",
-                            disabled
-                              ? "cursor-not-allowed opacity-50"
-                              : "cursor-pointer",
-                          )}
-                        >
-                          <Terminal className="h-3.5 w-3.5" />
-                          <span className="hidden md:inline">Playground</span>
-                          <ChevronDown className="h-3 w-3" />
-                        </Button>
-                      </Trigger>
-                    )}
-                  </JumpToPlaygroundDropdownMenuController>
-                )}
               <CommentDrawerController
                 projectId={projectId}
                 objectId={observation.id}
@@ -677,7 +702,7 @@ export const ObservationDetailViewHeader = memo(
                     ) : (
                       <>
                         <MessageSquare className="h-3.5 w-3.5" />
-                        <span>Add comment</span>
+                        <span>Comment</span>
                         {!!commentCount ? (
                           <ActionButtonCountBadge count={commentCount} />
                         ) : null}
@@ -690,39 +715,28 @@ export const ObservationDetailViewHeader = memo(
           )}
         </div>
 
-        {/* Metadata badges */}
+        {/* Timestamp on its own line: sharing the title row broke with long
+            observation names. */}
+        {preparedDate ? (
+          <div
+            title={preparedDate.title}
+            className="text-muted-foreground text-xs"
+          >
+            {preparedDate.display}
+          </div>
+        ) : null}
 
         <div className="flex flex-col gap-2">
-          {/* Timestamp */}
-          {preparedDate ? (
-            <div className="flex flex-wrap items-center gap-1 text-sm">
-              <span title={preparedDate.title}>{preparedDate.display}</span>
-            </div>
-          ) : null}
-
           {/* Other badges */}
           {!isAnnotationMode && (
             <CollapsibleBadgeRow>
+              {/* Measured metrics, then user-supplied context, then specialty
+                  badges. Session/user render once in the TraceSummaryStrip —
+                  in v4 every observation carries the trace's values. */}
               <LatencyBadge latencySeconds={latencySeconds} />
               <TimeToFirstTokenBadge
                 timeToFirstToken={observation.timeToFirstToken}
               />
-              <SessionBadge
-                sessionId={observation.sessionId ?? null}
-                projectId={projectId}
-              />
-              <UserIdBadge
-                userId={observation.userId ?? null}
-                projectId={projectId}
-              />
-              <EvaluatorBadge
-                evaluatorId={evaluatorId}
-                evaluatorName={evaluator.data?.name}
-                environment={observation.environment}
-                projectId={projectId}
-              />
-              <EnvironmentBadge environment={observation.environment} />
-              <ReleaseBadge release={observation.release} />
               {displayedTotalCost != null && displayedCostDetails && (
                 <CostBadge
                   totalCost={displayedTotalCost}
@@ -749,7 +763,13 @@ export const ObservationDetailViewHeader = memo(
               )}
               {subtreeMetrics
                 ? subtreeMetrics.hasGenerationLike &&
-                  subtreeMetrics.usageDetails && (
+                  subtreeMetrics.usageDetails &&
+                  hasRenderableUsage({
+                    inputUsage: subtreeMetrics.inputUsage,
+                    outputUsage: subtreeMetrics.outputUsage,
+                    totalUsage: subtreeMetrics.totalUsage,
+                    usageDetails: subtreeMetrics.usageDetails,
+                  }) && (
                     <UsageBadge
                       inputUsage={subtreeMetrics.inputUsage}
                       outputUsage={subtreeMetrics.outputUsage}
@@ -758,7 +778,13 @@ export const ObservationDetailViewHeader = memo(
                     />
                   )
                 : isGenerationLike(observation.type) &&
-                  observation.usageDetails && (
+                  observation.usageDetails &&
+                  hasRenderableUsage({
+                    inputUsage,
+                    outputUsage,
+                    totalUsage,
+                    usageDetails: observation.usageDetails,
+                  }) && (
                     <UsageBadge
                       inputUsage={inputUsage}
                       outputUsage={outputUsage}
@@ -766,12 +792,19 @@ export const ObservationDetailViewHeader = memo(
                       usageDetails={observation.usageDetails}
                     />
                   )}
-              <VersionBadge version={observation.version} />
               <ModelBadge
                 model={observation.model}
                 internalModelId={observation.internalModelId}
                 projectId={projectId}
-                usageDetails={observation.usageDetails}
+              />
+              <EnvironmentBadge environment={observation.environment} />
+              <ReleaseBadge release={observation.release} />
+              <VersionBadge version={observation.version} />
+              <EvaluatorBadge
+                evaluatorId={evaluatorId}
+                evaluatorName={evaluator.data?.name}
+                environment={observation.environment}
+                projectId={projectId}
               />
               <ModelParametersBadges
                 modelParameters={observation.modelParameters}

--- a/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx
@@ -809,9 +809,19 @@ export const ObservationDetailViewHeader = memo(
                 internalModelId={observation.internalModelId}
                 projectId={projectId}
               />
-              <EnvironmentBadge environment={observation.environment} />
-              <ReleaseBadge release={observation.release} />
-              <VersionBadge version={observation.version} />
+              {/* env/release/version render only when they DIFFER from the
+                  trace's (a differing value is signal — e.g. an observation
+                  from another release); the inherited common case is already
+                  shown once in the TraceSummaryStrip. */}
+              {observation.environment !== trace.environment && (
+                <EnvironmentBadge environment={observation.environment} />
+              )}
+              {observation.release !== trace.release && (
+                <ReleaseBadge release={observation.release} />
+              )}
+              {observation.version !== trace.version && (
+                <VersionBadge version={observation.version} />
+              )}
               <EvaluatorBadge
                 evaluatorId={evaluatorId}
                 evaluatorName={evaluator.data?.name}

--- a/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx
@@ -171,21 +171,28 @@ export const ObservationDetailViewHeader = memo(
     const datasetCount = existingDatasetItems.length;
     const hasExistingDatasetItems = datasetCount > 0;
 
-    // Playground availability for the combined "Add to" menu. The hook must
-    // run unconditionally; without IO it resolves to unavailable.
-    const playground = useJumpToPlayground({
-      source: "generation",
-      generation: observationWithIO ?? {
-        ...observation,
-        traceId: observation.traceId ?? null,
-        input: null,
-        output: null,
-        metadata: null,
-      },
-      analyticsEventName: "trace_detail:test_in_playground_button_click",
-    });
+    // Playground availability for the combined "Add to" menu. Only
+    // generation-like observations offer the Playground entry — matching
+    // that, gate the hook's internal API key query off for the rest so a
+    // span/event doesn't fetch LLM API keys it will never use. The hook
+    // itself must still run unconditionally (rules of hooks); without IO it
+    // resolves to unavailable.
     const showPlaygroundEntry = Boolean(
       observationWithIO && isGenerationLike(observationWithIO.type),
+    );
+    const playground = useJumpToPlayground(
+      {
+        source: "generation",
+        generation: observationWithIO ?? {
+          ...observation,
+          traceId: observation.traceId ?? null,
+          input: null,
+          output: null,
+          metadata: null,
+        },
+        analyticsEventName: "trace_detail:test_in_playground_button_click",
+      },
+      { enabled: showPlaygroundEntry },
     );
 
     // Format cost and usage values

--- a/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx
@@ -522,10 +522,15 @@ export const ObservationDetailViewHeader = memo(
                       onOpenDialog={openDialog}
                     >
                       {({ Anchor, openDropdown }) => (
-                        <Anchor>
-                          {/* One "Add to" menu for the send-this-somewhere verbs
-                              (dataset, playground). */}
-                          <DropdownMenu>
+                        // One "Add to" menu for the send-this-somewhere verbs
+                        // (dataset, playground). Anchor must wrap only the
+                        // real DOM trigger, not this whole DropdownMenu: the
+                        // menu root is a context provider with no DOM node of
+                        // its own, so anchoring it left the existing-items
+                        // menu anchorless whenever the observation already
+                        // had dataset items.
+                        <DropdownMenu>
+                          <Anchor>
                             <DropdownMenuTrigger asChild>
                               <Button variant="secondary" size="sm">
                                 <PlusIcon
@@ -536,52 +541,52 @@ export const ObservationDetailViewHeader = memo(
                                 <ChevronDown className="ml-2 h-3 w-3" />
                               </Button>
                             </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem
-                                disabled={!hasDatasetAccess}
-                                onSelect={() => {
-                                  if (hasExistingDatasetItems) {
-                                    openDropdown();
-                                    return;
-                                  }
-                                  captureNewDatasetItemFormOpen();
-                                  openDialog();
-                                }}
-                              >
-                                <Database className="mr-2 h-4 w-4" />
-                                {hasExistingDatasetItems
-                                  ? `Dataset — in ${datasetCount}`
-                                  : "Dataset"}
-                                {!hasDatasetAccess && (
-                                  <LockIcon className="ml-auto h-3 w-3" />
-                                )}
-                              </DropdownMenuItem>
-                              {showPlaygroundEntry && (
-                                <DropdownMenuSub>
-                                  <DropdownMenuSubTrigger
-                                    disabled={!playground.isAvailable}
-                                    title={playground.tooltipMessage}
-                                  >
-                                    <Terminal className="mr-2 h-4 w-4" />
-                                    Playground
-                                  </DropdownMenuSubTrigger>
-                                  <DropdownMenuSubContent>
-                                    <JumpToPlaygroundMenu
-                                      source="generation"
-                                      includeOutput={playground.includeOutput}
-                                      onIncludeOutputChange={
-                                        playground.setIncludeOutput
-                                      }
-                                      onPlaygroundAction={
-                                        playground.handlePlaygroundAction
-                                      }
-                                    />
-                                  </DropdownMenuSubContent>
-                                </DropdownMenuSub>
+                          </Anchor>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              disabled={!hasDatasetAccess}
+                              onSelect={() => {
+                                if (hasExistingDatasetItems) {
+                                  openDropdown();
+                                  return;
+                                }
+                                captureNewDatasetItemFormOpen();
+                                openDialog();
+                              }}
+                            >
+                              <Database className="mr-2 h-4 w-4" />
+                              {hasExistingDatasetItems
+                                ? `Dataset — in ${datasetCount}`
+                                : "Dataset"}
+                              {!hasDatasetAccess && (
+                                <LockIcon className="ml-auto h-3 w-3" />
                               )}
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </Anchor>
+                            </DropdownMenuItem>
+                            {showPlaygroundEntry && (
+                              <DropdownMenuSub>
+                                <DropdownMenuSubTrigger
+                                  disabled={!playground.isAvailable}
+                                  title={playground.tooltipMessage}
+                                >
+                                  <Terminal className="mr-2 h-4 w-4" />
+                                  Playground
+                                </DropdownMenuSubTrigger>
+                                <DropdownMenuSubContent>
+                                  <JumpToPlaygroundMenu
+                                    source="generation"
+                                    includeOutput={playground.includeOutput}
+                                    onIncludeOutputChange={
+                                      playground.setIncludeOutput
+                                    }
+                                    onPlaygroundAction={
+                                      playground.handlePlaygroundAction
+                                    }
+                                  />
+                                </DropdownMenuSubContent>
+                              </DropdownMenuSub>
+                            )}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
                       )}
                     </ExistingDatasetItemsDropdownMenuController>
                   )}

--- a/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/components/EvaluatorBadge/EvaluatorBadge.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/components/EvaluatorBadge/EvaluatorBadge.tsx
@@ -3,8 +3,6 @@ import { LangfuseInternalTraceEnvironment } from "@langfuse/shared";
 import { ExternalLinkIcon } from "lucide-react";
 import Link from "next/link";
 
-import { Badge } from "@/src/components/design-system/Badge/Badge";
-
 export function EvaluatorBadge({
   evaluatorId,
   evaluatorName,
@@ -27,12 +25,16 @@ export function EvaluatorBadge({
       href={`/project/${projectId}/evals/v2/${encodeURIComponent(evaluatorId)}`}
       target="_blank"
       rel="noopener noreferrer"
-      className="ph-no-capture inline-flex"
+      title={evaluatorName ? `Evaluator: ${evaluatorName}` : "Evaluator"}
+      className="ph-no-capture text-muted-foreground hover:text-foreground inline-flex max-w-48 items-center gap-1 text-xs hover:underline"
     >
-      <Badge
-        text={evaluatorName ? `Evaluator: ${evaluatorName}` : "Evaluator"}
-        trailingIcon={ExternalLinkIcon}
-      />
+      <span
+        className="truncate"
+        title={evaluatorName ? `Evaluator: ${evaluatorName}` : "Evaluator"}
+      >
+        {evaluatorName ? `Evaluator: ${evaluatorName}` : "Evaluator"}
+      </span>
+      <ExternalLinkIcon className="size-3 shrink-0" aria-hidden />
     </Link>
   );
 }

--- a/web/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple.clienttest.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple.clienttest.tsx
@@ -3,10 +3,11 @@ import { render, screen } from "@testing-library/react";
 import { ReleaseBadge } from "./ObservationMetadataBadgesSimple";
 
 describe("ReleaseBadge", () => {
-  it("shows an observation release", () => {
-    render(<ReleaseBadge release="181" />);
+  it("shows an observation release as key-value text", () => {
+    const { container } = render(<ReleaseBadge release="181" />);
 
-    expect(screen.getByText("Release: 181")).toBeInTheDocument();
+    expect(screen.getByText("181")).toBeInTheDocument();
+    expect(container).toHaveTextContent("release: 181");
   });
 
   it("hides when no release is available", () => {

--- a/web/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple.clienttest.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple.clienttest.tsx
@@ -3,11 +3,14 @@ import { render, screen } from "@testing-library/react";
 import { ReleaseBadge } from "./ObservationMetadataBadgesSimple";
 
 describe("ReleaseBadge", () => {
-  it("shows an observation release as key-value text", () => {
+  it("shows an observation release as a session-header-style pill", () => {
     const { container } = render(<ReleaseBadge release="181" />);
 
     expect(screen.getByText("181")).toBeInTheDocument();
-    expect(container).toHaveTextContent("release: 181");
+    expect(container).toHaveTextContent("release 181");
+    expect(
+      container.querySelector('[data-session-header-pill="true"]'),
+    ).not.toBeNull();
   });
 
   it("hides when no release is available", () => {

--- a/web/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple.tsx
@@ -1,10 +1,16 @@
 /* eslint-disable @repo/no-null-render */
 /**
- * Simple metadata badges for ObservationDetailView
- * Each badge handles its own null checks and returns null when data is unavailable
+ * Metadata text for the trace/observation headers and the trace summary strip.
+ *
+ * Two visual tiers, deliberately NOT chips (chips are for user-defined tags):
+ * - Measured metrics (latency, TTFT): plain muted text — measurements read as
+ *   typography, importance maps to visual weight.
+ * - User-supplied context (env, release, version): muted `key: value` text,
+ *   rendered only when set.
+ * Each element handles its own null checks and returns null when unavailable.
  */
 
-import { Badge } from "@/src/components/design-system/Badge/Badge";
+import { Clock } from "lucide-react";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 
 export function LatencyBadge({
@@ -14,7 +20,15 @@ export function LatencyBadge({
 }) {
   if (latencySeconds == null) return null;
 
-  return <Badge text={`Latency: ${formatIntervalSeconds(latencySeconds)}`} />;
+  return (
+    <span
+      title="Latency"
+      className="text-muted-foreground inline-flex items-center gap-1 text-xs"
+    >
+      <Clock className="size-3 shrink-0" aria-hidden />
+      {formatIntervalSeconds(latencySeconds)}
+    </span>
+  );
 }
 
 export function TimeToFirstTokenBadge({
@@ -25,9 +39,25 @@ export function TimeToFirstTokenBadge({
   if (timeToFirstToken == null) return null;
 
   return (
-    <Badge
-      text={`Time to first token: ${formatIntervalSeconds(timeToFirstToken)}`}
-    />
+    <span title="Time to first token" className="text-muted-foreground text-xs">
+      TTFT {formatIntervalSeconds(timeToFirstToken)}
+    </span>
+  );
+}
+
+function KeyValueText({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null | undefined;
+}) {
+  if (!value) return null;
+
+  return (
+    <span className="text-muted-foreground text-xs">
+      {label}: <span className="text-foreground/80">{value}</span>
+    </span>
   );
 }
 
@@ -36,9 +66,7 @@ export function EnvironmentBadge({
 }: {
   environment: string | null | undefined;
 }) {
-  if (!environment) return null;
-
-  return <Badge text={`Env: ${environment}`} />;
+  return <KeyValueText label="env" value={environment} />;
 }
 
 export function ReleaseBadge({
@@ -46,9 +74,7 @@ export function ReleaseBadge({
 }: {
   release: string | null | undefined;
 }) {
-  if (!release) return null;
-
-  return <Badge text={`Release: ${release}`} />;
+  return <KeyValueText label="release" value={release} />;
 }
 
 export function VersionBadge({
@@ -56,7 +82,5 @@ export function VersionBadge({
 }: {
   version: string | null | undefined;
 }) {
-  if (!version) return null;
-
-  return <Badge text={`Version: ${version}`} />;
+  return <KeyValueText label="version" value={version} />;
 }

--- a/web/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple.tsx
@@ -1,16 +1,13 @@
 /* eslint-disable @repo/no-null-render */
 /**
- * Metadata text for the trace/observation headers and the trace summary strip.
- *
- * Two visual tiers, deliberately NOT chips (chips are for user-defined tags):
- * - Measured metrics (latency, TTFT): plain muted text — measurements read as
- *   typography, importance maps to visual weight.
- * - User-supplied context (env, release, version): muted `key: value` text,
- *   rendered only when set.
- * Each element handles its own null checks and returns null when unavailable.
+ * Metadata pills for the trace/observation headers and the trace summary
+ * strip. Rendered through the session header's pill primitive
+ * (`ModernSessionHeaderPill`) so trace and session chips share one style.
+ * Each element handles its own null checks and returns null when the
+ * underlying value is unavailable.
  */
 
-import { Clock } from "lucide-react";
+import { ModernSessionHeaderPill } from "@/src/components/session/ModernSessionHeaderPill";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 
 export function LatencyBadge({
@@ -21,13 +18,11 @@ export function LatencyBadge({
   if (latencySeconds == null) return null;
 
   return (
-    <span
-      title="Latency"
-      className="text-muted-foreground inline-flex items-center gap-1 text-xs"
-    >
-      <Clock className="size-3 shrink-0" aria-hidden />
-      {formatIntervalSeconds(latencySeconds)}
-    </span>
+    <ModernSessionHeaderPill variant="display" title="Latency">
+      <span className="text-foreground">
+        {formatIntervalSeconds(latencySeconds)}
+      </span>
+    </ModernSessionHeaderPill>
   );
 }
 
@@ -39,9 +34,12 @@ export function TimeToFirstTokenBadge({
   if (timeToFirstToken == null) return null;
 
   return (
-    <span title="Time to first token" className="text-muted-foreground text-xs">
-      TTFT {formatIntervalSeconds(timeToFirstToken)}
-    </span>
+    <ModernSessionHeaderPill variant="display" title="Time to first token">
+      ttft{" "}
+      <span className="text-foreground">
+        {formatIntervalSeconds(timeToFirstToken)}
+      </span>
+    </ModernSessionHeaderPill>
   );
 }
 
@@ -55,9 +53,12 @@ function KeyValueText({
   if (!value) return null;
 
   return (
-    <span className="text-muted-foreground text-xs">
-      {label}: <span className="text-foreground/80">{value}</span>
-    </span>
+    <ModernSessionHeaderPill variant="display">
+      {label}{" "}
+      <span className="text-foreground max-w-40 truncate" title={value}>
+        {value}
+      </span>
+    </ModernSessionHeaderPill>
   );
 }
 

--- a/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
@@ -1,15 +1,22 @@
 /**
- * Tooltip-based metadata badges for ObservationDetailView
- * These badges use BreakdownTooltip to show detailed cost/usage information
+ * Cost/usage metadata text for ObservationDetailView and the trace summary
+ * strip. Muted text (measurements are typography, not chips) with a dotted
+ * underline as the hover affordance; BreakdownTooltip carries the detail.
  */
 
-import { Badge, BadgeShell } from "@/src/components/design-system/Badge/Badge";
 import {
   BreakdownTooltip,
   type PriceSource,
 } from "@/src/features/traces/components/BreakdownTooltip";
-import { usdFormatter, formatTokenCounts } from "@/src/utils/numbers";
+import {
+  usdFormatter,
+  formatTokenCounts,
+  numberFormatter,
+} from "@/src/utils/numbers";
 import { InfoIcon } from "lucide-react";
+
+const METRIC_TEXT_CLASSES =
+  "text-muted-foreground inline-flex cursor-help items-center gap-1 text-xs";
 
 export function CostBadge({
   totalCost,
@@ -26,12 +33,19 @@ export function CostBadge({
       isCost={true}
       priceSource={priceSource}
     >
-      <Badge text={usdFormatter(totalCost)} trailingIcon={InfoIcon} />
+      <span className={METRIC_TEXT_CLASSES} title="Cost breakdown on hover">
+        {usdFormatter(totalCost)}
+      </span>
     </BreakdownTooltip>
   );
 }
 
-export function UsageBadge({
+/**
+ * Whether a usage object is worth rendering at all. Callers gate on this:
+ * an all-zero usage would otherwise render a bare info icon opening a
+ * breakdown of zeros.
+ */
+export function hasRenderableUsage({
   inputUsage,
   outputUsage,
   totalUsage,
@@ -41,22 +55,46 @@ export function UsageBadge({
   outputUsage: number;
   totalUsage: number;
   usageDetails: Record<string, number>;
-}) {
-  const tokenText = formatTokenCounts(
-    inputUsage,
-    outputUsage,
-    totalUsage,
-    true,
+}): boolean {
+  return (
+    totalUsage > 0 ||
+    inputUsage > 0 ||
+    outputUsage > 0 ||
+    Object.values(usageDetails).some((v) => v > 0)
   );
+}
+
+export function UsageBadge({
+  inputUsage,
+  outputUsage,
+  totalUsage,
+  usageDetails,
+  compact = false,
+}: {
+  inputUsage: number;
+  outputUsage: number;
+  totalUsage: number;
+  usageDetails: Record<string, number>;
+  /** Total only ("259 tok"), for the trace summary strip — the in→out split
+      lives in the breakdown tooltip. */
+  compact?: boolean;
+}) {
+  const tokenText = compact
+    ? totalUsage > 0
+      ? `∑ ${numberFormatter(totalUsage, 0)}`
+      : ""
+    : formatTokenCounts(inputUsage, outputUsage, totalUsage, true);
 
   return (
     <BreakdownTooltip details={usageDetails} isCost={false}>
       {tokenText ? (
-        <Badge text={tokenText} trailingIcon={InfoIcon} />
+        <span className={METRIC_TEXT_CLASSES} title="Usage breakdown on hover">
+          {tokenText}
+        </span>
       ) : (
-        <BadgeShell aria-label="View usage breakdown">
+        <span className={METRIC_TEXT_CLASSES} aria-label="View usage breakdown">
           <InfoIcon aria-hidden className="size-3" />
-        </BadgeShell>
+        </span>
       )}
     </BreakdownTooltip>
   );

--- a/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
@@ -1,9 +1,11 @@
 /**
- * Cost/usage metadata text for ObservationDetailView and the trace summary
- * strip. Muted text (measurements are typography, not chips) with a dotted
- * underline as the hover affordance; BreakdownTooltip carries the detail.
+ * Cost/usage metadata pills for ObservationDetailView and the trace summary
+ * strip. Rendered through the session header's pill primitive
+ * (`ModernSessionHeaderPill`); `BreakdownTooltip` carries the detail on
+ * hover/click and its trigger semantics are unchanged.
  */
 
+import { ModernSessionHeaderPill } from "@/src/components/session/ModernSessionHeaderPill";
 import {
   BreakdownTooltip,
   type PriceSource,
@@ -14,9 +16,6 @@ import {
   numberFormatter,
 } from "@/src/utils/numbers";
 import { InfoIcon } from "lucide-react";
-
-const METRIC_TEXT_CLASSES =
-  "text-muted-foreground inline-flex cursor-help items-center gap-1 text-xs";
 
 export function CostBadge({
   totalCost,
@@ -33,9 +32,12 @@ export function CostBadge({
       isCost={true}
       priceSource={priceSource}
     >
-      <span className={METRIC_TEXT_CLASSES} title="Cost breakdown on hover">
-        {usdFormatter(totalCost)}
-      </span>
+      <ModernSessionHeaderPill
+        variant="display"
+        title="Cost breakdown on hover"
+      >
+        cost <span className="text-foreground">{usdFormatter(totalCost)}</span>
+      </ModernSessionHeaderPill>
     </BreakdownTooltip>
   );
 }
@@ -108,9 +110,16 @@ export function UsageBadge({
 
     return (
       <BreakdownTooltip details={usageDetails} isCost={false}>
-        <span className={METRIC_TEXT_CLASSES} title="Usage breakdown on hover">
-          {`∑ ${numberFormatter(compactTotal, 0)}`}
-        </span>
+        <ModernSessionHeaderPill
+          variant="display"
+          title="Usage breakdown on hover"
+        >
+          tokens{" "}
+          <span className="text-foreground">
+            {numberFormatter(inputUsage, 0)} → {numberFormatter(outputUsage, 0)}{" "}
+            (∑ {numberFormatter(compactTotal, 0)})
+          </span>
+        </ModernSessionHeaderPill>
       </BreakdownTooltip>
     );
   }
@@ -125,13 +134,18 @@ export function UsageBadge({
   return (
     <BreakdownTooltip details={usageDetails} isCost={false}>
       {tokenText ? (
-        <span className={METRIC_TEXT_CLASSES} title="Usage breakdown on hover">
-          {tokenText}
-        </span>
+        <ModernSessionHeaderPill
+          variant="display"
+          title="Usage breakdown on hover"
+        >
+          <span className="text-foreground">{tokenText}</span>
+        </ModernSessionHeaderPill>
       ) : (
-        <span className={METRIC_TEXT_CLASSES} aria-label="View usage breakdown">
-          <InfoIcon aria-hidden className="size-3" />
-        </span>
+        <ModernSessionHeaderPill variant="display">
+          <span aria-label="View usage breakdown">
+            <InfoIcon aria-hidden className="size-3" />
+          </span>
+        </ModernSessionHeaderPill>
       )}
     </BreakdownTooltip>
   );

--- a/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
@@ -64,6 +64,24 @@ export function hasRenderableUsage({
   );
 }
 
+/**
+ * The single number the compact `UsageBadge` shows. `totalUsage` can be 0
+ * while the in→out split still carries real numbers (e.g. usage recorded
+ * only per-direction) — fall back to their sum rather than showing a
+ * misleadingly empty total for a generation that does have usage.
+ */
+export function getCompactUsageTotal({
+  inputUsage,
+  outputUsage,
+  totalUsage,
+}: {
+  inputUsage: number;
+  outputUsage: number;
+  totalUsage: number;
+}): number {
+  return totalUsage > 0 ? totalUsage : inputUsage + outputUsage;
+}
+
 export function UsageBadge({
   inputUsage,
   outputUsage,
@@ -79,11 +97,30 @@ export function UsageBadge({
       lives in the breakdown tooltip. */
   compact?: boolean;
 }) {
-  const tokenText = compact
-    ? totalUsage > 0
-      ? `∑ ${numberFormatter(totalUsage, 0)}`
-      : ""
-    : formatTokenCounts(inputUsage, outputUsage, totalUsage, true);
+  if (compact) {
+    // Callers gate compact rendering on getCompactUsageTotal(...) > 0, same
+    // as this — see TraceSummaryStrip.
+    const compactTotal = getCompactUsageTotal({
+      inputUsage,
+      outputUsage,
+      totalUsage,
+    });
+
+    return (
+      <BreakdownTooltip details={usageDetails} isCost={false}>
+        <span className={METRIC_TEXT_CLASSES} title="Usage breakdown on hover">
+          {`∑ ${numberFormatter(compactTotal, 0)}`}
+        </span>
+      </BreakdownTooltip>
+    );
+  }
+
+  const tokenText = formatTokenCounts(
+    inputUsage,
+    outputUsage,
+    totalUsage,
+    true,
+  );
 
   return (
     <BreakdownTooltip details={usageDetails} isCost={false}>

--- a/web/src/features/traces/components/PromptBadge.tsx
+++ b/web/src/features/traces/components/PromptBadge.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @repo/no-null-render */
 import Link from "next/link";
 import { ExternalLinkIcon } from "lucide-react";
-import { Badge } from "@/src/components/design-system/Badge/Badge";
 import { api } from "@/src/utils/api";
 
 export const PromptBadge = (props: { promptId: string; projectId: string }) => {
@@ -12,14 +11,18 @@ export const PromptBadge = (props: { promptId: string; projectId: string }) => {
 
   if (prompt.isLoading || !prompt.data) return null;
 
-  const text = `Prompt: ${prompt.data.name} - v${prompt.data.version}`;
+  const text = `${prompt.data.name} v${prompt.data.version}`;
 
   return (
     <Link
       href={`/project/${props.projectId}/prompts/${encodeURIComponent(prompt.data.name)}?version=${prompt.data.version}`}
-      className="inline-flex"
+      title={`Prompt: ${text}`}
+      className="text-muted-foreground hover:text-foreground inline-flex max-w-48 items-center gap-1 text-xs hover:underline"
     >
-      <Badge text={text} trailingIcon={ExternalLinkIcon} />
+      <span className="truncate" title={`Prompt: ${text}`}>
+        {text}
+      </span>
+      <ExternalLinkIcon className="size-3 shrink-0" aria-hidden />
     </Link>
   );
 };

--- a/web/src/features/traces/components/Trace.tsx
+++ b/web/src/features/traces/components/Trace.tsx
@@ -28,6 +28,7 @@ import { TraceTimelineCompact } from "@/src/features/traces/components/TraceTime
 import { useIsMobile } from "@/src/hooks/use-mobile";
 import { useTraceComments } from "@/src/features/traces/hooks/useTraceComments";
 import { TraceGraphView } from "@/src/features/traces/components/TraceGraphView/TraceGraphView";
+import { TraceSummaryStrip } from "@/src/features/traces/components/TraceSummaryStrip";
 
 import { useMemo } from "react";
 
@@ -36,6 +37,7 @@ export type TraceProps = {
   trace: Omit<WithStringifiedMetadata<TraceDomain>, "input" | "output"> & {
     input: string | null;
     output: string | null;
+    latency?: number;
   };
   scores: WithStringifiedMetadata<ScoreDomain>[];
   corrections: ScoreDomain[];
@@ -189,17 +191,24 @@ function TraceWithSelection({
  */
 function TraceContent({ desktopLayout }: { desktopLayout: DesktopLayout }) {
   const isMobile = useIsMobile();
-  const { showGraph } = useViewPreferences();
+  const { showGraph, isAnnotationMode } = useViewPreferences();
   const { isGraphViewAvailable } = useTraceGraphData();
   const shouldShowGraph = showGraph && isGraphViewAvailable;
 
-  return isMobile ? (
-    <MobileTraceContent shouldShowGraph={shouldShowGraph} />
-  ) : (
-    <DesktopTraceContent
-      shouldShowGraph={shouldShowGraph}
-      desktopLayout={desktopLayout}
-    />
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {!isAnnotationMode && <TraceSummaryStrip />}
+      <div className="min-h-0 flex-1">
+        {isMobile ? (
+          <MobileTraceContent shouldShowGraph={shouldShowGraph} />
+        ) : (
+          <DesktopTraceContent
+            shouldShowGraph={shouldShowGraph}
+            desktopLayout={desktopLayout}
+          />
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/web/src/features/traces/components/Trace.tsx
+++ b/web/src/features/traces/components/Trace.tsx
@@ -191,13 +191,15 @@ function TraceWithSelection({
  */
 function TraceContent({ desktopLayout }: { desktopLayout: DesktopLayout }) {
   const isMobile = useIsMobile();
-  const { showGraph, isAnnotationMode } = useViewPreferences();
+  const { showGraph } = useViewPreferences();
   const { isGraphViewAvailable } = useTraceGraphData();
   const shouldShowGraph = showGraph && isGraphViewAvailable;
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      {!isAnnotationMode && <TraceSummaryStrip />}
+      {/* Trace-level attributes (tags included) have their only home here —
+          annotation mode still needs them, so the strip is not gated on it. */}
+      <TraceSummaryStrip />
       <div className="min-h-0 flex-1">
         {isMobile ? (
           <MobileTraceContent shouldShowGraph={shouldShowGraph} />

--- a/web/src/features/traces/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/features/traces/components/TraceDetailView/TraceDetailView.tsx
@@ -12,6 +12,7 @@ import {
   TabsBarTrigger,
 } from "@/src/components/ui/tabs-bar";
 import { Tabs } from "@/src/components/design-system/Tabs/Tabs";
+import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-badge";
 import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { useCallback, useMemo, useState } from "react";
 import { type SelectionData } from "@/src/features/comments/contexts/InlineCommentSelectionContext";
@@ -30,7 +31,6 @@ import {
 
 // Preview tab components
 import { IOPreview } from "@/src/features/traces/components/IOPreview/IOPreview";
-import TagList from "@/src/features/tag/components/TagList";
 import { useJsonExpansion } from "@/src/features/traces/contexts/JsonExpansionContext";
 import { useMedia } from "@/src/features/traces/hooks/useMedia";
 import { useParsedTrace } from "@/src/hooks/useParsedTrace";
@@ -114,9 +114,6 @@ export function TraceDetailView({
 
   // Map jsonViewPreference to currentView format expected by child components
   const currentView = jsonViewPreference;
-  // Both formatted variants share the pretty layout; JSON views differ.
-  const isPrettyLikeView =
-    currentView === "pretty" || currentView === "pretty-beta";
 
   // A persisted "pretty-beta" preference clamps to "pretty" when the beta
   // tab is unavailable, so the highlighted tab matches the rendered parser.
@@ -291,7 +288,15 @@ export function TraceDetailView({
                 </TabsBarTrigger>
               )}
               {showScoresTab && (
-                <TabsBarTrigger value="scores">Scores</TabsBarTrigger>
+                <TabsBarTrigger value="scores" className="gap-1">
+                  Scores
+                  {/* All scores of the trace (incl. observation-level) — the
+                      count must match what the tab's table lists. */}
+                  <ActionButtonCountBadge
+                    count={scores.length}
+                    variant="muted"
+                  />
+                </TabsBarTrigger>
               )}
 
               {/* View toggle (Formatted/JSON) - show for preview and log tabs when pretty view available */}
@@ -399,21 +404,7 @@ export function TraceDetailView({
                 : "overflow-auto pb-4"
             }`}
           >
-            {/* Tags Section - scrolls with content except in JSON Beta (virtualized) */}
-            {trace.tags.length > 0 && (
-              <>
-                <div
-                  className={`px-2 pt-2 text-sm font-bold ${!isPrettyLikeView ? "shrink-0" : ""}`}
-                >
-                  Tags
-                </div>
-                <div
-                  className={`flex flex-wrap gap-x-1 gap-y-1 px-2 pb-2 ${!isPrettyLikeView ? "shrink-0" : ""}`}
-                >
-                  <TagList selectedTags={trace.tags} isLoading={false} />
-                </div>
-              </>
-            )}
+            {/* Tags render in the persistent TraceSummaryStrip, not here. */}
 
             {/* I/O Preview (includes metadata in both views) */}
             <IOPreview

--- a/web/src/features/traces/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/features/traces/components/TraceDetailView/TraceDetailView.tsx
@@ -251,7 +251,6 @@ export function TraceDetailView({
       {/* Header section (extracted component) */}
       <TraceDetailViewHeader
         trace={trace}
-        observations={observations}
         parsedMetadata={parsedMetadata}
         projectId={projectId}
         traceScores={traceScores}

--- a/web/src/features/traces/components/TraceDetailView/components/TraceDetailViewHeader.tsx
+++ b/web/src/features/traces/components/TraceDetailView/components/TraceDetailViewHeader.tsx
@@ -2,7 +2,7 @@
  * TraceDetailViewHeader - Extracted header component for TraceDetailView
  *
  * Contains:
- * - Title row with ItemBadge, trace name, options menu
+ * - Title row with trace name and options menu
  * - Action buttons (Dataset, Annotate, Queue, Comments)
  * - Metadata badges (timestamp, latency, session, user, environment, release, version, cost, usage)
  *
@@ -19,7 +19,6 @@ import {
 import { type SelectionData } from "@/src/features/comments/contexts/InlineCommentSelectionContext";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
 import { type ObservationReturnTypeWithMetadata } from "@/src/server/api/routers/traces";
-import { ItemBadge } from "@/src/components/ItemBadge";
 import { DetailHeaderActionsMenuController } from "@/src/features/traces/components/DetailHeaderActionsMenuController";
 import { ExistingDatasetItemsDropdownMenuController } from "@/src/features/datasets/components/ExistingDatasetItemsDropdownMenuController";
 import { NewDatasetItemFromExistingObjectDialogController } from "@/src/features/datasets/components/NewDatasetItemFromExistingObjectDialogController";
@@ -29,16 +28,11 @@ import { CommentDrawerController } from "@/src/features/comments/CommentDrawerCo
 import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-badge";
 import { AnnotationQueueItemDropdownMenuController } from "@/src/features/annotation-queues/components/AnnotationQueueItemDropdownMenuController";
 import { AnnotationQueueItemCountBadge } from "@/src/features/annotation-queues/components/AnnotationQueueItemCountBadge";
+import { VersionBadge, TargetTraceBadge } from "../../TraceMetadataBadges";
 import {
-  SessionBadge,
-  UserIdBadge,
-  EnvironmentBadge,
-  ReleaseBadge,
-  VersionBadge,
-  TargetTraceBadge,
-} from "../../TraceMetadataBadges";
-import { LatencyBadge } from "../../ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple";
-import { CostBadge, UsageBadge } from "../../ObservationMetadataBadgesTooltip";
+  hasRenderableUsage,
+  UsageBadge,
+} from "../../ObservationMetadataBadgesTooltip";
 import { aggregateTraceMetrics } from "@/src/features/traces/fns/traceAggregation";
 import { resolveEvalExecutionMetadata } from "@/src/features/traces/fns/resolveMetadata";
 import { useViewPreferences } from "@/src/features/traces/contexts/ViewPreferencesContext";
@@ -122,14 +116,13 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
   });
 
   return (
-    <div className="@container shrink-0 space-y-2 border-b p-2">
+    <div className="@container shrink-0 space-y-2 p-3">
       {/* Title row with actions */}
       <div className="grid w-full grid-cols-1 items-start gap-2 @2xl:grid-cols-[auto_auto] @2xl:justify-between">
         <div className="flex w-full flex-row items-center gap-1">
-          <ItemBadge type="TRACE" isSmall />
           <span
             className={cn(
-              "line-clamp-2 min-w-0 font-bold break-all md:break-normal md:wrap-break-word",
+              "line-clamp-2 min-w-0 text-base font-bold break-all md:break-normal md:wrap-break-word",
               isMobile && "flex-1",
             )}
           >
@@ -317,7 +310,7 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
                       ) : (
                         <MessageSquare className="h-4 w-4" />
                       )}
-                      <span className="text-sm">Add comment</span>
+                      <span className="text-sm">Comment</span>
                       {!disabled && commentCount ? (
                         <ActionButtonCountBadge count={commentCount} />
                       ) : null}
@@ -428,9 +421,9 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
                       variant="secondary"
                       size="sm"
                       disabled={disabled !== undefined}
-                      className="rounded-l-none rounded-r-md border-l-2"
+                      className="rounded-l-none rounded-r-md border-l px-1.5"
                     >
-                      <span className="relative mr-1 text-xs">
+                      <span className="relative text-xs">
                         <ChevronDown className="h-3 w-3" />
                         {totalCount > 0 && (
                           <AnnotationQueueItemCountBadge
@@ -468,7 +461,7 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
                   ) : (
                     <>
                       <MessageSquare className="h-3.5 w-3.5" />
-                      <span>Add comment</span>
+                      <span>Comment</span>
                       {!!commentCount ? (
                         <ActionButtonCountBadge count={commentCount} />
                       ) : null}
@@ -481,37 +474,35 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
         )}
       </div>
 
-      {/* Metadata badges */}
-      <div className="flex flex-col gap-2">
-        {/* Timestamp */}
-        {preparedDate ? (
-          <div className="flex flex-wrap items-center gap-1 text-sm">
-            <span title={preparedDate.title}>{preparedDate.display}</span>
-          </div>
-        ) : null}
+      {/* Timestamp on its own line: sharing the title row broke with long
+          trace names. */}
+      {preparedDate ? (
+        <div
+          title={preparedDate.title}
+          className="text-muted-foreground text-xs"
+        >
+          {preparedDate.display}
+        </div>
+      ) : null}
 
-        {/* Other badges */}
+      <div className="flex flex-col gap-2">
+        {/* Trace-level attributes (latency, session, user, environment,
+            release, cost, tags) live in the TraceSummaryStrip, not here. */}
         {!isAnnotationMode && (
           <CollapsibleBadgeRow>
-            <LatencyBadge latencySeconds={trace.latency ?? null} />
-            <SessionBadge sessionId={trace.sessionId} projectId={projectId} />
-            <UserIdBadge userId={trace.userId} projectId={projectId} />
             <TargetTraceBadge
               targetTraceId={targetTraceId}
               projectId={projectId}
             />
-            <EnvironmentBadge environment={trace.environment} />
-            <ReleaseBadge release={trace.release} />
             <VersionBadge version={trace.version} />
-            {aggregatedMetrics.totalCost != null &&
-              aggregatedMetrics.costDetails && (
-                <CostBadge
-                  totalCost={aggregatedMetrics.totalCost}
-                  costDetails={aggregatedMetrics.costDetails}
-                />
-              )}
             {aggregatedMetrics.hasGenerationLike &&
-              aggregatedMetrics.usageDetails && (
+              aggregatedMetrics.usageDetails &&
+              hasRenderableUsage({
+                inputUsage: aggregatedMetrics.inputUsage,
+                outputUsage: aggregatedMetrics.outputUsage,
+                totalUsage: aggregatedMetrics.totalUsage,
+                usageDetails: aggregatedMetrics.usageDetails,
+              }) && (
                 <UsageBadge
                   inputUsage={aggregatedMetrics.inputUsage}
                   outputUsage={aggregatedMetrics.outputUsage}

--- a/web/src/features/traces/components/TraceDetailView/components/TraceDetailViewHeader.tsx
+++ b/web/src/features/traces/components/TraceDetailView/components/TraceDetailViewHeader.tsx
@@ -28,7 +28,7 @@ import { CommentDrawerController } from "@/src/features/comments/CommentDrawerCo
 import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-badge";
 import { AnnotationQueueItemDropdownMenuController } from "@/src/features/annotation-queues/components/AnnotationQueueItemDropdownMenuController";
 import { AnnotationQueueItemCountBadge } from "@/src/features/annotation-queues/components/AnnotationQueueItemCountBadge";
-import { VersionBadge, TargetTraceBadge } from "../../TraceMetadataBadges";
+import { TargetTraceBadge } from "../../TraceMetadataBadges";
 import {
   hasRenderableUsage,
   UsageBadge,
@@ -494,7 +494,6 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
               targetTraceId={targetTraceId}
               projectId={projectId}
             />
-            <VersionBadge version={trace.version} />
             {aggregatedMetrics.hasGenerationLike &&
               aggregatedMetrics.usageDetails &&
               hasRenderableUsage({

--- a/web/src/features/traces/components/TraceDetailView/components/TraceDetailViewHeader.tsx
+++ b/web/src/features/traces/components/TraceDetailView/components/TraceDetailViewHeader.tsx
@@ -4,12 +4,12 @@
  * Contains:
  * - Title row with trace name and options menu
  * - Action buttons (Dataset, Annotate, Queue, Comments)
- * - Metadata badges (timestamp, latency, session, user, environment, release, version, cost, usage)
+ * - Metadata badges (timestamp, target-trace link)
  *
  * Memoized to prevent unnecessary re-renders when tab state changes.
  */
 
-import { memo, useMemo } from "react";
+import { memo } from "react";
 import {
   type TraceDomain,
   type ScoreDomain,
@@ -18,7 +18,6 @@ import {
 } from "@langfuse/shared";
 import { type SelectionData } from "@/src/features/comments/contexts/InlineCommentSelectionContext";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
-import { type ObservationReturnTypeWithMetadata } from "@/src/server/api/routers/traces";
 import { DetailHeaderActionsMenuController } from "@/src/features/traces/components/DetailHeaderActionsMenuController";
 import { ExistingDatasetItemsDropdownMenuController } from "@/src/features/datasets/components/ExistingDatasetItemsDropdownMenuController";
 import { NewDatasetItemFromExistingObjectDialogController } from "@/src/features/datasets/components/NewDatasetItemFromExistingObjectDialogController";
@@ -29,11 +28,6 @@ import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-
 import { AnnotationQueueItemDropdownMenuController } from "@/src/features/annotation-queues/components/AnnotationQueueItemDropdownMenuController";
 import { AnnotationQueueItemCountBadge } from "@/src/features/annotation-queues/components/AnnotationQueueItemCountBadge";
 import { TargetTraceBadge } from "../../TraceMetadataBadges";
-import {
-  hasRenderableUsage,
-  UsageBadge,
-} from "../../ObservationMetadataBadgesTooltip";
-import { aggregateTraceMetrics } from "@/src/features/traces/fns/traceAggregation";
 import { resolveEvalExecutionMetadata } from "@/src/features/traces/fns/resolveMetadata";
 import { useViewPreferences } from "@/src/features/traces/contexts/ViewPreferencesContext";
 import { CollapsibleBadgeRow } from "@/src/features/traces/components/CollapsibleBadgeRow";
@@ -64,7 +58,6 @@ export interface TraceDetailViewHeaderProps {
     input: string | null;
     output: string | null;
   };
-  observations: ObservationReturnTypeWithMetadata[];
   parsedMetadata: unknown;
   projectId: string;
   traceScores: WithStringifiedMetadata<ScoreDomain>[];
@@ -78,7 +71,6 @@ export interface TraceDetailViewHeaderProps {
 
 export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
   trace,
-  observations,
   parsedMetadata,
   projectId,
   traceScores,
@@ -90,10 +82,6 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
 }: TraceDetailViewHeaderProps) {
   const { isAnnotationMode } = useViewPreferences();
   const isMobile = useIsMobile();
-  const aggregatedMetrics = useMemo(
-    () => aggregateTraceMetrics(observations),
-    [observations],
-  );
   const {
     existingDatasetItems,
     hasAccess: hasDatasetAccess,
@@ -487,28 +475,15 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
 
       <div className="flex flex-col gap-2">
         {/* Trace-level attributes (latency, session, user, environment,
-            release, cost, tags) live in the TraceSummaryStrip, not here. */}
+            release, cost, usage, tags) live in the TraceSummaryStrip, not
+            here — its compact usage badge already carries the breakdown
+            tooltip, so this header only adds the target-trace link. */}
         {!isAnnotationMode && (
           <CollapsibleBadgeRow>
             <TargetTraceBadge
               targetTraceId={targetTraceId}
               projectId={projectId}
             />
-            {aggregatedMetrics.hasGenerationLike &&
-              aggregatedMetrics.usageDetails &&
-              hasRenderableUsage({
-                inputUsage: aggregatedMetrics.inputUsage,
-                outputUsage: aggregatedMetrics.outputUsage,
-                totalUsage: aggregatedMetrics.totalUsage,
-                usageDetails: aggregatedMetrics.usageDetails,
-              }) && (
-                <UsageBadge
-                  inputUsage={aggregatedMetrics.inputUsage}
-                  outputUsage={aggregatedMetrics.outputUsage}
-                  totalUsage={aggregatedMetrics.totalUsage}
-                  usageDetails={aggregatedMetrics.usageDetails}
-                />
-              )}
           </CollapsibleBadgeRow>
         )}
       </div>

--- a/web/src/features/traces/components/TraceMetadataBadges.clienttest.tsx
+++ b/web/src/features/traces/components/TraceMetadataBadges.clienttest.tsx
@@ -20,27 +20,26 @@ describe("TraceMetadataBadges session replay privacy", () => {
       </>,
     );
 
-    expect(
-      screen.getByText("Session: customer-session").closest("a"),
-    ).toHaveClass("ph-no-capture");
-    expect(screen.getByText("User ID: customer-user").closest("a")).toHaveClass(
+    // The session link is label-only ("Session"); the id lives in the title.
+    expect(screen.getByText("Session").closest("a")).toHaveClass(
       "ph-no-capture",
     );
-    expect(
-      screen.getByText("Target Trace: target-trace").closest("a"),
-    ).toHaveClass("ph-no-capture");
-    expect(
-      screen.getByText("Session: customer-session").parentElement,
-    ).toHaveClass("bg-primary");
-    expect(
-      screen.getByText("User ID: customer-user").parentElement,
-    ).toHaveClass("bg-primary");
-    expect(
-      screen.getByText("Target Trace: target-trace").parentElement,
-    ).toHaveClass("bg-primary");
-    expect(screen.getByText("Env: production").parentElement).toHaveClass(
-      "bg-tertiary",
+    // The user id renders in full (it is often an email) — link still masked.
+    expect(screen.getByText("customer-user").closest("a")).toHaveClass(
+      "ph-no-capture",
     );
+    expect(screen.getByText("Target trace").closest("a")).toHaveClass(
+      "ph-no-capture",
+    );
+    // Quiet text links, not primary-filled chips.
+    expect(screen.getByText("Session").closest("a")).toHaveClass(
+      "text-muted-foreground",
+    );
+    // Environment renders as muted key-value text, not a chip.
+    expect(screen.getByText("production").closest("span")).not.toBeNull();
+    expect(
+      screen.getByText("production").closest("span")?.parentElement,
+    ).toHaveTextContent("env: production");
   });
 });
 

--- a/web/src/features/traces/components/TraceMetadataBadges.clienttest.tsx
+++ b/web/src/features/traces/components/TraceMetadataBadges.clienttest.tsx
@@ -20,26 +20,31 @@ describe("TraceMetadataBadges session replay privacy", () => {
       </>,
     );
 
-    // The session link is label-only ("Session"); the id lives in the title.
-    expect(screen.getByText("Session").closest("a")).toHaveClass(
+    // The session id now renders as visible text (session pill convention),
+    // so the mask must sit directly on the link, not just in a title attr.
+    expect(screen.getByText("customer-session").closest("a")).toHaveClass(
       "ph-no-capture",
     );
     // The user id renders in full (it is often an email) — link still masked.
     expect(screen.getByText("customer-user").closest("a")).toHaveClass(
       "ph-no-capture",
     );
-    expect(screen.getByText("Target trace").closest("a")).toHaveClass(
+    expect(screen.getByText("target-trace").closest("a")).toHaveClass(
       "ph-no-capture",
     );
-    // Quiet text links, not primary-filled chips.
-    expect(screen.getByText("Session").closest("a")).toHaveClass(
+    // Session header pill styling, not primary-filled chips.
+    expect(screen.getByText("customer-session").closest("a")).toHaveClass(
       "text-muted-foreground",
     );
-    // Environment renders as muted key-value text, not a chip.
+    expect(screen.getByText("customer-session").closest("a")).toHaveAttribute(
+      "data-session-header-pill",
+      "true",
+    );
+    // Environment renders as a display pill, not a text chip.
     expect(screen.getByText("production").closest("span")).not.toBeNull();
     expect(
       screen.getByText("production").closest("span")?.parentElement,
-    ).toHaveTextContent("env: production");
+    ).toHaveTextContent("env production");
   });
 });
 

--- a/web/src/features/traces/components/TraceMetadataBadges.tsx
+++ b/web/src/features/traces/components/TraceMetadataBadges.tsx
@@ -1,14 +1,22 @@
 /* eslint-disable @repo/no-null-render */
 /**
- * TraceMetadataBadges - Extracted badge components for trace metadata
+ * Trace-level metadata text for the trace summary strip and detail headers.
  *
- * Following the pattern from ObservationDetailView/ObservationMetadataBadgesSimple.tsx
- * Each badge handles its own null check and returns null when data is unavailable.
+ * Links and context render as quiet text, not chips — chips are reserved for
+ * user-defined tags. Each element handles its own null check and returns null
+ * when the data is unavailable.
  */
 
 import Link from "next/link";
 import { ExternalLinkIcon } from "lucide-react";
-import { Badge } from "@/src/components/design-system/Badge/Badge";
+import {
+  EnvironmentBadge,
+  ReleaseBadge,
+  VersionBadge,
+} from "@/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple";
+
+const META_LINK_CLASSES =
+  "ph-no-capture text-muted-foreground hover:text-foreground inline-flex max-w-48 items-center gap-1 text-xs hover:underline";
 
 export function SessionBadge({
   sessionId,
@@ -19,14 +27,18 @@ export function SessionBadge({
 }) {
   if (!sessionId) return null;
 
-  const text = `Session: ${sessionId}`;
-
   return (
     <Link
       href={`/project/${projectId}/sessions/${encodeURIComponent(sessionId)}`}
-      className="ph-no-capture inline-flex"
+      className={META_LINK_CLASSES}
+      title={`Session: ${sessionId}`}
     >
-      <Badge color="primary" text={text} trailingIcon={ExternalLinkIcon} />
+      {/* Label-only link: the raw session id is noise here; the tooltip
+          carries it and the link leads to the session itself. */}
+      <span className="truncate" title={`Session: ${sessionId}`}>
+        Session
+      </span>
+      <ExternalLinkIcon className="size-3 shrink-0" aria-hidden />
     </Link>
   );
 }
@@ -40,14 +52,18 @@ export function UserIdBadge({
 }) {
   if (!userId) return null;
 
-  const text = `User ID: ${userId}`;
-
   return (
     <Link
       href={`/project/${projectId}/users/${encodeURIComponent(userId)}`}
-      className="ph-no-capture inline-flex"
+      className={META_LINK_CLASSES}
+      title={`User: ${userId}`}
     >
-      <Badge color="primary" text={text} trailingIcon={ExternalLinkIcon} />
+      {/* Unlike sessions, the user id itself carries meaning (it is often an
+          email), so it renders in full; only the "User ID:" label is dropped. */}
+      <span className="truncate" title={`User: ${userId}`}>
+        {userId}
+      </span>
+      <ExternalLinkIcon className="size-3 shrink-0" aria-hidden />
     </Link>
   );
 }
@@ -61,33 +77,20 @@ export function TargetTraceBadge({
 }) {
   if (!targetTraceId) return null;
 
-  const text = `Target Trace: ${targetTraceId}`;
-
   return (
     <Link
       href={`/project/${projectId}/traces/${encodeURIComponent(targetTraceId)}`}
-      className="ph-no-capture inline-flex"
+      className={META_LINK_CLASSES}
+      title={`Target trace: ${targetTraceId}`}
     >
-      <Badge color="primary" text={text} trailingIcon={ExternalLinkIcon} />
+      <span className="truncate" title={`Target trace: ${targetTraceId}`}>
+        Target trace
+      </span>
+      <ExternalLinkIcon className="size-3 shrink-0" aria-hidden />
     </Link>
   );
 }
 
-export function EnvironmentBadge({
-  environment,
-}: {
-  environment: string | null;
-}) {
-  if (!environment) return null;
-  return <Badge text={`Env: ${environment}`} />;
-}
-
-export function ReleaseBadge({ release }: { release: string | null }) {
-  if (!release) return null;
-  return <Badge text={`Release: ${release}`} />;
-}
-
-export function VersionBadge({ version }: { version: string | null }) {
-  if (!version) return null;
-  return <Badge text={`Version: ${version}`} />;
-}
+// Context text (env/release/version) is shared with the observation header so
+// both surfaces speak the same visual grammar.
+export { EnvironmentBadge, ReleaseBadge, VersionBadge };

--- a/web/src/features/traces/components/TraceMetadataBadges.tsx
+++ b/web/src/features/traces/components/TraceMetadataBadges.tsx
@@ -12,7 +12,6 @@ import { ExternalLinkIcon } from "lucide-react";
 import {
   EnvironmentBadge,
   ReleaseBadge,
-  VersionBadge,
 } from "@/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple";
 
 const META_LINK_CLASSES =
@@ -91,6 +90,6 @@ export function TargetTraceBadge({
   );
 }
 
-// Context text (env/release/version) is shared with the observation header so
-// both surfaces speak the same visual grammar.
-export { EnvironmentBadge, ReleaseBadge, VersionBadge };
+// Context text (env/release) is shared with the observation header so both
+// surfaces speak the same visual grammar.
+export { EnvironmentBadge, ReleaseBadge };

--- a/web/src/features/traces/components/TraceMetadataBadges.tsx
+++ b/web/src/features/traces/components/TraceMetadataBadges.tsx
@@ -1,21 +1,19 @@
 /* eslint-disable @repo/no-null-render */
 /**
- * Trace-level metadata text for the trace summary strip and detail headers.
+ * Trace-level metadata pills for the trace summary strip and detail headers.
  *
- * Links and context render as quiet text, not chips — chips are reserved for
- * user-defined tags. Each element handles its own null check and returns null
- * when the data is unavailable.
+ * Rendered through the session header's pill primitive
+ * (`ModernSessionHeaderPill`) so trace and session chips are indistinguishable.
+ * Each element handles its own null check and returns null when the data is
+ * unavailable.
  */
 
-import Link from "next/link";
-import { ExternalLinkIcon } from "lucide-react";
+import { ArrowUpRight } from "lucide-react";
+import { ModernSessionHeaderPill } from "@/src/components/session/ModernSessionHeaderPill";
 import {
   EnvironmentBadge,
   ReleaseBadge,
 } from "@/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple";
-
-const META_LINK_CLASSES =
-  "ph-no-capture text-muted-foreground hover:text-foreground inline-flex max-w-48 items-center gap-1 text-xs hover:underline";
 
 export function SessionBadge({
   sessionId,
@@ -27,18 +25,20 @@ export function SessionBadge({
   if (!sessionId) return null;
 
   return (
-    <Link
+    <ModernSessionHeaderPill
+      variant="link"
       href={`/project/${projectId}/sessions/${encodeURIComponent(sessionId)}`}
-      className={META_LINK_CLASSES}
-      title={`Session: ${sessionId}`}
+      maskFromSessionReplay
     >
-      {/* Label-only link: the raw session id is noise here; the tooltip
-          carries it and the link leads to the session itself. */}
-      <span className="truncate" title={`Session: ${sessionId}`}>
-        Session
+      session{" "}
+      <span
+        className="text-foreground group-hover:text-link truncate"
+        title={sessionId}
+      >
+        {sessionId}
       </span>
-      <ExternalLinkIcon className="size-3 shrink-0" aria-hidden />
-    </Link>
+      <ArrowUpRight className="text-link h-3 w-3 shrink-0" />
+    </ModernSessionHeaderPill>
   );
 }
 
@@ -52,18 +52,20 @@ export function UserIdBadge({
   if (!userId) return null;
 
   return (
-    <Link
+    <ModernSessionHeaderPill
+      variant="link"
       href={`/project/${projectId}/users/${encodeURIComponent(userId)}`}
-      className={META_LINK_CLASSES}
-      title={`User: ${userId}`}
+      maskFromSessionReplay
     >
-      {/* Unlike sessions, the user id itself carries meaning (it is often an
-          email), so it renders in full; only the "User ID:" label is dropped. */}
-      <span className="truncate" title={`User: ${userId}`}>
+      user{" "}
+      <span
+        className="text-foreground group-hover:text-link truncate"
+        title={userId}
+      >
         {userId}
       </span>
-      <ExternalLinkIcon className="size-3 shrink-0" aria-hidden />
-    </Link>
+      <ArrowUpRight className="text-link h-3 w-3 shrink-0" />
+    </ModernSessionHeaderPill>
   );
 }
 
@@ -77,16 +79,20 @@ export function TargetTraceBadge({
   if (!targetTraceId) return null;
 
   return (
-    <Link
+    <ModernSessionHeaderPill
+      variant="link"
       href={`/project/${projectId}/traces/${encodeURIComponent(targetTraceId)}`}
-      className={META_LINK_CLASSES}
-      title={`Target trace: ${targetTraceId}`}
+      maskFromSessionReplay
     >
-      <span className="truncate" title={`Target trace: ${targetTraceId}`}>
-        Target trace
+      target trace{" "}
+      <span
+        className="text-foreground group-hover:text-link truncate"
+        title={targetTraceId}
+      >
+        {targetTraceId}
       </span>
-      <ExternalLinkIcon className="size-3 shrink-0" aria-hidden />
-    </Link>
+      <ArrowUpRight className="text-link h-3 w-3 shrink-0" />
+    </ModernSessionHeaderPill>
   );
 }
 

--- a/web/src/features/traces/components/TraceSummaryStrip.tsx
+++ b/web/src/features/traces/components/TraceSummaryStrip.tsx
@@ -1,0 +1,114 @@
+/**
+ * TraceSummaryStrip - persistent trace-level summary row.
+ *
+ * Renders directly under the page header, above the navigation/detail panels,
+ * and stays visible regardless of which observation is selected. This is the
+ * single home for trace-level attributes (session, user, environment, release,
+ * tags) and trace totals (latency, cost) — the detail-panel headers no longer
+ * repeat them.
+ *
+ * Totals are shuffled, not computed: latency comes from the tRPC trace payload
+ * (server-derived from observation timestamps) and cost from the same
+ * client-side aggregation the detail header already used.
+ */
+
+import { useMemo, useState } from "react";
+
+import { CollapsibleBadgeRow } from "@/src/features/traces/components/CollapsibleBadgeRow";
+import { TagPill } from "@/src/features/tag/components/TagPill";
+import {
+  EnvironmentBadge,
+  ReleaseBadge,
+  SessionBadge,
+  UserIdBadge,
+} from "@/src/features/traces/components/TraceMetadataBadges";
+import { LatencyBadge } from "@/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple";
+import {
+  CostBadge,
+  hasRenderableUsage,
+  UsageBadge,
+} from "@/src/features/traces/components/ObservationMetadataBadgesTooltip";
+import { aggregateTraceMetrics } from "@/src/features/traces/fns/traceAggregation";
+import { useTraceData } from "@/src/features/traces/contexts/TraceDataContext";
+
+// Tags shown before the rest folds into a "+N" toggle — tag-heavy traces must
+// not turn the one-line strip into a wall of chips.
+const MAX_VISIBLE_TAGS = 3;
+
+export function TraceSummaryStrip() {
+  const { trace, observations } = useTraceData();
+  const [showAllTags, setShowAllTags] = useState(false);
+
+  const aggregatedMetrics = useMemo(
+    () => aggregateTraceMetrics(observations),
+    [observations],
+  );
+
+  const visibleTags = showAllTags
+    ? trace.tags
+    : trace.tags.slice(0, MAX_VISIBLE_TAGS);
+  const hiddenTagCount = trace.tags.length - visibleTags.length;
+
+  return (
+    <div className="shrink-0 border-b px-3 py-2">
+      <CollapsibleBadgeRow>
+        <LatencyBadge latencySeconds={trace.latency ?? null} />
+        {aggregatedMetrics.totalCost != null &&
+          aggregatedMetrics.costDetails && (
+            <CostBadge
+              totalCost={aggregatedMetrics.totalCost}
+              costDetails={aggregatedMetrics.costDetails}
+            />
+          )}
+        {aggregatedMetrics.hasGenerationLike &&
+          aggregatedMetrics.usageDetails &&
+          hasRenderableUsage({
+            inputUsage: aggregatedMetrics.inputUsage,
+            outputUsage: aggregatedMetrics.outputUsage,
+            totalUsage: aggregatedMetrics.totalUsage,
+            usageDetails: aggregatedMetrics.usageDetails,
+          }) && (
+            <UsageBadge
+              compact
+              inputUsage={aggregatedMetrics.inputUsage}
+              outputUsage={aggregatedMetrics.outputUsage}
+              totalUsage={aggregatedMetrics.totalUsage}
+              usageDetails={aggregatedMetrics.usageDetails}
+            />
+          )}
+        <SessionBadge sessionId={trace.sessionId} projectId={trace.projectId} />
+        <UserIdBadge userId={trace.userId} projectId={trace.projectId} />
+        <EnvironmentBadge environment={trace.environment} />
+        <ReleaseBadge release={trace.release} />
+        {trace.tags.length > 0 && (
+          <div className="flex min-w-0 items-center gap-1">
+            {/* Quiet chips (dim fill, tight padding): v4 tags are immutable,
+                so no edit affordance. */}
+            {visibleTags.map((tag) => (
+              <TagPill key={tag} tag={tag} />
+            ))}
+            {hiddenTagCount > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowAllTags(true)}
+                title={trace.tags.slice(MAX_VISIBLE_TAGS).join(", ")}
+                className="text-muted-foreground hover:text-foreground text-xs"
+              >
+                +{hiddenTagCount}
+              </button>
+            )}
+            {showAllTags && trace.tags.length > MAX_VISIBLE_TAGS && (
+              <button
+                type="button"
+                onClick={() => setShowAllTags(false)}
+                className="text-muted-foreground hover:text-foreground text-xs"
+              >
+                show fewer
+              </button>
+            )}
+          </div>
+        )}
+      </CollapsibleBadgeRow>
+    </div>
+  );
+}

--- a/web/src/features/traces/components/TraceSummaryStrip.tsx
+++ b/web/src/features/traces/components/TraceSummaryStrip.tsx
@@ -22,7 +22,10 @@ import {
   SessionBadge,
   UserIdBadge,
 } from "@/src/features/traces/components/TraceMetadataBadges";
-import { LatencyBadge } from "@/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple";
+import {
+  LatencyBadge,
+  VersionBadge,
+} from "@/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple";
 import {
   CostBadge,
   hasRenderableUsage,
@@ -80,6 +83,7 @@ export function TraceSummaryStrip() {
         <UserIdBadge userId={trace.userId} projectId={trace.projectId} />
         <EnvironmentBadge environment={trace.environment} />
         <ReleaseBadge release={trace.release} />
+        <VersionBadge version={trace.version} />
         {trace.tags.length > 0 && (
           <div className="flex min-w-0 items-center gap-1">
             {/* Quiet chips (dim fill, tight padding): v4 tags are immutable,

--- a/web/src/features/traces/components/TraceSummaryStrip.tsx
+++ b/web/src/features/traces/components/TraceSummaryStrip.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple";
 import {
   CostBadge,
-  hasRenderableUsage,
+  getCompactUsageTotal,
   UsageBadge,
 } from "@/src/features/traces/components/ObservationMetadataBadgesTooltip";
 import { aggregateTraceMetrics } from "@/src/features/traces/fns/traceAggregation";
@@ -65,12 +65,11 @@ export function TraceSummaryStrip() {
           )}
         {aggregatedMetrics.hasGenerationLike &&
           aggregatedMetrics.usageDetails &&
-          hasRenderableUsage({
+          getCompactUsageTotal({
             inputUsage: aggregatedMetrics.inputUsage,
             outputUsage: aggregatedMetrics.outputUsage,
             totalUsage: aggregatedMetrics.totalUsage,
-            usageDetails: aggregatedMetrics.usageDetails,
-          }) && (
+          }) > 0 && (
             <UsageBadge
               compact
               inputUsage={aggregatedMetrics.inputUsage}

--- a/web/src/features/traces/components/TraceSummaryStrip.tsx
+++ b/web/src/features/traces/components/TraceSummaryStrip.tsx
@@ -16,6 +16,7 @@ import { useMemo, useState } from "react";
 
 import { CollapsibleBadgeRow } from "@/src/features/traces/components/CollapsibleBadgeRow";
 import { TagPill } from "@/src/features/tag/components/TagPill";
+import { ModernSessionHeaderPill } from "@/src/components/session/ModernSessionHeaderPill";
 import {
   EnvironmentBadge,
   ReleaseBadge,
@@ -85,29 +86,28 @@ export function TraceSummaryStrip() {
         <VersionBadge version={trace.version} />
         {trace.tags.length > 0 && (
           <div className="flex min-w-0 items-center gap-1">
-            {/* Quiet chips (dim fill, tight padding): v4 tags are immutable,
-                so no edit affordance. */}
+            {/* Session-header pill styling; v4 tags are immutable here, so no
+                edit affordance. */}
             {visibleTags.map((tag) => (
               <TagPill key={tag} tag={tag} />
             ))}
             {hiddenTagCount > 0 && (
-              <button
-                type="button"
+              <ModernSessionHeaderPill
+                variant="button"
+                ariaLabel={`Show ${hiddenTagCount} more tags`}
                 onClick={() => setShowAllTags(true)}
-                title={trace.tags.slice(MAX_VISIBLE_TAGS).join(", ")}
-                className="text-muted-foreground hover:text-foreground text-xs"
               >
                 +{hiddenTagCount}
-              </button>
+              </ModernSessionHeaderPill>
             )}
             {showAllTags && trace.tags.length > MAX_VISIBLE_TAGS && (
-              <button
-                type="button"
+              <ModernSessionHeaderPill
+                variant="button"
+                ariaLabel="Show fewer tags"
                 onClick={() => setShowAllTags(false)}
-                className="text-muted-foreground hover:text-foreground text-xs"
               >
                 show fewer
-              </button>
+              </ModernSessionHeaderPill>
             )}
           </div>
         )}

--- a/web/src/features/traces/contexts/TraceDataContext.tsx
+++ b/web/src/features/traces/contexts/TraceDataContext.tsx
@@ -41,6 +41,8 @@ type TraceType = Omit<
 > & {
   input: string | null;
   output: string | null;
+  /** Server-derived total latency in seconds; absent on payloads that don't compute it. */
+  latency?: number;
 };
 
 interface TraceDataContextValue {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17080 app preview](https://pr-17080.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

| Change | Detail |
|---|---|
| Persistent trace summary strip | Latency, cost, `∑` tokens, session/user quiet links, environment/release/version, tag pills capped at 3 + N overflow |
| Reordered observation header badges | Tier-ordered, with the timestamp on its own line |
| Combined "Add to ▾" menu | Merges Dataset and Playground actions, with Playground as a submenu |
| Comment action relabeled | Now reads "Comment" |
| Tags moved out of preview | Removed from the detail-panel preview; they now live in the persistent strip |
| Corrected-output collapsed | One-line affordance instead of always-expanded |
| Section controls reveal on hover | Copy/expand controls no longer render always-on |
| Scores tab count badge | Tab shows the number of scores |
| Label-only type chip | Page header and peek header badges show label only, no icon |

## How to test

Preview: https://pr-17080.preview.langfuse.com (seed data: `pnpm run seed -- support-agent --v4` locally, or use preview seed traces)
1. Open a trace — confirm the summary strip renders under the header with latency/cost/tags.
2. Select an observation and open its detail panel, then peek open the same trace from a table — confirm headers, "Add to" menu, and hover-reveal controls behave as described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reorganizes trace and observation detail presentation around a persistent trace-summary strip, simplified metadata typography, consolidated destination actions, hover-revealed I/O controls, collapsed corrected output, and score-count badges.

- Adds a persistent trace-level strip for latency, cost, usage, identity context, environment, release, and tags.
- Simplifies trace and observation headers and consolidates dataset/playground actions.
- Updates formatted and JSON previews with hover-revealed section controls.
- Adds score counts and label-only item-type chips.
- The combined dataset menu, mobile control visibility, and missing trace version need correction before merge.
</details>


<details><summary><h3>Confidence Score: 2/5</h3></summary>

The PR is not safe to merge until the combined dataset menu has a valid anchor, touch users can access section controls, and the persistent strip retains the trace version.

The nested dataset menu can open without the DOM trigger required for positioning, mobile previews hide essential controls behind unavailable hover behavior, and selecting an observation removes access to the enclosing trace’s version metadata.

**Files Needing Attention:** web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx, web/src/components/ui/MarkdownJsonView.tsx, web/src/features/traces/components/TraceSummaryStrip.tsx
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Trace[Trace data context] --> Strip[Persistent trace summary strip]
  Trace --> Navigation[Tree / timeline / graph]
  Navigation --> Selection{Selected resource}
  Selection -->|Trace| TraceDetail[Trace detail header and tabs]
  Selection -->|Observation| ObservationDetail[Observation detail header and tabs]
  ObservationDetail --> AddTo[Combined Add to menu]
  AddTo --> Dataset[Dataset actions]
  AddTo --> Playground[Playground submenu]
  TraceDetail --> Preview[I/O preview]
  ObservationDetail --> Preview
  Preview --> Controls[Hover-revealed copy and expand controls]
  Preview --> Corrections[Collapsed corrected-output affordance]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx:528
**Dataset menu loses anchor**

When an observation already belongs to a dataset, selecting “Dataset” calls `openDropdown()` on the outer existing-dataset controller. That controller expects `Anchor` to wrap a DOM trigger so it can retain the positioning ref, but `Anchor` now wraps another `DropdownMenu` root. The outer dataset-item menu therefore opens without a reliable DOM anchor and cannot be reliably positioned or focused. Please keep the existing-dataset menu outside the inner menu lifecycle or provide it with a real button anchor.

### Issue 2
web/src/components/ui/MarkdownJsonView.tsx:105-106
**Touch controls remain hidden**

These copy and expand/collapse controls stay at `opacity-0` until hover or keyboard focus. The same previews render in the mobile trace Data view, where touch-only users have no hover operation to reveal the buttons, making the controls unavailable. Please add the established `[@media(hover:none)]:opacity-100` fallback so they remain visible on devices without hover.

### Issue 3
web/src/features/traces/components/TraceSummaryStrip.tsx:81-82
**Trace version disappears**

The persistent strip omits `trace.version` even though trace-level metadata was removed from the detail header to make this strip its persistent home. After selecting an observation, users can see only that observation’s version, which may differ from the enclosing trace version. Please render `VersionBadge` alongside the environment and release.

### Issue 4
web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx:176-189
**Playground query runs unnecessarily**

`useJumpToPlayground` now queries all project LLM API-key and model configurations for every observation header, including spans, events, and observations whose IO has not loaded. Those states never render the Playground entry, so navigating between such observations adds unnecessary authorized database requests. Please gate the query on Playground eligibility.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): trace view persistent summary..."](https://github.com/langfuse/langfuse/commit/5ad73ed539f46afeb0cfe7e1e7f63e3ed51853fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60452175)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Trace exploration workflows](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-exploration-workflows.md)

<!-- /greptile_comment -->