### PR TITLE
feat(web): graph as a trace view with relocated playback controls

### DIFF
--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -81,14 +81,11 @@ type TablePeekViewProps = Pick<
   | "isV4"
 > & {
   title?: string;
-  /**
-   * Item-specific header actions (star / publish / delete …), shared with the
-   * full detail page so the peek and the page expose the same controls.
-   */
+  /** Always-visible item action (share) rendered inline in the header. */
   actions?: React.ReactNode;
   /**
-   * The same actions rendered as labeled menu rows — shown in the header's
-   * overflow "…" menu when the peek is too narrow for the inline icon row.
+   * Item-specific header actions (delete …) as labeled menu rows — always
+   * shown in the header's "…" menu.
    */
   actionsMenu?: React.ReactNode;
   // Content

--- a/web/src/components/table/peek/PeekHeader.tsx
+++ b/web/src/components/table/peek/PeekHeader.tsx
@@ -33,9 +33,9 @@ type PeekHeaderProps = {
   itemId: string;
   detailNavigationKey?: string;
   resolveDetailNavigationPath?: (entry: ListEntry) => string;
-  /** Item actions (star / publish / delete …) as the inline icon row. */
+  /** Always-visible item action (share) rendered inline before the menu. */
   actions?: React.ReactNode;
-  /** The same actions as labeled rows for the overflow "…" menu. */
+  /** Item actions (delete …) as labeled rows for the "…" menu. */
   actionsMenu?: React.ReactNode;
   /** Expand-to-max-width toggle. Desktop only; hidden on mobile. */
   expand?: { isExpanded: boolean; onToggle: () => void };
@@ -49,7 +49,6 @@ type PeekHeaderProps = {
 // icon-xs button. Tuned by eye — planner `safety` covers inter-control gaps.
 const MIN_TITLE_PX = 240;
 const BADGE_ICON_PX = 32;
-const MORE_BUTTON_PX = 32;
 const BADGE_LABEL_FALLBACK_PX = 72;
 const NAV_FULL_FALLBACK_PX = 92;
 const NAV_COMPACT_FALLBACK_PX = 52;
@@ -125,15 +124,11 @@ export function PeekHeader({
   // control cluster too, whose width does change, to re-trigger the plan.
   const [clusterRef, clusterSize] = useElementSize<HTMLDivElement>();
   const badgeRef = useRef<HTMLDivElement>(null);
-  const actionsRef = useRef<HTMLDivElement>(null);
-  const openInTabRef = useRef<HTMLDivElement>(null);
   const navRef = useRef<HTMLDivElement>(null);
   const pinnedRef = useRef<HTMLDivElement>(null);
-  // Cached widths survive a part being folded / collapsed (it can't be
-  // re-measured while hidden, in the closed popover, or in the other nav mode).
+  // Cached widths survive a part being collapsed (it can't be re-measured
+  // while hidden or in the other nav mode).
   const widthsRef = useRef<{
-    actions?: number;
-    openInTab?: number;
     badgeLabel?: number;
     navFull?: number;
     navCompact?: number;
@@ -141,8 +136,9 @@ export function PeekHeader({
   }>({});
   const [plan, setPlan] = useState<PeekHeaderPlan>(FULL);
 
-  const hasActions = Boolean(actions);
-  const hasOpenInTab = Boolean(openInNewTab);
+  // Actions and open-in-tab ALWAYS live in the "…" menu — the header shows
+  // only nav / expand / close inline (usage data: nav dwarfs everything else).
+  const hasMenu = Boolean(actionsMenu || openInNewTab);
   const hasNav = Boolean(detailNavigationKey && resolveDetailNavigationPath);
 
   // Measure + plan in a layout effect (before paint), reading width from the
@@ -155,12 +151,6 @@ export function PeekHeader({
 
     if (plan.badgeShowLabel && badgeRef.current) {
       widthsRef.current.badgeLabel = badgeRef.current.offsetWidth;
-    }
-    if (hasActions && !plan.foldActions && actionsRef.current) {
-      widthsRef.current.actions = actionsRef.current.offsetWidth;
-    }
-    if (hasOpenInTab && !plan.foldOpenInTab && openInTabRef.current) {
-      widthsRef.current.openInTab = openInTabRef.current.offsetWidth;
     }
     if (pinnedRef.current) {
       const navW = hasNav && navRef.current ? navRef.current.offsetWidth : 0;
@@ -183,24 +173,12 @@ export function PeekHeader({
         ? (widthsRef.current.navCompact ?? NAV_COMPACT_FALLBACK_PX)
         : 0,
       otherPinnedWidth: widthsRef.current.otherPinned ?? 0,
-      moreWidth: MORE_BUTTON_PX,
-      actionsWidth: hasActions ? (widthsRef.current.actions ?? 0) : undefined,
-      openInTabWidth: hasOpenInTab
-        ? (widthsRef.current.openInTab ?? 0)
-        : undefined,
+      // The "…" trigger sits inside the pinned cluster now (always shown), so
+      // it is already counted in otherPinnedWidth.
+      moreWidth: 0,
     });
     setPlan((prev) => (samePlan(prev, next) ? prev : next));
-  }, [
-    headerRef,
-    headerSize?.width,
-    clusterSize?.width,
-    hasActions,
-    hasOpenInTab,
-    hasNav,
-    plan,
-  ]);
-
-  const anyFolded = plan.foldActions || plan.foldOpenInTab;
+  }, [headerRef, headerSize?.width, clusterSize?.width, hasNav, plan]);
 
   return (
     <TooltipProvider delayDuration={TOOLTIP_DELAY_MS}>
@@ -226,82 +204,75 @@ export function PeekHeader({
           ref={clusterRef}
           className="flex shrink-0 flex-row items-center gap-1"
         >
-          {/* Overflow: a labeled menu of whatever folded away. */}
-          {anyFolded && (
-            <Popover>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      aria-label="More actions"
-                    >
-                      <MoreHorizontal className="h-4 w-4" />
-                    </Button>
-                  </PopoverTrigger>
-                </TooltipTrigger>
-                <TooltipContent>More</TooltipContent>
-              </Tooltip>
-              <PopoverContent
-                align="end"
-                className="flex w-auto min-w-44 flex-col gap-0.5 p-1"
-              >
-                {plan.foldActions ? actionsMenu : null}
-                {plan.foldOpenInTab && openInNewTab ? (
-                  <button
-                    type="button"
-                    onClick={openInNewTab}
-                    className="hover:bg-accent flex w-full items-center gap-2 rounded-sm py-1.5 pr-2 pl-1.5 text-sm"
-                  >
-                    <ExternalLink className="h-4 w-4" />
-                    Open in new tab
-                  </button>
-                ) : null}
-              </PopoverContent>
-            </Popover>
-          )}
-
-          {hasActions && !plan.foldActions ? (
-            <div ref={actionsRef} className="flex flex-row items-center gap-1">
-              {actions}
-            </div>
-          ) : null}
-
-          {hasOpenInTab && !plan.foldOpenInTab && openInNewTab ? (
-            <div ref={openInTabRef}>
-              <HeaderIconButton label="Open in new tab" onClick={openInNewTab}>
-                <ExternalLink className="h-4 w-4" />
-              </HeaderIconButton>
-            </div>
-          ) : null}
-
-          {/* Pinned block: nav (keeps K/J live), expand, close. */}
+          {/* Pinned block, in order: "…" menu (delete / open-in-tab / expand),
+              share, nav (keeps K/J live), close. */}
           <div
             ref={pinnedRef}
             className="flex h-full flex-row items-center gap-1"
           >
+            {hasMenu && (
+              <Popover>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <PopoverTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        aria-label="More actions"
+                      >
+                        <MoreHorizontal className="h-4 w-4" />
+                      </Button>
+                    </PopoverTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>More</TooltipContent>
+                </Tooltip>
+                <PopoverContent
+                  align="end"
+                  // forceMount + hide-when-closed: the menu hosts controls with
+                  // their own dialogs/popovers (share URL, delete confirm) that
+                  // must survive the trigger closing.
+                  forceMount
+                  className="flex w-auto min-w-44 flex-col gap-0.5 p-1 data-[state=closed]:hidden"
+                >
+                  {actionsMenu}
+                  {openInNewTab ? (
+                    <button
+                      type="button"
+                      onClick={openInNewTab}
+                      className="hover:bg-accent flex w-full items-center gap-2 rounded-sm py-1.5 pr-2 pl-1.5 text-sm"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                      Open in new tab
+                    </button>
+                  ) : null}
+                  {expand ? (
+                    <button
+                      type="button"
+                      onClick={expand.onToggle}
+                      className="hover:bg-accent flex w-full items-center gap-2 rounded-sm py-1.5 pr-2 pl-1.5 text-sm"
+                    >
+                      {expand.isExpanded ? (
+                        <Minimize2 className="h-4 w-4" />
+                      ) : (
+                        <Maximize2 className="h-4 w-4" />
+                      )}
+                      {expand.isExpanded ? "Collapse panel" : "Expand panel"}
+                    </button>
+                  ) : null}
+                </PopoverContent>
+              </Popover>
+            )}
+            {actions}
             {hasNav && (
               <div ref={navRef} className="flex flex-row items-center">
+                {/* Always compact so the arrows match the icon-xs neighbors. */}
                 <DetailPageNav
                   currentId={itemId}
                   path={resolveDetailNavigationPath!}
                   listKey={detailNavigationKey!}
-                  compact={plan.navCompact}
+                  compact
                 />
               </div>
-            )}
-            {expand && (
-              <HeaderIconButton
-                label={expand.isExpanded ? "Collapse" : "Expand"}
-                onClick={expand.onToggle}
-              >
-                {expand.isExpanded ? (
-                  <Minimize2 className="h-4 w-4" />
-                ) : (
-                  <Maximize2 className="h-4 w-4" />
-                )}
-              </HeaderIconButton>
             )}
             <HeaderIconButton label="Close" onClick={onClose}>
               <X className="h-4 w-4" />

--- a/web/src/components/table/peek/PeekHeader.tsx
+++ b/web/src/components/table/peek/PeekHeader.tsx
@@ -138,7 +138,7 @@ export function PeekHeader({
 
   // Actions and open-in-tab ALWAYS live in the "…" menu — the header shows
   // only nav / expand / close inline (usage data: nav dwarfs everything else).
-  const hasMenu = Boolean(actionsMenu || openInNewTab);
+  const hasMenu = Boolean(actionsMenu || openInNewTab || expand);
   const hasNav = Boolean(detailNavigationKey && resolveDetailNavigationPath);
 
   // Measure + plan in a layout effect (before paint), reading width from the

--- a/web/src/components/table/peek/PeekHeader.tsx
+++ b/web/src/components/table/peek/PeekHeader.tsx
@@ -44,11 +44,10 @@ type PeekHeaderProps = {
   onClose: () => void;
 };
 
-// The title keeps at least this much width before anything else collapses; the
-// type badge falls back to this width when icon-only; the "…" trigger is an
-// icon-xs button. Tuned by eye — planner `safety` covers inter-control gaps.
+// The title keeps at least this much width before anything else collapses;
+// the "…" trigger is an icon-xs button. Tuned by eye — planner `safety`
+// covers inter-control gaps.
 const MIN_TITLE_PX = 240;
-const BADGE_ICON_PX = 32;
 const BADGE_LABEL_FALLBACK_PX = 72;
 const NAV_FULL_FALLBACK_PX = 92;
 const NAV_COMPACT_FALLBACK_PX = 52;
@@ -165,7 +164,11 @@ export function PeekHeader({
       headerWidth: width,
       minTitle: MIN_TITLE_PX,
       badgeLabelWidth: widthsRef.current.badgeLabel ?? BADGE_LABEL_FALLBACK_PX,
-      badgeIconWidth: BADGE_ICON_PX,
+      // The badge always renders `showLabel hideIcon` below — it never
+      // actually shrinks to icon-only — so the planner must see the same
+      // width for both inputs, or it credits the title with space the badge
+      // never gives up.
+      badgeIconWidth: widthsRef.current.badgeLabel ?? BADGE_LABEL_FALLBACK_PX,
       navFullWidth: hasNav
         ? (widthsRef.current.navFull ?? NAV_FULL_FALLBACK_PX)
         : 0,

--- a/web/src/components/table/peek/peek-observation-detail.tsx
+++ b/web/src/components/table/peek/peek-observation-detail.tsx
@@ -74,11 +74,13 @@ export const TablePeekViewObservationDetail = (
       {...props}
       title={traceDetailTitle(trace.data, traceId)}
       actions={
-        actionProps ? <TraceDetailActions {...actionProps} /> : undefined
+        actionProps ? (
+          <TraceDetailActions {...actionProps} layout="share-only" />
+        ) : undefined
       }
       actionsMenu={
         actionProps ? (
-          <TraceDetailActions {...actionProps} layout="menu" />
+          <TraceDetailActions {...actionProps} layout="delete-only" />
         ) : undefined
       }
     >

--- a/web/src/components/table/peek/peek-trace-detail.tsx
+++ b/web/src/components/table/peek/peek-trace-detail.tsx
@@ -68,11 +68,13 @@ export const TablePeekViewTraceDetail = (
       {...props}
       title={traceDetailTitle(trace.data, traceId)}
       actions={
-        actionProps ? <TraceDetailActions {...actionProps} /> : undefined
+        actionProps ? (
+          <TraceDetailActions {...actionProps} layout="share-only" />
+        ) : undefined
       }
       actionsMenu={
         actionProps ? (
-          <TraceDetailActions {...actionProps} layout="menu" />
+          <TraceDetailActions {...actionProps} layout="delete-only" />
         ) : undefined
       }
     >

--- a/web/src/features/navigate-detail-pages/DetailPageNav.tsx
+++ b/web/src/features/navigate-detail-pages/DetailPageNav.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @repo/no-null-render */
 import { Button, type ButtonProps } from "@/src/components/ui/button";
 import { InputCommandShortcut } from "@/src/components/ui/input-command";
-import { KeyboardShortcut } from "@/src/components/design-system/KeyboardShortcut/KeyboardShortcut";
 import {
   Tooltip,
   TooltipContent,
@@ -138,18 +137,18 @@ export const DetailPageNav = (props: {
   }, [previousPageEntry, nextPageEntry, navigateToEntry, pulseShortcut]);
 
   if (entries.length > 1) {
+    // Ghost icon buttons; the K/J hints live in the tooltips.
     const buttonClassName = (active: boolean) =>
       cn(
         "transition-[background-color,border-color,box-shadow,color] duration-150",
-        !compact && "gap-1.5 px-2",
-        active && "border-primary/60 bg-accent/60 ring-primary/20 ring-2",
+        active && "bg-accent/60 ring-primary/20 ring-2",
       );
     return (
       <div className="flex flex-row gap-1">
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
-              variant={compact ? "ghost" : "outline"}
+              variant="ghost"
               type="button"
               size={compact ? "icon-xs" : size}
               className={buttonClassName(shortcutPulse === "previous")}
@@ -161,11 +160,6 @@ export const DetailPageNav = (props: {
               }}
             >
               <ArrowUp className="h-4 w-4" />
-              {!compact && (
-                <span className="hidden md:inline-flex">
-                  <KeyboardShortcut keys={["K"]} />
-                </span>
-              )}
             </Button>
           </TooltipTrigger>
           <TooltipContent>
@@ -177,7 +171,7 @@ export const DetailPageNav = (props: {
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
-              variant={compact ? "ghost" : "outline"}
+              variant="ghost"
               type="button"
               size={compact ? "icon-xs" : size}
               className={buttonClassName(shortcutPulse === "next")}
@@ -189,11 +183,6 @@ export const DetailPageNav = (props: {
               }}
             >
               <ArrowDown className="h-4 w-4" />
-              {!compact && (
-                <span className="hidden md:inline-flex">
-                  <KeyboardShortcut keys={["J"]} />
-                </span>
-              )}
             </Button>
           </TooltipTrigger>
           <TooltipContent>

--- a/web/src/features/trace-graph-view/components/ElkGraphRenderer.tsx
+++ b/web/src/features/trace-graph-view/components/ElkGraphRenderer.tsx
@@ -548,7 +548,7 @@ export const ElkGraphRenderer: React.FC<ElkGraphRendererProps> = ({
       >
         <Button
           onClick={() => zoomBy(ZOOM_STEP)}
-          variant="outline"
+          variant="ghost"
           size="icon"
           className="bg-background/80 h-7 w-7 backdrop-blur"
           title="Zoom in"
@@ -557,7 +557,7 @@ export const ElkGraphRenderer: React.FC<ElkGraphRendererProps> = ({
         </Button>
         <Button
           onClick={() => zoomBy(1 / ZOOM_STEP)}
-          variant="outline"
+          variant="ghost"
           size="icon"
           className="bg-background/80 h-7 w-7 backdrop-blur"
           title="Zoom out"
@@ -566,7 +566,7 @@ export const ElkGraphRenderer: React.FC<ElkGraphRendererProps> = ({
         </Button>
         <Button
           onClick={handleFit}
-          variant="outline"
+          variant="ghost"
           size="icon"
           className="bg-background/80 h-7 w-7 backdrop-blur"
           title="Fit to view"

--- a/web/src/features/trace-graph-view/components/GraphViewModeSwitch.tsx
+++ b/web/src/features/trace-graph-view/components/GraphViewModeSwitch.tsx
@@ -1,29 +1,25 @@
 import React from "react";
-import { Combine, Route, type LucideIcon } from "lucide-react";
 
 import { cn } from "@/src/utils/tailwind";
 import { type GraphViewMode } from "../types";
 
 /**
- * Segmented mode switch overlaid on the graph canvas. Mirrors the Tree/Timeline
- * ViewModeSwitch styling (TracePanelNavigationHeader) so the trace view's mode
- * switches read as one family.
+ * Segmented mode switch overlaid on the graph canvas. Mirrors the
+ * Tree/Timeline/Graph ViewModeSwitch styling (TracePanelNavigationHeader) —
+ * text-only labels — so the trace view's mode switches read as one family.
  */
 const MODES: {
   mode: GraphViewMode;
-  icon: LucideIcon;
   label: string;
   title: string;
 }[] = [
   {
     mode: "aggregated",
-    icon: Combine,
     label: "Aggregated",
     title: "Repeated steps grouped into one node — the overall shape",
   },
   {
     mode: "expanded",
-    icon: Route,
     label: "Expanded",
     title: "Every call as its own node, in the order it ran",
   },
@@ -38,7 +34,7 @@ export function GraphViewModeSwitch({
 }) {
   return (
     <div className="bg-background/80 inline-flex h-7 items-center rounded-md border p-0.5 backdrop-blur">
-      {MODES.map(({ mode, icon: Icon, label, title }) => (
+      {MODES.map(({ mode, label, title }) => (
         <button
           key={mode}
           type="button"
@@ -47,16 +43,13 @@ export function GraphViewModeSwitch({
           aria-label={label}
           title={title}
           className={cn(
-            "flex h-6 items-center gap-1.5 rounded-md px-2 text-xs font-bold transition-colors",
+            "flex h-6 items-center rounded-md px-2 text-xs font-bold transition-colors",
             value === mode
               ? "bg-primary text-primary-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground",
           )}
         >
-          <Icon className="h-3.5 w-3.5 shrink-0" />
-          {/* Collapse to icons on narrow canvases (mirrors the nav header's
-              switch) so the pill never collides with the zoom stack. */}
-          <span className="@max-[340px]/graphcanvas:hidden">{label}</span>
+          {label}
         </button>
       ))}
     </div>

--- a/web/src/features/trace-graph-view/components/TraceGraphView.tsx
+++ b/web/src/features/trace-graph-view/components/TraceGraphView.tsx
@@ -42,6 +42,11 @@ type TraceGraphViewProps = {
    * system start/end nodes or background deselects.
    */
   onObservationSelect?: () => void;
+  /**
+   * Playback transport rendered beside the mode switch. A slot (not an import)
+   * so this feature module stays free of trace-view context dependencies.
+   */
+  transport?: React.ReactNode;
 };
 
 export const TraceGraphView: React.FC<TraceGraphViewProps> = ({
@@ -50,6 +55,7 @@ export const TraceGraphView: React.FC<TraceGraphViewProps> = ({
   viewMode = "aggregated",
   onViewModeChange,
   onObservationSelect,
+  transport,
 }) => {
   const [selectedNodeName, setSelectedNodeName] = useState<string | null>(null);
   const [currentObservationId, setCurrentObservationId] = useQueryParam(
@@ -348,11 +354,14 @@ export const TraceGraphView: React.FC<TraceGraphViewProps> = ({
           }
         />
       )}
-      {onViewModeChange && (
+      {(onViewModeChange || transport) && (
         // Overlaid sibling of the canvas (top-left, opposite the zoom stack)
         // so canvas clicks/gestures underneath are untouched.
-        <div className="absolute top-2 left-2 z-10">
-          <GraphViewModeSwitch value={viewMode} onChange={onViewModeChange} />
+        <div className="absolute top-2 left-2 z-10 flex items-center gap-1">
+          {onViewModeChange && (
+            <GraphViewModeSwitch value={viewMode} onChange={onViewModeChange} />
+          )}
+          {transport}
         </div>
       )}
     </div>

--- a/web/src/features/traces/components/PlaybackControls.tsx
+++ b/web/src/features/traces/components/PlaybackControls.tsx
@@ -1,16 +1,13 @@
 /* eslint-disable @repo/no-null-render */
 /**
- * PlaybackControls - transport for the trace playhead, in the navigation
- * header. The play/pause button is wrapped in a circular progress ring that
- * fills as the playhead sweeps the trace's total time — a compact "where are
- * we in the trace" indicator that isn't tied to the gantt. Stop resets it.
+ * PlaybackControls - transport for the trace playhead. The play/pause button
+ * is wrapped in a circular progress ring that fills as the playhead sweeps the
+ * trace's total time — a compact "where are we in the trace" indicator. Stop
+ * resets it.
  *
- * Shown only when there is something to WATCH play: the timeline view (the
- * sweeping playhead) or a visible graph panel (the node glow). In the default
- * tree view without a graph the transport is hidden — the row glow alone
- * isn't a playback surface — but it never disappears while a playhead is
- * actively placed, so an in-flight playback keeps its controls across view
- * switches.
+ * Mounted only inside the graph view's mode bar (the node glow is the one
+ * playback surface with controls); the timeline keeps its playhead and
+ * scrubbing but carries no transport buttons.
  *
  * The ring is driven imperatively off the playhead position feed, so it
  * animates at 60fps without re-rendering (only the play/pause icon flips, via
@@ -19,7 +16,6 @@
 
 import { useEffect, useRef } from "react";
 import { Pause, Play, Square } from "lucide-react";
-import { DropdownMenuItem } from "@/src/components/ui/dropdown-menu";
 import { StringParam, useQueryParam } from "use-query-params";
 import { Button } from "@/src/components/ui/button";
 import {
@@ -28,9 +24,6 @@ import {
   useShowPlayhead,
 } from "@/src/features/traces/contexts/PlayheadContext";
 import { useTraceData } from "@/src/features/traces/contexts/TraceDataContext";
-import { useTraceGraphData } from "@/src/features/traces/contexts/TraceGraphDataContext";
-import { useSearch } from "@/src/features/traces/contexts/SearchContext";
-import { useViewPreferences } from "@/src/features/traces/contexts/ViewPreferencesContext";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics";
 import { useTraceAnalyticsDimensions } from "@/src/features/traces/hooks/useTraceAnalyticsDimensions";
 
@@ -41,41 +34,19 @@ const RING_R = (RING_SIZE - RING_STROKE) / 2;
 const RING_C = 2 * Math.PI * RING_R;
 
 /**
- * Whether a playback surface exists to drive.
- *
- * Shared, because the transport has two homes now: inline in the header, and
- * folded into its overflow menu when the panel is too narrow for it. One rule for
- * both — a second copy would drift the moment either home changed.
- *
- * A playback surface exists in the timeline view (unless a search query has
- * replaced it with the search list) or when the graph panel renders — a
- * COLLAPSED panel still counts (the surface is one click away; hiding the
- * transport when the user collapses the panel would make it undiscoverable), and
- * a pending graph query counts too, so graph-eligible traces don't get a
- * transport pop-in after first load. An actively-placed playhead keeps its
- * controls regardless.
+ * Whether there is anything to play: the transport mounts only inside the
+ * graph view's chrome (its one playback surface), so the only remaining guard
+ * is a trace with actual duration.
  */
 function useHasPlayback(): boolean {
   const { traceDuration } = useTraceData();
-  const { isGraphViewAvailable, isLoading: isGraphDataLoading } =
-    useTraceGraphData();
-  const { showGraph } = useViewPreferences();
-  const { searchQuery } = useSearch();
-  const [viewMode] = useQueryParam("view", StringParam);
-  const showPlayhead = useShowPlayhead();
-
-  const isSearching = searchQuery.trim().length > 0;
-  const hasPlaybackSurface =
-    (viewMode === "timeline" && !isSearching) ||
-    (showGraph && (isGraphViewAvailable || isGraphDataLoading));
-  return traceDuration > 0 && (hasPlaybackSurface || showPlayhead);
+  return traceDuration > 0;
 }
 
 /**
- * Shared play/pause/stop handlers for the header buttons and the overflow
- * menu. Capture at this click seam (not the store's play/pause/stop): auto-pause
- * at end-of-trace must not look like a user stop, and a programmatic reset
- * must not inflate usage.
+ * Play/pause/stop click handlers. Capture at this click seam (not the store's
+ * play/pause/stop): auto-pause at end-of-trace must not look like a user stop,
+ * and a programmatic reset must not inflate usage.
  */
 function usePlaybackClickHandlers() {
   const capture = usePostHogClientCapture();
@@ -89,7 +60,11 @@ function usePlaybackClickHandlers() {
   // Tree is stored as a null query param; anything else is still tree.
   const props = {
     viewMode:
-      viewMode === "timeline" ? ("timeline" as const) : ("tree" as const),
+      viewMode === "timeline"
+        ? ("timeline" as const)
+        : viewMode === "graph"
+          ? ("graph" as const)
+          : ("tree" as const),
     observationCount: observations.length,
     ...analyticsDimensions,
   };
@@ -140,7 +115,7 @@ export function PlaybackControls() {
   if (!hasPlayback) return null;
 
   return (
-    <div className="ml-1 flex shrink-0 flex-row items-center gap-0.5">
+    <div className="flex shrink-0 flex-row items-center gap-0.5">
       <Button
         type="button"
         variant="ghost"
@@ -198,37 +173,5 @@ export function PlaybackControls() {
         <Square className="h-2.5 w-2.5" />
       </Button>
     </div>
-  );
-}
-
-/**
- * The transport as menu items, for the overflow menu the header folds into below
- * ~360px. Two 28px buttons plus their ring are what tipped that row over: the
- * search input collapsed to "Se" and the segmented switch clipped. Play is a
- * verb, so it reads fine as a menu entry — and unlike hiding it, the transport
- * stays reachable while a playhead is placed.
- */
-export function PlaybackMenuItems() {
-  const hasPlayback = useHasPlayback();
-  const { isPlaying, showPlayhead, handlePlayPause, handleStop } =
-    usePlaybackClickHandlers();
-
-  if (!hasPlayback) return null;
-
-  return (
-    <>
-      <DropdownMenuItem onSelect={handlePlayPause}>
-        {isPlaying ? (
-          <Pause className="mr-2 h-3.5 w-3.5" />
-        ) : (
-          <Play className="mr-2 h-3.5 w-3.5" />
-        )}
-        {isPlaying ? "Pause playback" : "Play trace over time"}
-      </DropdownMenuItem>
-      <DropdownMenuItem onSelect={handleStop} disabled={!showPlayhead}>
-        <Square className="mr-2 h-3 w-3" />
-        Stop playback
-      </DropdownMenuItem>
-    </>
   );
 }

--- a/web/src/features/traces/components/Trace.tsx
+++ b/web/src/features/traces/components/Trace.tsx
@@ -191,23 +191,20 @@ function TraceWithSelection({
  */
 function TraceContent({ desktopLayout }: { desktopLayout: DesktopLayout }) {
   const isMobile = useIsMobile();
-  const { showGraph } = useViewPreferences();
+  // Graph is a view: desktop via the Tree/Timeline/Graph switch, mobile via
+  // its Graph tab — both gated only on graph data being available.
   const { isGraphViewAvailable } = useTraceGraphData();
-  const shouldShowGraph = showGraph && isGraphViewAvailable;
+  // Annotation mode is a focused surface — no trace-level summary strip.
+  const { isAnnotationMode } = useViewPreferences();
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      {/* Trace-level attributes (tags included) have their only home here —
-          annotation mode still needs them, so the strip is not gated on it. */}
-      <TraceSummaryStrip />
+      {!isAnnotationMode && <TraceSummaryStrip />}
       <div className="min-h-0 flex-1">
         {isMobile ? (
-          <MobileTraceContent shouldShowGraph={shouldShowGraph} />
+          <MobileTraceContent shouldShowGraph={isGraphViewAvailable} />
         ) : (
-          <DesktopTraceContent
-            shouldShowGraph={shouldShowGraph}
-            desktopLayout={desktopLayout}
-          />
+          <DesktopTraceContent desktopLayout={desktopLayout} />
         )}
       </div>
     </div>
@@ -223,18 +220,14 @@ function TraceContent({ desktopLayout }: { desktopLayout: DesktopLayout }) {
  * - Navigation panel (left) + Detail panel (right)
  */
 function DesktopTraceContent({
-  shouldShowGraph,
   desktopLayout,
 }: {
-  shouldShowGraph: boolean;
   desktopLayout: DesktopLayout;
 }) {
   return (
     <TraceLayoutDesktop key={desktopLayout.groupId} {...desktopLayout}>
       <TraceLayoutDesktop.NavigationPanel>
-        <TracePanelNavigationLayoutDesktop
-          secondaryContent={shouldShowGraph ? <TraceGraphView /> : undefined}
-        >
+        <TracePanelNavigationLayoutDesktop>
           <TracePanelNavigation />
         </TracePanelNavigationLayoutDesktop>
       </TraceLayoutDesktop.NavigationPanel>

--- a/web/src/features/traces/components/Trace.tsx
+++ b/web/src/features/traces/components/Trace.tsx
@@ -2,10 +2,7 @@ import { type TraceDomain, type ScoreDomain } from "@langfuse/shared";
 import { type ObservationReturnTypeWithMetadata } from "@/src/server/api/routers/traces";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
 import { TraceDataProvider } from "@/src/features/traces/contexts/TraceDataContext";
-import {
-  ViewPreferencesProvider,
-  useViewPreferences,
-} from "@/src/features/traces/contexts/ViewPreferencesContext";
+import { ViewPreferencesProvider } from "@/src/features/traces/contexts/ViewPreferencesContext";
 import {
   SelectionProvider,
   useSelection,
@@ -186,7 +183,6 @@ function TraceWithSelection({
  *
  * Hooks:
  * - useIsMobile() - for responsive platform detection
- * - useViewPreferences() - for graph toggle state
  * - useTraceGraphData() - for graph availability
  */
 function TraceContent({ desktopLayout }: { desktopLayout: DesktopLayout }) {
@@ -194,12 +190,12 @@ function TraceContent({ desktopLayout }: { desktopLayout: DesktopLayout }) {
   // Graph is a view: desktop via the Tree/Timeline/Graph switch, mobile via
   // its Graph tab — both gated only on graph data being available.
   const { isGraphViewAvailable } = useTraceGraphData();
-  // Annotation mode is a focused surface — no trace-level summary strip.
-  const { isAnnotationMode } = useViewPreferences();
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      {!isAnnotationMode && <TraceSummaryStrip />}
+      {/* Trace-level attributes (tags included) have their only home here —
+          annotation mode still needs them, so the strip is not gated on it. */}
+      <TraceSummaryStrip />
       <div className="min-h-0 flex-1">
         {isMobile ? (
           <MobileTraceContent shouldShowGraph={isGraphViewAvailable} />

--- a/web/src/features/traces/components/TraceDetailActions.tsx
+++ b/web/src/features/traces/components/TraceDetailActions.tsx
@@ -1,6 +1,13 @@
 import { api } from "@/src/utils/api";
+import { MoreHorizontal } from "lucide-react";
 import { PublishTraceSwitch } from "@/src/components/publish-object-switch";
 import { DeleteTraceButton } from "@/src/components/deleteButton";
+import { Button } from "@/src/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/src/components/ui/popover";
 
 /**
  * Trace-level header actions (publish / delete) shared by the peek and
@@ -44,7 +51,13 @@ export function TraceDetailActions({
   deleteRedirectUrl?: string;
   onAfterDelete?: (deletedTraceId: string) => void;
   size?: "icon" | "icon-xs";
-  layout?: "toolbar" | "menu";
+  /**
+   * - "toolbar": Share visible + delete behind a "…" popover (full page header)
+   * - "menu": Share + Delete as labeled rows (mobile overflow)
+   * - "share-only": just the Share switch (peek header, inline)
+   * - "delete-only": just the Delete row (peek header's "…" menu)
+   */
+  layout?: "toolbar" | "menu" | "share-only" | "delete-only";
 }) {
   const utils = api.useUtils();
   const isMenu = layout === "menu";
@@ -58,6 +71,35 @@ export function TraceDetailActions({
     utils.invalidate();
     onAfterDelete?.(traceId);
   };
+
+  if (layout === "share-only") {
+    return (
+      <PublishTraceSwitch
+        projectId={projectId}
+        traceId={traceId}
+        timestamp={timestamp}
+        isPublic={isPublic}
+        shareUrl={shareUrl}
+        size={size}
+        tooltip={isPublic ? "Shared (public)" : "Share"}
+      />
+    );
+  }
+
+  if (layout === "delete-only") {
+    return (
+      <DeleteTraceButton
+        itemId={traceId}
+        projectId={projectId}
+        redirectUrl={deleteRedirectUrl}
+        invalidateFunc={onDeleteInvalidate}
+        deleteConfirmation={name ?? ""}
+        variant="ghost"
+        size="sm"
+        className="w-full justify-start font-normal"
+      />
+    );
+  }
 
   if (isMenu) {
     return (
@@ -95,18 +137,38 @@ export function TraceDetailActions({
         size={size}
         tooltip={isPublic ? "Shared (public)" : "Share"}
       />
-      <DeleteTraceButton
-        itemId={traceId}
-        projectId={projectId}
-        redirectUrl={deleteRedirectUrl}
-        invalidateFunc={onDeleteInvalidate}
-        deleteConfirmation={name ?? ""}
-        icon
-        // Match Publish so both icons share one row height and a ghost (not
-        // boxed "outline") style.
-        size={size}
-        variant="ghost"
-      />
+      {/* Delete is low-traffic (~100 users/30d) and destructive — folded
+          behind an overflow trigger instead of a bare trash icon in the
+          toolbar. forceMount + hide-when-closed: DeleteTraceButton hosts its
+          own confirm dialog, which a default Popover would unmount mid-flow. */}
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            size={size}
+            title="More actions"
+            aria-label="More actions"
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="end"
+          forceMount
+          className="flex w-auto min-w-36 flex-col gap-0.5 p-1 data-[state=closed]:hidden"
+        >
+          <DeleteTraceButton
+            itemId={traceId}
+            projectId={projectId}
+            redirectUrl={deleteRedirectUrl}
+            invalidateFunc={onDeleteInvalidate}
+            deleteConfirmation={name ?? ""}
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start font-normal"
+          />
+        </PopoverContent>
+      </Popover>
     </div>
   );
 }

--- a/web/src/features/traces/components/TraceGraphView/TraceGraphView.tsx
+++ b/web/src/features/traces/components/TraceGraphView/TraceGraphView.tsx
@@ -15,6 +15,7 @@ import { useViewPreferences } from "@/src/features/traces/contexts/ViewPreferenc
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics";
 import { useTraceAnalyticsDimensions } from "@/src/features/traces/hooks/useTraceAnalyticsDimensions";
 import { useMobileLayoutContextOptional } from "../TraceLayoutMobile";
+import { PlaybackControls } from "../PlaybackControls";
 
 export function TraceGraphView() {
   const { agentGraphData, isLoading } = useTraceGraphData();
@@ -70,6 +71,7 @@ export function TraceGraphView() {
       viewMode={graphViewMode}
       onViewModeChange={handleViewModeChange}
       onObservationSelect={handleObservationSelect}
+      transport={<PlaybackControls />}
     />
   );
 }

--- a/web/src/features/traces/components/TraceGraphView/TraceGraphView.tsx
+++ b/web/src/features/traces/components/TraceGraphView/TraceGraphView.tsx
@@ -6,11 +6,14 @@
  * and uses data from GraphDataContext.
  */
 
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { TraceGraphView as TraceGraphViewComponent } from "@/src/features/trace-graph-view/components/TraceGraphView";
 import { type GraphViewMode } from "@/src/features/trace-graph-view/types";
 import { useTraceGraphData } from "@/src/features/traces/contexts/TraceGraphDataContext";
-import { useActiveObservationIds } from "@/src/features/traces/contexts/PlayheadContext";
+import {
+  useActiveObservationIds,
+  usePlayhead,
+} from "@/src/features/traces/contexts/PlayheadContext";
 import { useViewPreferences } from "@/src/features/traces/contexts/ViewPreferencesContext";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics";
 import { useTraceAnalyticsDimensions } from "@/src/features/traces/hooks/useTraceAnalyticsDimensions";
@@ -20,6 +23,7 @@ import { PlaybackControls } from "../PlaybackControls";
 export function TraceGraphView() {
   const { agentGraphData, isLoading } = useTraceGraphData();
   const activeObservationIds = useActiveObservationIds();
+  const { stop: stopPlayback } = usePlayhead();
   const { graphViewMode, setGraphViewMode } = useViewPreferences();
   const capture = usePostHogClientCapture();
   const analyticsDimensions = useTraceAnalyticsDimensions();
@@ -51,6 +55,13 @@ export function TraceGraphView() {
     },
     [capture, graphViewMode, setGraphViewMode, analyticsDimensions],
   );
+
+  // Playback is a Graph-only feature (its controls mount below via
+  // `transport`), but the playhead store outlives this component — it is
+  // owned by PlayheadProvider one level up, so it keeps sweeping in the
+  // background if left running when the user switches away from Graph.
+  // Stop and reset it here so playback never outlives the view it belongs to.
+  useEffect(() => () => stopPlayback(), [stopPlayback]);
 
   if (isLoading) {
     return (

--- a/web/src/features/traces/components/TraceLayoutDesktop.tsx
+++ b/web/src/features/traces/components/TraceLayoutDesktop.tsx
@@ -139,7 +139,6 @@ interface TraceLayoutDesktopContext {
   setIsNavigationPanelCollapsed: (collapsed: boolean) => void;
   panelRef: React.RefObject<PanelImperativeHandle | null>;
   handleTogglePanel: () => void;
-  shouldPulseToggle: boolean;
   // Detail (info/preview) panel — collapsible like the navigation panel.
   detailPanelRef: React.RefObject<PanelImperativeHandle | null>;
   isDetailPanelCollapsed: boolean;
@@ -181,10 +180,6 @@ export function TraceLayoutDesktop({
   defaultNavigationCollapsed: boolean;
   expandDetailOnMount: boolean;
 }) {
-  // Get current view mode from URL
-  const [viewMode] = useQueryParam("view", StringParam);
-  const isTimelineView = viewMode === "timeline";
-
   // Peek sizing depends on the drawer width; persistence scope is caller-owned.
   const { isPeekMode } = useViewPreferences();
 
@@ -435,27 +430,11 @@ export function TraceLayoutDesktop({
     }
   };
 
-  // Pulse animation: hint to user that panel can be collapsed when switching to timeline
-  const [shouldPulseToggle, setShouldPulseToggle] = useState(false);
-
-  useEffect(() => {
-    if (isTimelineView) {
-      setShouldPulseToggle(true);
-      const timeout = setTimeout(() => {
-        setShouldPulseToggle(false);
-      }, 12000); // Stop pulse after 12 seconds
-      return () => clearTimeout(timeout);
-    }
-    // Reset pulse when leaving timeline view
-    setShouldPulseToggle(false);
-  }, [isTimelineView]);
-
   const contextValue: TraceLayoutDesktopContext = {
     isNavigationPanelCollapsed,
     setIsNavigationPanelCollapsed,
     panelRef,
     handleTogglePanel,
-    shouldPulseToggle,
     detailPanelRef,
     isDetailPanelCollapsed,
     setIsDetailPanelCollapsed,

--- a/web/src/features/traces/components/TracePanelNavigation.tsx
+++ b/web/src/features/traces/components/TracePanelNavigation.tsx
@@ -19,29 +19,37 @@
 
 import { StringParam, useQueryParam } from "use-query-params";
 import { useSearch } from "@/src/features/traces/contexts/SearchContext";
+import { useTraceGraphData } from "@/src/features/traces/contexts/TraceGraphDataContext";
 import { TraceTree } from "./TraceTree";
 import { TraceSearchList } from "./TraceSearchList";
 import { TraceTimelineCompact } from "./TraceTimelineDense/TraceTimelineCompact";
+import { TraceGraphView } from "./TraceGraphView/TraceGraphView";
 import { useMemo } from "react";
 
 export function TracePanelNavigation() {
   const { searchQuery } = useSearch();
+  const { isGraphViewAvailable } = useTraceGraphData();
   const [viewMode] = useQueryParam("view", StringParam);
 
   const hasQuery = searchQuery.trim().length > 0;
   const isTimelineView = viewMode === "timeline";
+  // A stale ?view=graph URL on a trace without graph data falls back to tree.
+  const isGraphView = viewMode === "graph" && isGraphViewAvailable;
 
   // Memoize to prevent recreation when deps haven't changed
   const content = useMemo(() => {
-    // Priority: Search > Timeline > Tree
+    // Priority: Search > Graph > Timeline > Tree
     if (hasQuery) {
       return <TraceSearchList />;
+    }
+    if (isGraphView) {
+      return <TraceGraphView />;
     }
     if (isTimelineView) {
       return <TraceTimelineCompact />;
     }
     return <TraceTree />;
-  }, [hasQuery, isTimelineView]);
+  }, [hasQuery, isGraphView, isTimelineView]);
 
   return content;
 }

--- a/web/src/features/traces/components/TracePanelNavigationHeader/TracePanelNavigationHeader.tsx
+++ b/web/src/features/traces/components/TracePanelNavigationHeader/TracePanelNavigationHeader.tsx
@@ -21,10 +21,7 @@ import {
   UnfoldVertical,
   Download,
   Loader2,
-  ListTree,
-  GanttChartSquare,
-  MoreHorizontal,
-  type LucideIcon,
+  SlidersHorizontal,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -36,16 +33,12 @@ import {
 import { StringParam, useQueryParam } from "use-query-params";
 import { cn } from "@/src/utils/tailwind";
 import { useCallback } from "react";
-import {
-  TraceSettingsDropdown,
-  TraceViewOptionsMenuItems,
-} from "../TraceSettingsDropdown";
+import { TraceViewOptionsMenuItems } from "../TraceSettingsDropdown";
 import {
   downloadLegacyTraceAsJson,
   downloadServerTraceAsJson,
 } from "../../fns/downloadTrace";
 import { TracePanelNavigationButton } from "./components/TracePanelNavigationButton";
-import { PlaybackControls, PlaybackMenuItems } from "../PlaybackControls";
 import { useDesktopLayoutContextOptional } from "../TraceLayoutDesktop";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics";
 import { useTraceAnalyticsDimensions } from "@/src/features/traces/hooks/useTraceAnalyticsDimensions";
@@ -56,7 +49,6 @@ import { useWatchedPromiseCallback } from "@/src/hooks/useWatchedPromiseCallback
 interface TracePanelNavigationHeaderProps {
   isPanelCollapsed: boolean;
   onTogglePanel: () => void;
-  shouldPulseToggle?: boolean;
 }
 
 export function TracePanelNavigationHeader(
@@ -71,14 +63,12 @@ export function TracePanelNavigationHeader(
 function TracePanelNavigationHeaderCollapsed({
   isPanelCollapsed,
   onTogglePanel,
-  shouldPulseToggle = false,
 }: TracePanelNavigationHeaderProps) {
   return (
     <div className="flex w-full flex-row items-center justify-center p-2">
       <TracePanelNavigationButton
         isPanelCollapsed={isPanelCollapsed}
         onTogglePanel={onTogglePanel}
-        shouldPulseToggle={shouldPulseToggle}
       />
     </div>
   );
@@ -87,7 +77,6 @@ function TracePanelNavigationHeaderCollapsed({
 function TracePanelNavigationHeaderExpanded({
   isPanelCollapsed,
   onTogglePanel,
-  shouldPulseToggle = false,
 }: TracePanelNavigationHeaderProps) {
   const { searchInputValue, setSearchInputValue, setSearchQueryImmediate } =
     useSearch();
@@ -176,26 +165,20 @@ function TracePanelNavigationHeaderExpanded({
       }
     }, [isV4, observations, trace, capture, analyticsDimensions]);
 
-  const isTimelineView = viewMode === "timeline";
+  const activeView: TraceViewMode =
+    viewMode === "timeline"
+      ? "timeline"
+      : viewMode === "graph" && isGraphViewAvailable
+        ? "graph"
+        : "tree";
 
   return (
     <Command className="flex h-auto shrink-0 flex-col gap-1 overflow-hidden rounded-none border-b">
-      {/* Responsive toolbar via container queries on this row's own width — no JS
-          measurement. The breakpoints are tuned to the row's actual content
-          minimums (all fixed-size icon buttons plus the search input's
-          min-width, so the sums are font-independent). Measured states:
-
-            ≥ 440px   switcher labels, minor tools and transport all inline
-            360-440   switcher icons-only, tools and transport still inline
-            < 360px   tools AND transport folded into the "…" menu; this row
-                      first overflows at 188px, well under the 260px panel min
-
-          Hence: labels < 440px → hidden; tools and the transport < 360px →
-          folded; search < 300px → narrower min-width (covers dragging to the
-          panel min). If you ADD anything to this row, re-measure and retune all
-          three — stale thresholds show up as a clipped switcher at default
-          widths, which is what the folding exists to prevent. */}
-      <div className="@container/navheader flex flex-row items-center justify-between pr-2 pl-1">
+      {/* Toolbar: search, download, view-options menu, view switch. flex-wrap
+          lets the switch drop to its own line on a narrow panel instead of
+          clipping (text segments cannot shrink). A container query cannot
+          reach into the menu's portal, so menu contents never depend on it. */}
+      <div className="@container/navheader flex flex-row flex-wrap items-center justify-between gap-y-1 pr-2 pl-1">
         {/* Panel Toggle Button; special p-0.5 offset to pixel align with closed
             version. Hidden while the detail panel is closed (nothing useful to
             collapse the full-width tree/timeline into). */}
@@ -204,7 +187,6 @@ function TracePanelNavigationHeaderExpanded({
             <TracePanelNavigationButton
               isPanelCollapsed={isPanelCollapsed}
               onTogglePanel={onTogglePanel}
-              shouldPulseToggle={shouldPulseToggle}
             />
           </div>
         )}
@@ -222,53 +204,33 @@ function TracePanelNavigationHeaderExpanded({
           />
         </div>
         <div className="flex shrink-0 flex-row items-center gap-0.5">
-          {/* Minor tools — inline when the panel is wide enough. */}
-          <div className="hidden flex-row items-center gap-0.5 @min-[360px]/navheader:flex">
-            <Button
-              onClick={handleToggleTreeNodes}
-              variant="ghost"
-              size="icon"
-              title={isEverythingCollapsed ? "Expand all" : "Collapse all"}
-              className="h-7 w-7"
-            >
-              {isEverythingCollapsed ? (
-                <UnfoldVertical className="h-3.5 w-3.5" />
-              ) : (
-                <FoldVertical className="h-3.5 w-3.5" />
-              )}
-            </Button>
+          {/* Download stays inline (heavily used); lower-traffic tools live
+              in the view-options menu. */}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleDownload}
+            disabled={isDownloading}
+            title="Download trace as JSON"
+            className="h-7 w-7"
+          >
+            {isDownloading ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Download className="h-3.5 w-3.5" />
+            )}
+          </Button>
 
-            <TraceSettingsDropdown
-              isGraphViewAvailable={isGraphViewAvailable}
-            />
-
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={handleDownload}
-              disabled={isDownloading}
-              title="Download trace as JSON"
-              className="h-7 w-7"
-            >
-              {isDownloading ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Download className="h-3.5 w-3.5" />
-              )}
-            </Button>
-          </div>
-
-          {/* …and folded into an overflow menu when it's narrow. */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
                 variant="ghost"
                 size="icon"
-                title="More"
-                aria-label="More options"
-                className="h-7 w-7 @min-[360px]/navheader:hidden"
+                title="View options"
+                aria-label="View options"
+                className="h-7 w-7"
               >
-                <MoreHorizontal className="h-3.5 w-3.5" />
+                <SlidersHorizontal className="h-3.5 w-3.5" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="center" className="w-64">
@@ -280,79 +242,74 @@ function TracePanelNavigationHeaderExpanded({
                 )}
                 {isEverythingCollapsed ? "Expand all" : "Collapse all"}
               </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => handleDownload()}
-                disabled={isDownloading}
-              >
-                <Download className="mr-2 h-3.5 w-3.5" />
-                Download trace as JSON
-              </DropdownMenuItem>
-              <PlaybackMenuItems />
               <DropdownMenuSeparator />
-              <TraceViewOptionsMenuItems
-                isGraphViewAvailable={isGraphViewAvailable}
-              />
+              <TraceViewOptionsMenuItems />
             </DropdownMenuContent>
           </DropdownMenu>
 
-          {/* Playback transport + circular time-progress ring. View-agnostic:
-              shown in both Tree and Timeline views (see PlaybackControls) — and
-              folded into the overflow menu on a narrow panel, like the tools
-              above it. Two more 28px buttons are what tipped this row over: the
-              search input collapsed to "Se" and the switch clipped. */}
-          <div className="hidden flex-row items-center @min-[360px]/navheader:flex">
-            <PlaybackControls />
-          </div>
-
-          {/* Tree / Timeline segmented switch (labels collapse to icons when
-              the panel is narrow — see @container/navheader). */}
-          <ViewModeSwitch
-            isTimelineView={isTimelineView}
-            onSelect={(timeline) => {
-              // Clicking the already-active segment is a no-op — don't count it.
-              if (timeline !== isTimelineView) {
-                capture("trace_detail:view_mode_switch", {
-                  viewMode: timeline ? "timeline" : "tree",
-                  ...analyticsDimensions,
-                });
-              }
-              setViewMode(timeline ? "timeline" : null);
-            }}
-          />
           {/* When the detail panel is closed it shows its own collapsed rail
               with a "Show detail panel" button on the right edge (DetailPanel in
               TraceLayoutDesktop, mirroring the navigation panel's rail), so the
               header needs no re-open button of its own. */}
+        </div>
+        {/* The view switch is its own flex item so it wraps to a second line
+            on a narrow panel instead of clipping at the panel edge. */}
+        <div className="flex shrink-0 items-center">
+          <ViewModeSwitch
+            activeView={activeView}
+            showGraphSegment={isGraphViewAvailable}
+            onSelect={(view) => {
+              // Clicking the already-active segment is a no-op — don't count it.
+              if (view !== activeView) {
+                capture("trace_detail:view_mode_switch", {
+                  viewMode: view,
+                  ...analyticsDimensions,
+                });
+              }
+              setViewMode(view === "tree" ? null : view);
+            }}
+          />
         </div>
       </div>
     </Command>
   );
 }
 
+export type TraceViewMode = "tree" | "timeline" | "graph";
+
 function ViewModeSwitch({
-  isTimelineView,
+  activeView,
+  showGraphSegment,
   onSelect,
 }: {
-  isTimelineView: boolean;
-  onSelect: (timeline: boolean) => void;
+  activeView: TraceViewMode;
+  showGraphSegment: boolean;
+  onSelect: (view: TraceViewMode) => void;
 }) {
   return (
     <div className="bg-muted/60 ml-2 inline-flex h-7 shrink-0 items-center rounded-md border p-0.5">
       <ViewModeSegment
-        active={!isTimelineView}
-        onClick={() => onSelect(false)}
-        icon={ListTree}
+        active={activeView === "tree"}
+        onClick={() => onSelect("tree")}
         label="Tree"
       />
       {/* One Timeline. What it IS depends on the Compact Timeline feature
           preview — see TracePanelNavigation — rather than on a third segment
           the user has to understand. */}
       <ViewModeSegment
-        active={isTimelineView}
-        onClick={() => onSelect(true)}
-        icon={GanttChartSquare}
+        active={activeView === "timeline"}
+        onClick={() => onSelect("timeline")}
         label="Timeline"
       />
+      {/* Graph is a full view, not a side panel — the segment only exists for
+          traces that have graph data (agent traces under the node cap). */}
+      {showGraphSegment && (
+        <ViewModeSegment
+          active={activeView === "graph"}
+          onClick={() => onSelect("graph")}
+          label="Graph"
+        />
+      )}
     </div>
   );
 }
@@ -360,12 +317,10 @@ function ViewModeSwitch({
 function ViewModeSegment({
   active,
   onClick,
-  icon: Icon,
   label,
 }: {
   active: boolean;
   onClick: () => void;
-  icon: LucideIcon;
   label: string;
 }) {
   return (
@@ -375,14 +330,13 @@ function ViewModeSegment({
       aria-pressed={active}
       title={label}
       className={cn(
-        "flex h-6 items-center gap-1.5 rounded-md px-2 text-xs font-bold transition-colors",
+        "flex h-6 items-center rounded-md px-2 text-xs font-bold transition-colors",
         active
           ? "bg-primary text-primary-foreground shadow-sm"
           : "text-muted-foreground hover:text-foreground",
       )}
     >
-      <Icon className="h-3.5 w-3.5 shrink-0" />
-      <span className="@max-[440px]/navheader:hidden">{label}</span>
+      {label}
     </button>
   );
 }

--- a/web/src/features/traces/components/TracePanelNavigationHeader/TracePanelNavigationHeader.tsx
+++ b/web/src/features/traces/components/TracePanelNavigationHeader/TracePanelNavigationHeader.tsx
@@ -275,7 +275,7 @@ function TracePanelNavigationHeaderExpanded({
   );
 }
 
-export type TraceViewMode = "tree" | "timeline" | "graph";
+type TraceViewMode = "tree" | "timeline" | "graph";
 
 function ViewModeSwitch({
   activeView,

--- a/web/src/features/traces/components/TracePanelNavigationHeader/components/TracePanelNavigationButton.tsx
+++ b/web/src/features/traces/components/TracePanelNavigationHeader/components/TracePanelNavigationButton.tsx
@@ -7,13 +7,11 @@ import { useTraceAnalyticsDimensions } from "@/src/features/traces/hooks/useTrac
 interface TracePanelNavigationButtonProps {
   isPanelCollapsed: boolean;
   onTogglePanel: () => void;
-  shouldPulseToggle?: boolean;
 }
 
 export function TracePanelNavigationButton({
   isPanelCollapsed,
   onTogglePanel,
-  shouldPulseToggle = false,
 }: TracePanelNavigationButtonProps) {
   const capture = usePostHogClientCapture();
   const analyticsDimensions = useTraceAnalyticsDimensions();
@@ -38,14 +36,6 @@ export function TracePanelNavigationButton({
           <PanelLeftClose className="h-3.5 w-3.5" />
         )}
       </Button>
-
-      {/* Pulsing status indicator */}
-      {shouldPulseToggle && (
-        <span className="pointer-events-none absolute top-0.5 right-0.5 flex h-2.5 w-2.5">
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-75" />
-          <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-blue-500" />
-        </span>
-      )}
     </div>
   );
 }

--- a/web/src/features/traces/components/TracePanelNavigationLayoutDesktop/TracePanelNavigationLayoutDesktop.tsx
+++ b/web/src/features/traces/components/TracePanelNavigationLayoutDesktop/TracePanelNavigationLayoutDesktop.tsx
@@ -5,226 +5,40 @@
  * - Wrap navigation content with header and collapsible layout structure
  * - Handle panel collapse/expand state for desktop
  * - Position the truncation + hidden-observation notices above content
- * - Render graph view panel below tree/timeline when enabled
- * - Own the graph panel's collapse state: drag the divider down (or click the
- *   "Graph" bar) to collapse it to a slim bar; persisted per-project. Traces
- *   that only qualify for a graph via the >1-node rule start collapsed;
- *   real agent graphs start expanded.
+ *
+ * The graph used to render here as a resizable secondary panel below the
+ * tree/timeline; it is a full view on the Tree/Timeline/Graph switch now, so
+ * this wrapper is just header + notices + content.
  *
  * Hooks:
  * - useDesktopLayoutContext() - for panel collapse state
- * - useTraceData() - for the per-project persistence key
- * - useTraceGraphData() - for the collapsed-by-default heuristic
  */
 
-import { useLayoutEffect, useRef, type ReactNode } from "react";
-import { ChevronDown, ChevronUp } from "lucide-react";
-import { useGroupRef } from "react-resizable-panels";
-import {
-  ResizablePanel,
-  ResizablePanelGroup,
-  ResizableHandle,
-  usePanelRef,
-  useDefaultLayout,
-} from "@/src/components/ui/resizable";
-import useLocalStorage from "@/src/components/useLocalStorage";
+import { type ReactNode } from "react";
 import { useDesktopLayoutContext } from "../TraceLayoutDesktop";
-import { useTraceData } from "@/src/features/traces/contexts/TraceDataContext";
-import { useTraceGraphData } from "@/src/features/traces/contexts/TraceGraphDataContext";
-import { useViewPreferences } from "@/src/features/traces/contexts/ViewPreferencesContext";
 import { TracePanelNavigationHeader } from "../TracePanelNavigationHeader/TracePanelNavigationHeader";
 import { TracePanelNavigationHiddenNotice } from "./components/TracePanelNavigationHiddenNotice";
 import { TraceTruncationNotice } from "@/src/features/traces/components/TraceTruncationNotice";
 
-// Height of the "Graph" bar — the panel's collapsed form. Must match the bar's
-// h-7 so a collapsed panel shows exactly the bar and nothing else.
-const GRAPH_BAR_PX = 28;
-
-// The tree/graph split persists in localStorage like the outer nav/detail
-// split (LFE-10601/LFE-10729 model): peek and full-page each keep their own
-// group so a ratio dragged in the short peek panel doesn't leak into the tall
-// full-page view and vice versa. The graph panel's collapse state persists
-// separately (per-project, below) — the saved layout is always the OPEN ratio.
-const GRAPH_SPLIT_GROUP_ID = "trace-nav-graph-split-v1";
-const PEEK_GRAPH_SPLIT_GROUP_ID = "trace-nav-graph-split-peek-v1";
-const GRAPH_SPLIT_TREE_PANEL_ID = "trace-nav-graph-split-tree";
-const GRAPH_SPLIT_GRAPH_PANEL_ID = "trace-nav-graph-split-graph";
-
-// No-op storage so `useDefaultLayout` never touches a real Storage during
-// SSR / DOM-less tests (mirrors TraceLayoutDesktop).
-const NOOP_LAYOUT_STORAGE = {
-  getItem: () => null,
-  setItem: () => {},
-};
-
-/**
- * Slim header strip of the graph panel — its collapsed form, and the
- * click-to-toggle affordance while expanded (mirrors the mobile layout's bar).
- */
-function GraphPanelBar({
-  collapsed,
-  onToggle,
-}: {
-  collapsed: boolean;
-  onToggle: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onToggle}
-      title={collapsed ? "Expand graph panel" : "Collapse graph panel"}
-      aria-expanded={!collapsed}
-      className="text-muted-foreground hover:bg-muted/50 hover:text-foreground flex h-7 w-full shrink-0 items-center justify-between border-b px-2"
-    >
-      <span className="text-xs font-bold">Graph</span>
-      {collapsed ? (
-        <ChevronUp className="h-3.5 w-3.5" />
-      ) : (
-        <ChevronDown className="h-3.5 w-3.5" />
-      )}
-    </button>
-  );
-}
-
 export function TracePanelNavigationLayoutDesktop({
   children,
-  secondaryContent,
 }: {
   children: ReactNode;
-  secondaryContent?: ReactNode;
 }) {
-  const { isNavigationPanelCollapsed, handleTogglePanel, shouldPulseToggle } =
+  const { isNavigationPanelCollapsed, handleTogglePanel } =
     useDesktopLayoutContext();
-  const { trace } = useTraceData();
-  const { isAgentGraph } = useTraceGraphData();
-  const { isPeekMode } = useViewPreferences();
-
-  // Per-project persisted collapse. Tri-state: null = no user choice yet, so
-  // the default stays reactive (agent graphs expand, >1-node-only graphs stay
-  // collapsed) instead of freezing whatever loaded first into storage.
-  const [storedGraphCollapsed, setStoredGraphCollapsed] = useLocalStorage<
-    boolean | null
-  >(`trace-graph-panel-collapsed-${trace.projectId}`, null);
-  const graphCollapsed = storedGraphCollapsed ?? !isAgentGraph;
-
-  const graphPanelRef = usePanelRef();
-  const graphGroupRef = useGroupRef();
-
-  // Persisted tree/graph ratio (see the group-id comment above).
-  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
-    id: isPeekMode ? PEEK_GRAPH_SPLIT_GROUP_ID : GRAPH_SPLIT_GROUP_ID,
-    panelIds: [GRAPH_SPLIT_TREE_PANEL_ID, GRAPH_SPLIT_GRAPH_PANEL_ID],
-    storage:
-      typeof window === "undefined" ? NOOP_LAYOUT_STORAGE : window.localStorage,
-  });
-
-  // Save only the OPEN ratio: while the graph panel sits on its 28px rail the
-  // layout is the collapse state (persisted separately) — letting it through
-  // would overwrite the user's preferred split with the rail share. The ref
-  // tracks the freshest saved share for the expand-restore below (the hook's
-  // `defaultLayout` is the mount-time snapshot).
-  const lastOpenGraphSharePct = useRef<number | null>(
-    defaultLayout?.[GRAPH_SPLIT_GRAPH_PANEL_ID] ?? null,
-  );
-  const handleLayoutChanged = (layout: Record<string, number>) => {
-    if (graphPanelRef.current?.isCollapsed()) return;
-    lastOpenGraphSharePct.current =
-      layout[GRAPH_SPLIT_GRAPH_PANEL_ID] ?? lastOpenGraphSharePct.current;
-    onLayoutChanged(layout);
-  };
-
-  // State → panel: keep the imperative panel in sync (mount, storage default,
-  // bar toggle). Pre-paint so an initially-collapsed panel never flashes open.
-  useLayoutEffect(() => {
-    const panel = graphPanelRef.current;
-    if (!panel) return;
-    if (graphCollapsed && !panel.isCollapsed()) {
-      panel.collapse();
-    } else if (!graphCollapsed && panel.isCollapsed()) {
-      // A panel that mounted collapsed has no in-session pre-collapse size —
-      // a bare expand() falls back to its minSize. Reopen at the persisted
-      // open ratio instead, atomically via the GROUP (chained per-panel
-      // expand()+resize() validates against a stale store and no-ops — the
-      // TraceLayoutDesktop lesson). Bounded by the panels' 20% mins so a
-      // corrupt value can't strand the layout.
-      const share = lastOpenGraphSharePct.current;
-      const group = graphGroupRef.current;
-      if (group && share !== null && share >= 20 && share <= 80) {
-        group.setLayout({
-          [GRAPH_SPLIT_TREE_PANEL_ID]: 100 - share,
-          [GRAPH_SPLIT_GRAPH_PANEL_ID]: share,
-        });
-      } else {
-        panel.expand();
-      }
-    }
-  }, [graphCollapsed, graphPanelRef, graphGroupRef, secondaryContent]);
 
   return (
     <div className="flex h-full flex-col border-r">
       <TracePanelNavigationHeader
         isPanelCollapsed={isNavigationPanelCollapsed}
         onTogglePanel={handleTogglePanel}
-        shouldPulseToggle={shouldPulseToggle}
       />
       {!isNavigationPanelCollapsed && (
         <>
           <TraceTruncationNotice />
           <TracePanelNavigationHiddenNotice />
-          {secondaryContent ? (
-            <ResizablePanelGroup
-              orientation="vertical"
-              className="flex-1 overflow-hidden"
-              id={isPeekMode ? PEEK_GRAPH_SPLIT_GROUP_ID : GRAPH_SPLIT_GROUP_ID}
-              groupRef={graphGroupRef}
-              defaultLayout={defaultLayout}
-              onLayoutChanged={handleLayoutChanged}
-            >
-              <ResizablePanel
-                id={GRAPH_SPLIT_TREE_PANEL_ID}
-                defaultSize="60%"
-                minSize="20%"
-              >
-                <div className="h-full overflow-hidden">{children}</div>
-              </ResizablePanel>
-              <ResizableHandle className="bg-border h-px" />
-              <ResizablePanel
-                id={GRAPH_SPLIT_GRAPH_PANEL_ID}
-                defaultSize="40%"
-                minSize="20%"
-                collapsible
-                collapsedSize={`${GRAPH_BAR_PX}px`}
-                panelRef={graphPanelRef}
-                onResize={(_size, _id, prevPanelSize) => {
-                  // Panel → state: a divider drag snapped the panel
-                  // collapsed/open — persist the user's choice. Skip the
-                  // mount call (prevPanelSize undefined): it reports the
-                  // pre-sync defaultSize and would clobber a stored/default
-                  // collapsed state before the layout effect below applies it.
-                  if (prevPanelSize === undefined) return;
-                  const collapsed =
-                    graphPanelRef.current?.isCollapsed() ?? false;
-                  if (collapsed !== graphCollapsed) {
-                    setStoredGraphCollapsed(collapsed);
-                  }
-                }}
-              >
-                <div className="flex h-full flex-col overflow-hidden">
-                  <GraphPanelBar
-                    collapsed={graphCollapsed}
-                    onToggle={() => setStoredGraphCollapsed(!graphCollapsed)}
-                  />
-                  {!graphCollapsed && (
-                    <div className="min-h-0 flex-1 overflow-hidden">
-                      {secondaryContent}
-                    </div>
-                  )}
-                </div>
-              </ResizablePanel>
-            </ResizablePanelGroup>
-          ) : (
-            <div className="flex-1 overflow-hidden">{children}</div>
-          )}
+          <div className="flex-1 overflow-hidden">{children}</div>
         </>
       )}
     </div>

--- a/web/src/features/traces/components/TraceSettingsDropdown.tsx
+++ b/web/src/features/traces/components/TraceSettingsDropdown.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @repo/no-abstracted-overlay-trigger */
 /**
  * TraceSettingsDropdown - View preferences dropdown component
  *
@@ -16,13 +15,8 @@
  */
 
 import { ObservationLevel } from "@langfuse/shared";
-import { Settings2 } from "lucide-react";
-import { Button } from "@/src/components/ui/button";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuTrigger,
   DropdownMenuSub,
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,
@@ -34,52 +28,17 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics";
 import { useViewPreferences } from "@/src/features/traces/contexts/ViewPreferencesContext";
 import { useTraceAnalyticsDimensions } from "@/src/features/traces/hooks/useTraceAnalyticsDimensions";
 
-export interface TraceSettingsDropdownProps {
-  isGraphViewAvailable: boolean;
-}
-
-export function TraceSettingsDropdown({
-  isGraphViewAvailable,
-}: TraceSettingsDropdownProps) {
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          title="View Options"
-          className="h-7 w-7"
-        >
-          <Settings2 className="h-3.5 w-3.5" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="center"
-        className="w-64 space-y-0 space-x-0 p-0 px-0"
-      >
-        <TraceViewOptionsMenuItems
-          isGraphViewAvailable={isGraphViewAvailable}
-        />
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
 /**
  * The view-option menu items (toggles + min-level submenu) without the
  * dropdown shell, so they can be reused inside the navigation header's overflow
  * "⋯" menu when the panel is too narrow for inline toolbar icons.
  */
-export function TraceViewOptionsMenuItems({
-  isGraphViewAvailable,
-}: TraceSettingsDropdownProps) {
+export function TraceViewOptionsMenuItems() {
   const capture = usePostHogClientCapture();
   const analyticsDimensions = useTraceAnalyticsDimensions();
 
   // Get all preferences directly from context
   const {
-    showGraph,
-    setShowGraph,
     showComments,
     setShowComments,
     showScores,
@@ -102,30 +61,8 @@ export function TraceViewOptionsMenuItems({
   return (
     <>
       <div className="space-y-0 p-0 py-1">
-        {/* Show Graph Toggle (only when available) */}
-        {isGraphViewAvailable && (
-          <DropdownMenuItem
-            asChild
-            onSelect={(e) => e.preventDefault()}
-            className="space-y-0 px-2 py-1"
-          >
-            <div className="flex w-full items-center justify-between">
-              <span className="mr-2">Show Graph</span>
-              <Switch
-                size="sm"
-                checked={showGraph}
-                onCheckedChange={(checked) => {
-                  capture("trace_detail:graph_view_toggle", {
-                    show: checked,
-                    ...analyticsDimensions,
-                  });
-                  setShowGraph(checked);
-                }}
-              />
-            </div>
-          </DropdownMenuItem>
-        )}
-
+        {/* Graph is a view on the Tree/Timeline/Graph switch now — no
+            visibility toggle. */}
         {/* Show Comments Toggle */}
         <DropdownMenuItem
           asChild

--- a/web/src/features/traces/components/TraceSettingsDropdown.tsx
+++ b/web/src/features/traces/components/TraceSettingsDropdown.tsx
@@ -5,7 +5,7 @@
  * - Show Comments
  * - Show Scores
  * - Show Duration
- * - Show Cost/Tokens
+ * - Show Cost
  * - Color Code Metrics (dependent on duration or cost being enabled)
  * - Collapse System Prompts
  * - Minimum Observation Level filter
@@ -117,14 +117,14 @@ export function TraceViewOptionsMenuItems() {
           </div>
         </DropdownMenuItem>
 
-        {/* Show Cost/Tokens Toggle */}
+        {/* Show Cost Toggle */}
         <DropdownMenuItem
           asChild
           onSelect={(e) => e.preventDefault()}
           className="px-2 py-1"
         >
           <div className="flex w-full items-center justify-between">
-            <span className="mr-2">Show Cost/Tokens</span>
+            <span className="mr-2">Show Cost</span>
             <Switch
               size="sm"
               checked={showCostTokens}

--- a/web/src/features/traces/components/TraceTimelineDense/TraceTimelineCompact.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TraceTimelineCompact.tsx
@@ -10,17 +10,12 @@
  * which is what keeps it reviewable in Storybook across every size and shape.
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { useViewPreferences } from "@/src/features/traces/contexts/ViewPreferencesContext";
 import { type RowMetrics } from "./TimelineRowMetrics";
 import { usdFormatter } from "@/src/utils/numbers";
 import { useTraceData } from "@/src/features/traces/contexts/TraceDataContext";
 import { useSelection } from "@/src/features/traces/contexts/SelectionContext";
-import {
-  useActiveObservationIds,
-  usePlayhead,
-  useShowPlayhead,
-} from "@/src/features/traces/contexts/PlayheadContext";
 import { useHandlePrefetchObservation } from "@/src/features/traces/hooks/useHandlePrefetchObservation";
 import { useSelectTraceNode } from "@/src/features/traces/hooks/useSelectTraceNode";
 import { detectPointerModality } from "../../fns/timeline/density";
@@ -35,23 +30,6 @@ export function TraceTimelineCompact() {
   const { showDuration, showCostTokens } = useViewPreferences();
   const { handleHover } = useHandlePrefetchObservation();
   const selectNode = useSelectTraceNode("timeline_compact");
-
-  // Playback: the transport lives in the navigation header and drives the shared
-  // engine, so this view owes the two things you WATCH — a line that sweeps and
-  // the rows lighting up as it passes them. Both are handed to the renderer,
-  // which stays context-free so Storybook can still mount it anywhere.
-  const { seekToSec, getPlayheadSec, subscribePosition } = usePlayhead();
-  const showPlayhead = useShowPlayhead();
-  const activeIds = useActiveObservationIds();
-  const playhead = useMemo(
-    () => ({
-      visible: showPlayhead,
-      getSec: getPlayheadSec,
-      subscribe: subscribePosition,
-      onSeek: seekToSec,
-    }),
-    [showPlayhead, getPlayheadSec, subscribePosition, seekToSec],
-  );
 
   const [pointerModality] = useState(detectPointerModality);
   const [box, setBox] = useState<{ width: number; height: number } | null>(
@@ -98,9 +76,8 @@ export function TraceTimelineCompact() {
     (nodeId: string): RowMetrics => {
       const node = nodeMap.get(nodeId);
       if (!node?.totalCost || !showCostTokens) return {};
-      const aggregated = node.children.length > 0 || node.type === "TRACE";
       return {
-        costText: `${aggregated ? "∑ " : ""}${usdFormatter(node.totalCost.toNumber())}`,
+        costText: usdFormatter(node.totalCost.toNumber()),
       };
     },
     [nodeMap, showCostTokens],
@@ -121,8 +98,6 @@ export function TraceTimelineCompact() {
           selectedId={selectedNodeId}
           onSelect={selectNode}
           onHover={handleHoverNode}
-          activeIds={activeIds}
-          playhead={playhead}
           metricsOf={metricsOf}
           showDuration={showDuration}
         />

--- a/web/src/features/traces/contexts/ViewPreferencesContext.tsx
+++ b/web/src/features/traces/contexts/ViewPreferencesContext.tsx
@@ -48,8 +48,6 @@ interface ViewPreferencesContextValue {
   setColorCodeMetrics: (value: boolean) => void;
   showComments: boolean;
   setShowComments: (value: boolean) => void;
-  showGraph: boolean;
-  setShowGraph: (value: boolean) => void;
   /** Graph panel build mode (aggregated vs expanded "as it ran") */
   graphViewMode: GraphViewMode;
   setGraphViewMode: (value: GraphViewMode) => void;
@@ -115,12 +113,15 @@ export function ViewPreferencesProvider({
     "scoresOnObservationTree",
     true,
   );
+  // Off by default: the red/orange heat map made rows read as errors. The
+  // toggle stays in View Options for users who want hotspot coloring back.
+  // Key rotated (-v2) so the new default applies to users whose browsers
+  // stored the old always-on value.
   const [colorCodeMetrics, setColorCodeMetrics] = useLocalStorage(
-    "colorCodeMetricsOnObservationTree",
-    true,
+    "colorCodeMetricsOnObservationTree-v2",
+    false,
   );
   const [showComments, setShowComments] = useLocalStorage("showComments", true);
-  const [showGraph, setShowGraph] = useLocalStorage("showGraph", true);
   const [storedGraphViewMode, setGraphViewMode] =
     useLocalStorage<GraphViewMode>("graphViewMode", "aggregated");
   // Sanitize persisted values: the mode enum may evolve and a stale
@@ -165,8 +166,6 @@ export function ViewPreferencesProvider({
       setColorCodeMetrics,
       showComments,
       setShowComments,
-      showGraph,
-      setShowGraph,
       graphViewMode,
       setGraphViewMode,
       minObservationLevel,
@@ -196,8 +195,6 @@ export function ViewPreferencesProvider({
       setColorCodeMetrics,
       showComments,
       setShowComments,
-      showGraph,
-      setShowGraph,
       graphViewMode,
       setGraphViewMode,
       minObservationLevel,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17082 app preview](https://pr-17082.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

| Change | Detail |
|---|---|
| Graph promoted to a full view | Tree/Timeline/Graph switch replaces the old side-panel graph; side-panel machinery removed |
| Playback relocated | Transport now lives only in the graph view, not floating in the tree/timeline chrome |
| Peek header reordered | "⋯" menu (delete / open-in-tab / expand), then share, nav, close |
| Download stays inline | Always visible instead of folding into an overflow menu |
| View-options menu always available | No longer folds away at narrow widths |
| Pulse indicator removed | Dropped the collapse-toggle pulse animation |

## How to test

Preview: https://pr-17082.preview.langfuse.com (seed data: `pnpm run seed -- support-agent --v4` locally, or use preview seed traces)
1. Open a trace with graph data — use the Tree/Timeline/Graph switch, confirm Graph renders as its own view with working playback.
2. Peek open a trace from a table — confirm header order (⋯ menu, share, nav, close) and that download/view-options stay visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR promotes the trace graph from a secondary panel to a Tree/Timeline/Graph navigation view, relocates playback into the graph, simplifies trace and peek actions, and removes obsolete graph-panel and pulse state.

- Adds Graph as a desktop navigation mode while retaining the mobile graph tab.
- Moves playback transport into the graph canvas and reorganizes graph controls.
- Reorders peek actions and keeps share, download, and view options readily accessible.
- Simplifies the desktop navigation layout after removing the resizable graph side panel.
- The review identified regressions in timeline playback, cross-view playback control, evaluator-peek expansion, and navigation accessibility.
</details>


<details><summary><h3>Confidence Score: 2/5</h3></summary>

The PR is not safe to merge until timeline playback is restored, active playback remains controllable across view changes, and desktop evaluator peeks retain their expansion control.

The new composition removes timeline playhead and scrub wiring, allows graph-started playback to continue after its only controls unmount, and hides expansion for existing peek callers whose only menu action is expand; the unnamed navigation buttons are an additional accessibility issue.

**Files Needing Attention:** web/src/features/traces/components/TraceTimelineDense/TraceTimelineCompact.tsx, web/src/features/traces/components/TraceGraphView/TraceGraphView.tsx, web/src/components/table/peek/PeekHeader.tsx, web/src/features/navigate-detail-pages/DetailPageNav.tsx
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Trace[Trace data] --> Switch{Navigation view}
  Switch --> Tree[Tree]
  Switch --> Timeline[Timeline]
  Switch --> Graph[Graph]
  Search[Local search] --> Results[Search results]
  Tree --> Selection[Selected observation]
  Timeline --> Selection
  Graph --> Selection
  Results --> Selection
  Selection --> Detail[Detail panel]
  Graph --> Transport[Playback controls]
  Transport --> Playhead[Shared playhead store]
  Playhead --> Tree
  Playhead --> Timeline
  Playhead --> Graph
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/traces/components/TraceTimelineDense/TraceTimelineCompact.tsx:89-103
**Timeline playback is disabled**

Opening Timeline no longer shows the playhead line or highlights active rows, and dragging the timeline axis no longer seeks because `TimelineDense` receives neither `activeIds` nor `playhead`. This removes the timeline playback behavior that the updated playback contract says should remain while only the transport buttons move to Graph.

### Issue 2
web/src/components/table/peek/PeekHeader.tsx:141
**Expand control disappears**

The expand action now exists only inside this menu, but `hasMenu` does not consider `expand`. Desktop evaluator peeks provide `expand` without `actionsMenu` or `openInNewTab`, so the menu is not rendered and users lose the only way to expand or collapse those peeks.

```suggestion
  const hasMenu = Boolean(actionsMenu || openInNewTab || expand);
```

### Issue 3
web/src/features/traces/components/TraceGraphView/TraceGraphView.tsx:74
**Playback controls become unreachable**

If a user starts playback in Graph and then switches to Tree, Timeline, or search, this graph-owned transport unmounts while the shared playback loop keeps running. The user then has no pause or stop control until returning to Graph, leaving playback advancing invisibly in the background.

### Issue 4
web/src/features/navigate-detail-pages/DetailPageNav.tsx:150-162
**Navigation buttons lack labels**

The previous and next controls are now icon-only but have no accessible names. Tooltip text provides a description rather than a button name, so assistive-technology users encounter unidentified navigation controls and cannot tell which direction each button moves.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): trace view graph-as-a-view, p..."](https://github.com/langfuse/langfuse/commit/a9a4b2e9b9616cb72022c792de94a6f5a0205e7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60452268)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Trace exploration workflows](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-exploration-workflows.md)

<!-- /greptile_comment -->