### PR TITLE
feat(web): experimental lanes visualization for traces behind feature flag

### DIFF
--- a/web/src/components/ItemBadge.tsx
+++ b/web/src/components/ItemBadge.tsx
@@ -102,6 +102,28 @@ export function renderFilterIcon(value: string): React.ReactNode {
   );
 }
 
+/**
+ * Bare type icon without the badge chrome (background/border) — for rows where
+ * an opaque box would fight the row's own hover/selection highlight.
+ */
+export function ItemIcon({
+  type,
+  className,
+}: {
+  type: LangfuseItemType;
+  className?: string;
+}) {
+  const Icon = iconMap[type] || ListTree;
+  const label =
+    String(type).charAt(0).toUpperCase() + String(type).slice(1).toLowerCase();
+  return (
+    <Icon
+      aria-label={label}
+      className={cn("shrink-0", iconVariants({ type }), className)}
+    />
+  );
+}
+
 export function ItemBadge({
   type,
   showLabel = false,

--- a/web/src/components/grouped-score-badge.tsx
+++ b/web/src/components/grouped-score-badge.tsx
@@ -50,6 +50,7 @@ export const GroupedScoreBadges = <
   scores,
   maxVisible,
   compact,
+  hideLevels = false,
   expandable = true,
 }: {
   scores: T[];
@@ -63,6 +64,9 @@ export const GroupedScoreBadges = <
    * part that actually shows them.
    */
   expandable?: boolean;
+  /** Suppress the level tag even on mixed rows — for dense surfaces (tree
+      rows) where the level lives in the detail panel instead. */
+  hideLevels?: boolean;
 }) => {
   const groupedScores = groupScoresByName(scores);
 
@@ -72,6 +76,7 @@ export const GroupedScoreBadges = <
   // (e.g. the root carrying trace-level and observation-level scores) tags
   // each group so the levels are tellable apart.
   const showLevels =
+    !hideLevels &&
     new Set(scores.map((score) => scoreLevelFromScore(score))).size > 1;
 
   // "+N" expands IN PLACE on click (hover still previews the hidden chips);

--- a/web/src/features/feature-flags/available-flags.ts
+++ b/web/src/features/feature-flags/available-flags.ts
@@ -43,4 +43,7 @@ export const availableFlags = [
   // Internal flag (deliberately NOT in featurePreviewFlags): gates the
   // normalized-parser formatted trace view for admins/flagged users only.
   "normalizedIoPreview",
+  // Internal flag: experimental "Lanes" trace visualization (one swim lane per
+  // observation type, idle time compressed).
+  "laneTimelineView",
 ] as const;

--- a/web/src/features/feature-flags/types.ts
+++ b/web/src/features/feature-flags/types.ts
@@ -2,9 +2,13 @@ import { type availableFlags } from "./available-flags";
 
 export type Flag = (typeof availableFlags)[number];
 export type Flags = {
-  [key in Exclude<Flag, "modernSession" | "normalizedIoPreview">]: boolean;
+  [key in Exclude<
+    Flag,
+    "modernSession" | "normalizedIoPreview" | "laneTimelineView"
+  >]: boolean;
 } & {
   // Optional while older sessions and test fixtures roll across new flags.
   modernSession?: boolean;
   normalizedIoPreview?: boolean;
+  laneTimelineView?: boolean;
 };

--- a/web/src/features/traces/components/SpanContent.tsx
+++ b/web/src/features/traces/components/SpanContent.tsx
@@ -24,7 +24,7 @@ import { ObservationLevelBadge } from "@/src/features/traces/components/Observat
 import { CommentCountIcon } from "@/src/features/comments/CommentCountIcon";
 import { cn } from "@/src/utils/tailwind";
 import { formatIntervalSeconds } from "@/src/utils/dates";
-import { usdFormatter, formatTokenCounts } from "@/src/utils/numbers";
+import { usdFormatter } from "@/src/utils/numbers";
 import { getSubtreeDurationOverflowMs } from "@/src/features/traces/fns/getSubtreeDurationOverflowMs";
 import { heatMapTextColor } from "@/src/features/traces/fns/heatMapTextColor";
 import { useViewPreferences } from "@/src/features/traces/contexts/ViewPreferencesContext";
@@ -90,13 +90,10 @@ export function SpanContent({
   const shouldRenderSubtreeDuration =
     shouldRenderDuration && subtreeWallClockOverflowMs != null;
 
-  const shouldRenderCostTokens =
-    showCostTokens &&
-    Boolean(
-      node.inputUsage || node.outputUsage || node.totalUsage || totalCost,
-    );
+  // Rows carry only duration and cost; token counts live in the detail panel.
+  const shouldRenderCost = showCostTokens && Boolean(totalCost);
 
-  const shouldRenderAnyMetrics = shouldRenderDuration || shouldRenderCostTokens;
+  const shouldRenderAnyMetrics = shouldRenderDuration || shouldRenderCost;
 
   const nodeScores = selectNodeScores(
     mergedScores,
@@ -183,20 +180,8 @@ export function SpanContent({
               </span>
             ) : null}
 
-            {/* Token counts */}
-            {shouldRenderCostTokens &&
-            (node.inputUsage || node.outputUsage || node.totalUsage) ? (
-              <span className="text-foreground-tertiary text-xs">
-                {formatTokenCounts(
-                  node.inputUsage,
-                  node.outputUsage,
-                  node.totalUsage,
-                )}
-              </span>
-            ) : null}
-
             {/* Cost */}
-            {shouldRenderCostTokens && totalCost ? (
+            {shouldRenderCost && totalCost ? (
               <span
                 title={
                   node.children.length > 0 || node.type === "TRACE"
@@ -213,7 +198,6 @@ export function SpanContent({
                     }),
                 )}
               >
-                {node.children.length > 0 || node.type === "TRACE" ? "∑ " : ""}
                 {usdFormatter(totalCost.toNumber())}
               </span>
             ) : null}
@@ -227,6 +211,7 @@ export function SpanContent({
           <div className="flex flex-wrap gap-1">
             <GroupedScoreBadges
               compact
+              hideLevels
               scores={nodeScores}
               maxVisible={MAX_INLINE_SCORE_GROUPS}
             />

--- a/web/src/features/traces/components/TraceLanesView/TraceLanesView.tsx
+++ b/web/src/features/traces/components/TraceLanesView/TraceLanesView.tsx
@@ -1,0 +1,425 @@
+/**
+ * TraceLanesView — experimental "lanes" visualization (flag: laneTimelineView).
+ *
+ * One horizontal lane per observation type present in the trace; every
+ * observation renders as a bar in its type's lane. Idle stretches where NO
+ * observation is running are compressed into fixed-width hatched columns
+ * (unlabeled — the point is "time passed here", not how much), so traces with
+ * long waits stay readable.
+ *
+ * Deliberately not virtualized: the row count equals the number of observation
+ * types (≤ ~10).
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { cn } from "@/src/utils/tailwind";
+import { ItemIcon, type LangfuseItemType } from "@/src/components/ItemBadge";
+import { formatIntervalSeconds } from "@/src/utils/dates";
+import { formatDurationMs } from "@/src/features/traces/fns/timeline/layout";
+import { usdFormatter, numberFormatter } from "@/src/utils/numbers";
+import { Layer } from "@/src/components/ui/layer";
+import {
+  tooltipPlacement,
+  tooltipStyle,
+} from "@/src/features/traces/fns/timeline/tooltipPlacement";
+import { useTraceData } from "@/src/features/traces/contexts/TraceDataContext";
+import { useSelection } from "@/src/features/traces/contexts/SelectionContext";
+import { useSelectTraceNode } from "@/src/features/traces/hooks/useSelectTraceNode";
+import {
+  OBSERVATION_TYPE_COLOR,
+  OBSERVATION_TYPE_FALLBACK_COLOR,
+} from "@/src/features/traces/fns/observationTypeColors";
+
+// Lane ordering: generation-ish work first, plumbing last.
+const LANE_ORDER = [
+  "AGENT",
+  "GENERATION",
+  "TOOL",
+  "RETRIEVER",
+  "EMBEDDING",
+  "GUARDRAIL",
+  "CHAIN",
+  "EVENT",
+  "SPAN",
+];
+
+// An idle stretch must be both absolutely and relatively long before it is
+// compressed — short pauses stay proportional so the axis is not littered
+// with hatches.
+const IDLE_MIN_MS = 2_000;
+const IDLE_MIN_FRACTION = 0.05;
+/** Rendered width of a compressed idle column. */
+const IDLE_PX = 24;
+const LANE_HEIGHT_PX = 22;
+/** Height of the tick-label axis row above the lanes (matches the timeline). */
+const AXIS_HEIGHT_PX = 16;
+const GUTTER_PX = 88;
+/** Bars narrower than this carry no inline label (tooltip still names them). */
+const LABEL_MIN_PX = 56;
+const BAR_MIN_PX = 3;
+
+type LaneBar = {
+  id: string;
+  name: string;
+  type: string;
+  startMs: number;
+  endMs: number;
+  costText: string | null;
+  usageText: string | null;
+};
+
+type IdleGap = { startMs: number; endMs: number };
+
+/** Merge [start,end] intervals and return the gaps between the merged runs. */
+function findIdleGaps(intervals: Array<[number, number]>): IdleGap[] {
+  if (intervals.length === 0) return [];
+  const sorted = [...intervals].sort((a, b) => a[0] - b[0]);
+  const gaps: IdleGap[] = [];
+  let runEnd = sorted[0][1];
+  for (const [start, end] of sorted.slice(1)) {
+    if (start > runEnd) gaps.push({ startMs: runEnd, endMs: start });
+    runEnd = Math.max(runEnd, end);
+  }
+  return gaps;
+}
+
+export function TraceLanesView() {
+  const { observations, traceStartTime, traceDuration } = useTraceData();
+  const { selectedNodeId } = useSelection();
+  const selectNode = useSelectTraceNode("lanes");
+
+  const [width, setWidth] = useState(0);
+  const measureRef = useCallback((element: HTMLDivElement | null) => {
+    if (!element) return;
+    const measure = () => setWidth(element.clientWidth);
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    measure();
+    return () => observer.disconnect();
+  }, []);
+
+  const { lanes, idleGaps, toX, ticks } = useMemo(() => {
+    const originMs = traceStartTime.getTime();
+    const totalMs = Math.max(traceDuration * 1000, 1);
+    const laneWidthPx = Math.max(width - GUTTER_PX, 100);
+
+    const byType = new Map<string, LaneBar[]>();
+    const intervals: Array<[number, number]> = [];
+    // Idle detection uses LEAF observations only: a wrapper span (root, agent
+    // loop) covers its whole subtree including the waits inside it, so counting
+    // it as "busy" would mask every idle gap it contains.
+    const parentIds = new Set(
+      observations
+        .map((obs) => obs.parentObservationId)
+        .filter((id): id is string => Boolean(id)),
+    );
+    for (const obs of observations) {
+      if (!obs.startTime) continue;
+      const startMs = obs.startTime.getTime() - originMs;
+      const endMs = obs.endTime
+        ? obs.endTime.getTime() - originMs
+        : obs.latency
+          ? startMs + obs.latency * 1000
+          : startMs;
+      if (!parentIds.has(obs.id)) {
+        intervals.push([startMs, Math.max(endMs, startMs)]);
+      }
+      const bars = byType.get(obs.type) ?? [];
+      bars.push({
+        id: obs.id,
+        name: obs.name ?? obs.type.toLowerCase(),
+        type: obs.type,
+        startMs,
+        endMs: Math.max(endMs, startMs),
+        costText: obs.totalCost ? usdFormatter(obs.totalCost) : null,
+        usageText:
+          obs.totalUsage > 0 ? `∑ ${numberFormatter(obs.totalUsage, 0)}` : null,
+      });
+      byType.set(obs.type, bars);
+    }
+
+    const idleGaps = findIdleGaps(intervals).filter(
+      (gap) =>
+        gap.endMs - gap.startMs >= IDLE_MIN_MS &&
+        gap.endMs - gap.startMs >= totalMs * IDLE_MIN_FRACTION,
+    );
+
+    const idleMsTotal = idleGaps.reduce(
+      (sum, gap) => sum + (gap.endMs - gap.startMs),
+      0,
+    );
+    const busyMsTotal = Math.max(totalMs - idleMsTotal, 1);
+    const busyWidthPx = Math.max(
+      laneWidthPx - idleGaps.length * IDLE_PX,
+      idleGaps.length > 0 ? 100 : laneWidthPx,
+    );
+    const pxPerBusyMs = busyWidthPx / busyMsTotal;
+
+    // Piecewise time → x: busy time scales linearly; each idle gap collapses
+    // to a fixed-width column.
+    const toX = (ms: number): number => {
+      let x = 0;
+      let cursor = 0;
+      for (const gap of idleGaps) {
+        if (ms <= gap.startMs) break;
+        x += (gap.startMs - cursor) * pxPerBusyMs;
+        if (ms < gap.endMs) {
+          const fraction = (ms - gap.startMs) / (gap.endMs - gap.startMs);
+          return x + fraction * IDLE_PX;
+        }
+        x += IDLE_PX;
+        cursor = gap.endMs;
+      }
+      return x + (ms - cursor) * pxPerBusyMs;
+    };
+
+    const lanes = LANE_ORDER.filter((type) => byType.has(type))
+      .concat([...byType.keys()].filter((type) => !LANE_ORDER.includes(type)))
+      .map((type) => ({ type, bars: byType.get(type)! }));
+
+    // Axis ticks at a "nice" time step (1/2/5 × 10^n) targeting ~6 labels.
+    // Ticks are placed in real time and mapped through toX, so they stay
+    // truthful across compressed idle columns.
+    const roughStep = totalMs / 6;
+    const magnitude = 10 ** Math.floor(Math.log10(Math.max(roughStep, 1)));
+    const step =
+      [1, 2, 5, 10]
+        .map((m) => m * magnitude)
+        .find((candidate) => candidate >= roughStep) ?? magnitude * 10;
+    const ticks: Array<{ ms: number; x: number }> = [];
+    for (let ms = 0; ms <= totalMs; ms += step) {
+      ticks.push({ ms, x: toX(ms) });
+    }
+
+    return { lanes, idleGaps, toX, ticks };
+  }, [observations, traceStartTime, traceDuration, width]);
+
+  if (lanes.length === 0) {
+    return (
+      <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
+        No observations to lay out.
+      </div>
+    );
+  }
+
+  return (
+    <div ref={measureRef} className="w-full overflow-x-auto select-none">
+      <LaneRows
+        lanes={lanes}
+        idleGaps={idleGaps}
+        toX={toX}
+        ticks={ticks}
+        selectedNodeId={selectedNodeId}
+        onSelect={selectNode}
+      />
+    </div>
+  );
+}
+
+// Bars carry no inline labels (the tree below and the hover tooltip name
+// them); lanes stay as short as they can without shrinking icon or text size.
+const LANE_STYLE = {
+  laneHeightPx: LANE_HEIGHT_PX,
+  gutterPx: GUTTER_PX,
+  barInsetPx: 3,
+  showBarLabels: false,
+  showSeparators: true,
+  showLaneNames: true,
+};
+
+function LaneRows({
+  lanes,
+  idleGaps,
+  toX,
+  ticks,
+  selectedNodeId,
+  onSelect,
+}: {
+  lanes: Array<{ type: string; bars: LaneBar[] }>;
+  idleGaps: IdleGap[];
+  toX: (ms: number) => number;
+  ticks: Array<{ ms: number; x: number }>;
+  selectedNodeId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const v = LANE_STYLE;
+  // Hover tooltip, same pattern as the timeline: anchored to the pointer,
+  // rendered in the tooltip layer so nothing clips it.
+  const [hovered, setHovered] = useState<{
+    bar: LaneBar;
+    clientX: number;
+    clientY: number;
+  } | null>(null);
+
+  return (
+    <div
+      className="relative"
+      style={{ height: `${AXIS_HEIGHT_PX + lanes.length * v.laneHeightPx}px` }}
+    >
+      {/* Time axis — same structure and styling as the timeline view's axis
+          (16px row, contrast tick borders, 9px labels to the right of each
+          tick), plus faint gridlines continuing down through the lanes. */}
+      <div
+        className="border-border absolute inset-x-0 top-0 border-b"
+        style={{ height: `${AXIS_HEIGHT_PX}px` }}
+      >
+        <div
+          className="absolute inset-y-0 overflow-hidden"
+          style={{ left: `${v.gutterPx}px`, right: 0 }}
+        >
+          {ticks.map((tick) => (
+            <div
+              key={tick.ms}
+              className="border-border-contrast absolute inset-y-0 border-l"
+              style={{ left: `${tick.x}px` }}
+            >
+              <span
+                className="text-muted-foreground absolute left-1 whitespace-nowrap"
+                style={{ fontSize: "9px" }}
+              >
+                {formatDurationMs(tick.ms)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+      {ticks.map((tick) => (
+        <div
+          key={`grid-${tick.ms}`}
+          className="border-border/50 absolute bottom-0 border-l"
+          style={{
+            left: `${v.gutterPx + tick.x}px`,
+            top: `${AXIS_HEIGHT_PX}px`,
+          }}
+        />
+      ))}
+
+      {/* Idle columns span all lanes as hatched backdrops. */}
+      {idleGaps.map((gap) => (
+        <div
+          key={gap.startMs}
+          title={`Idle · ${formatIntervalSeconds((gap.endMs - gap.startMs) / 1000)}`}
+          className="absolute bottom-0 opacity-60"
+          style={{
+            top: `${AXIS_HEIGHT_PX}px`,
+            left: `${v.gutterPx + toX(gap.startMs)}px`,
+            width: `${IDLE_PX}px`,
+            backgroundImage:
+              "repeating-linear-gradient(135deg, transparent, transparent 3px, var(--border) 3px, var(--border) 4px)",
+          }}
+        />
+      ))}
+
+      {lanes.map(({ type, bars }, laneIndex) => (
+        <div
+          key={type}
+          className={cn(v.showSeparators && "border-border/50 border-b")}
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: `${AXIS_HEIGHT_PX + laneIndex * v.laneHeightPx}px`,
+            height: `${v.laneHeightPx}px`,
+          }}
+        >
+          {/* Lane label gutter */}
+          <div
+            className="text-muted-foreground absolute inset-y-0 left-0 flex items-center gap-1.5 pl-3.5 text-xs"
+            style={{ width: `${v.gutterPx}px` }}
+          >
+            <ItemIcon type={type as LangfuseItemType} className="size-3" />
+            {v.showLaneNames && (
+              <span className="truncate lowercase" title={type.toLowerCase()}>
+                {type.toLowerCase()}
+              </span>
+            )}
+          </div>
+
+          {bars.map((bar) => {
+            const left = v.gutterPx + toX(bar.startMs);
+            const barWidth = Math.max(
+              toX(bar.endMs) - toX(bar.startMs),
+              BAR_MIN_PX,
+            );
+            const isSelected = bar.id === selectedNodeId;
+            return (
+              <button
+                key={bar.id}
+                type="button"
+                onClick={() => onSelect(bar.id)}
+                onPointerMove={(event) =>
+                  setHovered({
+                    bar,
+                    clientX: event.clientX,
+                    clientY: event.clientY,
+                  })
+                }
+                onPointerLeave={() => setHovered(null)}
+                className={cn(
+                  // ring-background: a 1px page-colored seam so back-to-back
+                  // calls in one lane read as separate bars, not one block.
+                  "ring-background absolute cursor-pointer overflow-hidden rounded-[2px] text-left text-[11px] leading-tight whitespace-nowrap text-white/95 ring-1",
+                  v.showBarLabels && "px-1",
+                  OBSERVATION_TYPE_COLOR[type] ??
+                    OBSERVATION_TYPE_FALLBACK_COLOR,
+                  // Selection: accent ring (the selection color of the tree
+                  // and timeline rows), offset so it reads on any bar color;
+                  // z-bump keeps the ring above later-painted neighbors.
+                  isSelected &&
+                    "ring-primary-accent ring-offset-background z-[1] ring-2 ring-offset-1",
+                )}
+                style={{
+                  left: `${left}px`,
+                  width: `${barWidth}px`,
+                  top: `${v.barInsetPx}px`,
+                  bottom: `${v.barInsetPx}px`,
+                }}
+              >
+                {v.showBarLabels && barWidth >= LABEL_MIN_PX ? bar.name : null}
+              </button>
+            );
+          })}
+        </div>
+      ))}
+
+      {hovered ? (
+        <Layer name="tooltip">
+          <div
+            className="border-border bg-background text-foreground pointer-events-none fixed flex flex-col gap-0.5 rounded border px-1.5 py-1 text-xs shadow-md"
+            style={tooltipStyle(
+              tooltipPlacement({
+                clientX: hovered.clientX,
+                clientY: hovered.clientY,
+                viewportWidth: window.innerWidth,
+                viewportHeight: window.innerHeight,
+              }),
+            )}
+          >
+            <span className="flex items-center gap-1">
+              <ItemIcon
+                type={hovered.bar.type as LangfuseItemType}
+                className="size-3 shrink-0"
+              />
+              <span className="max-w-64 truncate" title={hovered.bar.name}>
+                {hovered.bar.name}
+              </span>
+            </span>
+            <span className="text-muted-foreground flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+              <span>
+                {formatIntervalSeconds(
+                  (hovered.bar.endMs - hovered.bar.startMs) / 1000,
+                )}
+              </span>
+              {hovered.bar.costText ? (
+                <span>{hovered.bar.costText}</span>
+              ) : null}
+              {hovered.bar.usageText ? (
+                <span>{hovered.bar.usageText}</span>
+              ) : null}
+            </span>
+          </div>
+        </Layer>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/features/traces/components/TraceLanesView/TraceLanesView.tsx
+++ b/web/src/features/traces/components/TraceLanesView/TraceLanesView.tsx
@@ -23,6 +23,7 @@ import {
   tooltipStyle,
 } from "@/src/features/traces/fns/timeline/tooltipPlacement";
 import { useTraceData } from "@/src/features/traces/contexts/TraceDataContext";
+import { type TreeNode } from "@/src/features/traces/types/treeNode";
 import { useSelection } from "@/src/features/traces/contexts/SelectionContext";
 import { useSelectTraceNode } from "@/src/features/traces/hooks/useSelectTraceNode";
 import {
@@ -84,7 +85,7 @@ function findIdleGaps(intervals: Array<[number, number]>): IdleGap[] {
 }
 
 export function TraceLanesView() {
-  const { observations, traceStartTime, traceDuration } = useTraceData();
+  const { roots, traceStartTime, traceDuration } = useTraceData();
   const { selectedNodeId } = useSelection();
   const selectNode = useSelectTraceNode("lanes");
 
@@ -105,37 +106,47 @@ export function TraceLanesView() {
 
     const byType = new Map<string, LaneBar[]>();
     const intervals: Array<[number, number]> = [];
+    // Walk the SAME level-filtered tree `traceStartTime`/`traceDuration` were
+    // derived from — the raw `observations` list still includes rows a level
+    // filter hides, and building bars from that against filtered bounds is
+    // what put hidden-level bars off-axis (or, with every root filtered out,
+    // against an origin that fell back to `new Date()`).
     // Idle detection uses LEAF observations only: a wrapper span (root, agent
     // loop) covers its whole subtree including the waits inside it, so counting
-    // it as "busy" would mask every idle gap it contains.
-    const parentIds = new Set(
-      observations
-        .map((obs) => obs.parentObservationId)
-        .filter((id): id is string => Boolean(id)),
-    );
-    for (const obs of observations) {
-      if (!obs.startTime) continue;
-      const startMs = obs.startTime.getTime() - originMs;
-      const endMs = obs.endTime
-        ? obs.endTime.getTime() - originMs
-        : obs.latency
-          ? startMs + obs.latency * 1000
+    // it as "busy" would mask every idle gap it contains. Iterative to avoid
+    // stack overflow on deep trees.
+    const stack: TreeNode[] = [...roots];
+    while (stack.length > 0) {
+      const node = stack.pop()!;
+      for (const child of node.children) stack.push(child);
+      if (node.type === "TRACE") continue;
+      const startMs = node.startTime.getTime() - originMs;
+      const endMs = node.endTime
+        ? node.endTime.getTime() - originMs
+        : node.latency
+          ? startMs + node.latency * 1000
           : startMs;
-      if (!parentIds.has(obs.id)) {
-        intervals.push([startMs, Math.max(endMs, startMs)]);
+      const clampedEndMs = Math.max(endMs, startMs);
+      if (node.children.length === 0) {
+        intervals.push([startMs, clampedEndMs]);
       }
-      const bars = byType.get(obs.type) ?? [];
+      const bars = byType.get(node.type) ?? [];
       bars.push({
-        id: obs.id,
-        name: obs.name ?? obs.type.toLowerCase(),
-        type: obs.type,
+        id: node.id,
+        name: node.name || node.type.toLowerCase(),
+        type: node.type,
         startMs,
-        endMs: Math.max(endMs, startMs),
-        costText: obs.totalCost ? usdFormatter(obs.totalCost) : null,
+        endMs: clampedEndMs,
+        costText:
+          node.calculatedTotalCost != null
+            ? usdFormatter(node.calculatedTotalCost)
+            : null,
         usageText:
-          obs.totalUsage > 0 ? `∑ ${numberFormatter(obs.totalUsage, 0)}` : null,
+          node.totalUsage && node.totalUsage > 0
+            ? `∑ ${numberFormatter(node.totalUsage, 0)}`
+            : null,
       });
-      byType.set(obs.type, bars);
+      byType.set(node.type, bars);
     }
 
     const idleGaps = findIdleGaps(intervals).filter(
@@ -192,7 +203,7 @@ export function TraceLanesView() {
     }
 
     return { lanes, idleGaps, toX, ticks };
-  }, [observations, traceStartTime, traceDuration, width]);
+  }, [roots, traceStartTime, traceDuration, width]);
 
   if (lanes.length === 0) {
     return (
@@ -346,6 +357,7 @@ function LaneRows({
               <button
                 key={bar.id}
                 type="button"
+                aria-label={bar.name}
                 onClick={() => onSelect(bar.id)}
                 onPointerMove={(event) =>
                   setHovered({

--- a/web/src/features/traces/components/TraceLanesView/TraceLanesView.tsx
+++ b/web/src/features/traces/components/TraceLanesView/TraceLanesView.tsx
@@ -30,6 +30,7 @@ import {
   OBSERVATION_TYPE_COLOR,
   OBSERVATION_TYPE_FALLBACK_COLOR,
 } from "@/src/features/traces/fns/observationTypeColors";
+import { MAX_NODES_FOR_GRAPH_UI } from "@/src/features/traces/contexts/TraceGraphDataContext";
 
 // Lane ordering: generation-ish work first, plumbing last.
 const LANE_ORDER = [
@@ -99,13 +100,15 @@ export function TraceLanesView() {
     return () => observer.disconnect();
   }, []);
 
-  const { lanes, idleGaps, toX, ticks } = useMemo(() => {
+  const { lanes, idleGaps, toX, ticks, exceedsBarCap } = useMemo(() => {
     const originMs = traceStartTime.getTime();
     const totalMs = Math.max(traceDuration * 1000, 1);
     const laneWidthPx = Math.max(width - GUTTER_PX, 100);
 
     const byType = new Map<string, LaneBar[]>();
     const intervals: Array<[number, number]> = [];
+    let barCount = 0;
+    let exceedsBarCap = false;
     // Walk the SAME level-filtered tree `traceStartTime`/`traceDuration` were
     // derived from — the raw `observations` list still includes rows a level
     // filter hides, and building bars from that against filtered bounds is
@@ -120,6 +123,13 @@ export function TraceLanesView() {
       const node = stack.pop()!;
       for (const child of node.children) stack.push(child);
       if (node.type === "TRACE") continue;
+      barCount++;
+      // Same size budget the graph view disables itself at (MAX_NODES_FOR_GRAPH_UI)
+      // — bail out of the rest of the layout math, a centered note replaces lanes.
+      if (barCount >= MAX_NODES_FOR_GRAPH_UI) {
+        exceedsBarCap = true;
+        break;
+      }
       const startMs = node.startTime.getTime() - originMs;
       const endMs = node.endTime
         ? node.endTime.getTime() - originMs
@@ -147,6 +157,16 @@ export function TraceLanesView() {
             : null,
       });
       byType.set(node.type, bars);
+    }
+
+    if (exceedsBarCap) {
+      return {
+        lanes: [],
+        idleGaps: [],
+        toX: (ms: number) => ms,
+        ticks: [],
+        exceedsBarCap: true,
+      };
     }
 
     const idleGaps = findIdleGaps(intervals).filter(
@@ -202,8 +222,16 @@ export function TraceLanesView() {
       ticks.push({ ms, x: toX(ms) });
     }
 
-    return { lanes, idleGaps, toX, ticks };
+    return { lanes, idleGaps, toX, ticks, exceedsBarCap: false };
   }, [roots, traceStartTime, traceDuration, width]);
+
+  if (exceedsBarCap) {
+    return (
+      <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
+        Too many observations for the lanes view.
+      </div>
+    );
+  }
 
   if (lanes.length === 0) {
     return (

--- a/web/src/features/traces/components/TracePanelNavigation.tsx
+++ b/web/src/features/traces/components/TracePanelNavigation.tsx
@@ -20,36 +20,58 @@
 import { StringParam, useQueryParam } from "use-query-params";
 import { useSearch } from "@/src/features/traces/contexts/SearchContext";
 import { useTraceGraphData } from "@/src/features/traces/contexts/TraceGraphDataContext";
+import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeatureEnabled";
+import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import { TraceTree } from "./TraceTree";
 import { TraceSearchList } from "./TraceSearchList";
 import { TraceTimelineCompact } from "./TraceTimelineDense/TraceTimelineCompact";
 import { TraceGraphView } from "./TraceGraphView/TraceGraphView";
+import { TraceLanesView } from "./TraceLanesView/TraceLanesView";
 import { useMemo } from "react";
 
 export function TracePanelNavigation() {
   const { searchQuery } = useSearch();
   const { isGraphViewAvailable } = useTraceGraphData();
   const [viewMode] = useQueryParam("view", StringParam);
+  const projectId = useProjectIdFromURL();
+  const isLanesEnabled = useIsFeatureEnabled("laneTimelineView", {
+    projectId: projectId as string,
+  });
 
   const hasQuery = searchQuery.trim().length > 0;
   const isTimelineView = viewMode === "timeline";
   // A stale ?view=graph URL on a trace without graph data falls back to tree.
   const isGraphView = viewMode === "graph" && isGraphViewAvailable;
+  const isLanesView = viewMode === "lanes" && isLanesEnabled;
 
   // Memoize to prevent recreation when deps haven't changed
   const content = useMemo(() => {
-    // Priority: Search > Graph > Timeline > Tree
+    // Priority: Search > Graph > Lanes > Timeline > Tree
     if (hasQuery) {
       return <TraceSearchList />;
     }
     if (isGraphView) {
       return <TraceGraphView />;
     }
+    if (isLanesView) {
+      // Lanes are an overview, not a replacement: the tree stays beneath them
+      // so selection and drill-down keep their usual home.
+      return (
+        <div className="flex h-full flex-col overflow-hidden">
+          <div className="border-border shrink-0 border-b pb-2">
+            <TraceLanesView />
+          </div>
+          <div className="min-h-0 flex-1 overflow-hidden pt-2">
+            <TraceTree />
+          </div>
+        </div>
+      );
+    }
     if (isTimelineView) {
       return <TraceTimelineCompact />;
     }
     return <TraceTree />;
-  }, [hasQuery, isGraphView, isTimelineView]);
+  }, [hasQuery, isGraphView, isLanesView, isTimelineView]);
 
   return content;
 }

--- a/web/src/features/traces/components/TracePanelNavigationHeader/TracePanelNavigationHeader.tsx
+++ b/web/src/features/traces/components/TracePanelNavigationHeader/TracePanelNavigationHeader.tsx
@@ -45,6 +45,7 @@ import { useTraceAnalyticsDimensions } from "@/src/features/traces/hooks/useTrac
 import { toast } from "sonner";
 import { TRACE_DOWNLOAD_OMIT_LARGE_FIELDS_THRESHOLD } from "@/src/features/traces/constants/traceDownloadConfig";
 import { useWatchedPromiseCallback } from "@/src/hooks/useWatchedPromiseCallback";
+import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeatureEnabled";
 
 interface TracePanelNavigationHeaderProps {
   isPanelCollapsed: boolean;
@@ -87,6 +88,9 @@ function TracePanelNavigationHeaderExpanded({
   const [viewMode, setViewMode] = useQueryParam("view", StringParam);
   const capture = usePostHogClientCapture();
   const analyticsDimensions = useTraceAnalyticsDimensions();
+  const isLanesEnabled = useIsFeatureEnabled("laneTimelineView", {
+    projectId: trace.projectId,
+  });
 
   // When the detail (info) panel is closed, the tree/timeline owns the whole
   // surface — so the left "collapse panel" toggle would only shrink the one
@@ -170,7 +174,9 @@ function TracePanelNavigationHeaderExpanded({
       ? "timeline"
       : viewMode === "graph" && isGraphViewAvailable
         ? "graph"
-        : "tree";
+        : viewMode === "lanes" && isLanesEnabled
+          ? "lanes"
+          : "tree";
 
   return (
     <Command className="flex h-auto shrink-0 flex-col gap-1 overflow-hidden rounded-none border-b">
@@ -258,6 +264,7 @@ function TracePanelNavigationHeaderExpanded({
           <ViewModeSwitch
             activeView={activeView}
             showGraphSegment={isGraphViewAvailable}
+            showLanesSegment={isLanesEnabled}
             onSelect={(view) => {
               // Clicking the already-active segment is a no-op — don't count it.
               if (view !== activeView) {
@@ -275,15 +282,17 @@ function TracePanelNavigationHeaderExpanded({
   );
 }
 
-type TraceViewMode = "tree" | "timeline" | "graph";
+type TraceViewMode = "tree" | "timeline" | "graph" | "lanes";
 
 function ViewModeSwitch({
   activeView,
   showGraphSegment,
+  showLanesSegment,
   onSelect,
 }: {
   activeView: TraceViewMode;
   showGraphSegment: boolean;
+  showLanesSegment: boolean;
   onSelect: (view: TraceViewMode) => void;
 }) {
   return (
@@ -308,6 +317,15 @@ function ViewModeSwitch({
           active={activeView === "graph"}
           onClick={() => onSelect("graph")}
           label="Graph"
+        />
+      )}
+      {/* Experimental (flag: laneTimelineView): swim lanes per observation
+          type with idle time compressed. */}
+      {showLanesSegment && (
+        <ViewModeSegment
+          active={activeView === "lanes"}
+          onClick={() => onSelect("lanes")}
+          label="Tree+"
         />
       )}
     </div>

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
@@ -1808,13 +1808,14 @@ export const FitIsDisabledWhenItWouldDoNothing = meta.story({
 });
 
 /**
- * A long trace fits as 1px rows — the whole clock, no names. The spent fit
- * control used to sit there disabled, so there was no obvious way to get the
- * labels back without also shrinking the duration. "Show labels" grows only
- * the rows; Fit then takes you back to the overview.
+ * A long trace fits as 1px rows — the whole clock, no names. There is no
+ * dedicated "show labels" affordance any more: Zoom in is the one way to grow
+ * the rows, and it keeps working step by step until a row is tall enough to
+ * hold a name. Fit is never swapped away for another control — it always
+ * takes you back to the overview.
  */
-export const ShowLabelsKeepsTheWholeClock = meta.story({
-  name: "(Test) Show Labels Keeps The Whole Clock",
+export const ZoomInReachesLabelledRows = meta.story({
+  name: "(Test) Zoom In Reaches Labelled Rows",
   args: {
     roots: manySpans(150),
     box: DESKTOP,
@@ -1832,10 +1833,6 @@ export const ShowLabelsKeepsTheWholeClock = meta.story({
       canvasElement.querySelector<HTMLElement>(
         '[data-testid="timeline-dense-readout"]',
       )?.textContent ?? "";
-    const toolbar = () =>
-      canvasElement.querySelector<HTMLElement>(
-        '[data-testid="timeline-dense-toolbar"]',
-      );
     const labels = () =>
       canvasElement.querySelectorAll('[data-testid="timeline-dense-metrics"]')
         .length;
@@ -1844,27 +1841,21 @@ export const ShowLabelsKeepsTheWholeClock = meta.story({
     await expect(readout()).toContain("4.0px rows");
     await expect(labels()).toBe(0);
 
-    const show = canvasElement.querySelector<HTMLButtonElement>(
-      'button[aria-label="Show labels"]',
+    const zoomIn = canvasElement.querySelector<HTMLButtonElement>(
+      'button[aria-label="Zoom in"]',
     );
-    if (!show) throw new Error("no show-labels button");
-    await expect(show.disabled).toBe(false);
-    await expect(show.innerText.toLowerCase()).toContain("show labels");
-    const caption = [...(toolbar()?.querySelectorAll("span") ?? [])].find(
-      (el) => el.textContent?.trim().toLowerCase() === "show labels",
-    );
-    if (!caption) throw new Error("Show labels text is not on the button");
-    await expect(show.contains(caption)).toBe(true);
-    await userEvent.click(caption);
+    if (!zoomIn) throw new Error("no zoom-in button");
+    for (let click = 0; click < 6; click++) {
+      await userEvent.click(zoomIn);
+    }
 
-    await waitFor(() => expect(readout()).toContain("26.0px rows (labelled)"));
+    await waitFor(() => expect(labels()).toBeGreaterThan(0));
     await expect(readout()).toContain("zoomed");
-    await expect(labels()).toBeGreaterThan(0);
 
     const fit = canvasElement.querySelector<HTMLButtonElement>(
       'button[aria-label="Fit whole trace"]',
     );
-    if (!fit) throw new Error("no fit button after expanding");
+    if (!fit) throw new Error("no fit button after zooming in");
     await expect(fit.disabled).toBe(false);
     await userEvent.click(fit);
 
@@ -1875,8 +1866,9 @@ export const ShowLabelsKeepsTheWholeClock = meta.story({
 });
 
 /**
- * A box that only slices time must not hide Fit behind Show labels. Growing
- * the rows would keep that narrow clock; Fit is the way back to the overview.
+ * A box that only slices time still leaves Fit in the toolbar — it is never
+ * swapped away for another control. Growing the rows would keep that narrow
+ * clock; Fit is the way back to the overview.
  */
 export const FitStaysAfterATimeOnlyBox = meta.story({
   name: "(Test) Fit Stays After A Time Only Box",
@@ -1903,10 +1895,18 @@ export const FitStaysAfterATimeOnlyBox = meta.story({
       canvasElement.querySelector<HTMLElement>(
         '[data-testid="timeline-dense-readout"]',
       )?.textContent ?? "";
+    // Matches either label: spent ("Whole trace already fits", at rest) or
+    // live ("Fit whole trace", once the drag has zoomed away from it) — Fit
+    // is the same button either way, never swapped out for another control.
+    const fitButton = () =>
+      canvasElement.querySelector<HTMLButtonElement>(
+        'button[aria-label*="fits"], button[aria-label="Fit whole trace"]',
+      );
 
-    await expect(
-      canvasElement.querySelector('button[aria-label="Show labels"]'),
-    ).not.toBeNull();
+    // At rest the whole trace already fits, so Fit is present but spent.
+    const atRest = fitButton();
+    if (!atRest) throw new Error("no fit button at rest");
+    await expect(atRest.disabled).toBe(true);
 
     const rect = surface.getBoundingClientRect();
     const drag = (type: string, x: number, y: number) =>
@@ -1928,76 +1928,22 @@ export const FitStaysAfterATimeOnlyBox = meta.story({
     await waitFor(() => expect(readout()).toContain("zoomed"));
     await expect(readout()).toMatch(/[1-4]\.\dpx rows/);
 
-    await expect(
-      canvasElement.querySelector('button[aria-label="Show labels"]'),
-    ).toBeNull();
-    const fit = canvasElement.querySelector<HTMLButtonElement>(
-      'button[aria-label="Fit whole trace"]',
-    );
+    const fit = fitButton();
     if (!fit) throw new Error("Fit disappeared after a time-only box");
     await expect(fit.disabled).toBe(false);
   },
 });
 
 /**
- * A short trace on a narrow pane already has readable rows, but auto will not
- * spend the lane on names. Show labels is still the ask: take the gutter,
- * even if the bars get thinner.
- */
-export const ShowLabelsOpensTheGutterOnANarrowPane = meta.story({
-  name: "(Test) Show Labels Opens The Gutter On A Narrow Pane",
-  args: {
-    roots: manySpans(12),
-    box: PHONE,
-    gutter: "auto",
-    pointer: "fine",
-    barColor: "type",
-    compress: false,
-    showReadout: true,
-    selectedId: null,
-    onSelect: fn(),
-    onHover: fn(),
-  },
-  play: async ({ canvasElement }) => {
-    const names = () =>
-      canvasElement.querySelectorAll(
-        '[data-testid="timeline-dense-peek"] span[title], [data-testid="timeline-dense-content"] > div span[title]',
-      ).length;
-    const barLeft = () => {
-      const bar = canvasElement.querySelector<HTMLElement>(
-        '[data-testid="timeline-dense-bar"]',
-      );
-      return bar?.getBoundingClientRect().left ?? 0;
-    };
-
-    await expect(names()).toBe(0);
-    const show = canvasElement.querySelector<HTMLButtonElement>(
-      'button[aria-label="Show labels"]',
-    );
-    if (!show) throw new Error("no show-labels button on a squeezed pane");
-    await expect(show.innerText.toLowerCase()).toContain("show labels");
-    const caption = [...show.querySelectorAll("span")].find(
-      (el) => el.textContent?.trim().toLowerCase() === "show labels",
-    );
-    if (!caption) throw new Error("Show labels text is not on the button");
-    const leftBefore = barLeft();
-
-    await userEvent.click(caption);
-    await waitFor(() => expect(names()).toBeGreaterThan(0));
-    await expect(barLeft()).toBeGreaterThan(leftBefore + 40);
-  },
-});
-
-/**
- * A pane too narrow to ever commit the gutter still offers Show labels, but
- * names float as a peek overlay. A second rail tap must be able to dismiss
- * that peek: committedOpen never becomes true, so the toggle has to look at
- * the held-open pin, not the committed lane.
+ * A pane too narrow to ever commit the gutter still lets a coarse-pointer rail
+ * tap peek at the names. A second tap must be able to dismiss that peek:
+ * committedOpen never becomes true here, so the toggle has to look at the
+ * held-open pin, not the committed lane.
  */
 const TOO_NARROW_TO_COMMIT = { width: 220, height: 400 };
 
-export const ShowLabelsPeekTogglesOffOnATooNarrowPane = meta.story({
-  name: "(Test) Show Labels Peek Toggles Off On A Too Narrow Pane",
+export const RailTapPeekTogglesOffOnATooNarrowPane = meta.story({
+  name: "(Test) Rail Tap Peek Toggles Off On A Too Narrow Pane",
   args: {
     roots: manySpans(12),
     box: TOO_NARROW_TO_COMMIT,
@@ -2037,13 +1983,9 @@ export const ShowLabelsPeekTogglesOffOnATooNarrowPane = meta.story({
       touch(surface, "pointerup", 1, rect.left + 2, rect.top + 80);
     };
 
-    const show = canvasElement.querySelector<HTMLButtonElement>(
-      'button[aria-label="Show labels"]',
-    );
-    if (!show) throw new Error("no show-labels button on a peek-only pane");
     const leftBefore = barLeft();
 
-    await userEvent.click(show);
+    tapRail();
     await waitFor(() => expect(peekNames()).toBeGreaterThan(0));
     await expect(gutterNames()).toBe(0);
     await expect(Math.abs(barLeft() - leftBefore)).toBeLessThan(20);
@@ -2059,12 +2001,12 @@ export const ShowLabelsPeekTogglesOffOnATooNarrowPane = meta.story({
 });
 
 /**
- * After a coarse rail tap collapses a committed gutter, Show labels must
- * clear that leftover override and take the lane again. A stale
- * override==="collapsed" used to leave names as a peek overlay.
+ * A coarse-pointer rail tap commits the gutter open, a second tap collapses
+ * it, and a third recommits it — the same toggle, driven purely by the tap
+ * gesture now that there is no separate button to ask for labels.
  */
-export const ShowLabelsRecommitsAfterARailCollapse = meta.story({
-  name: "(Test) Show Labels Recommits After A Rail Collapse",
+export const RailTapRecommitsAfterARailCollapse = meta.story({
+  name: "(Test) Rail Tap Recommits After A Rail Collapse",
   args: {
     roots: manySpans(12),
     box: PHONE,
@@ -2103,18 +2045,11 @@ export const ShowLabelsRecommitsAfterARailCollapse = meta.story({
       touch(surface, "pointerdown", 1, rect.left + 2, rect.top + 80);
       touch(surface, "pointerup", 1, rect.left + 2, rect.top + 80);
     };
-    const clickShowLabels = async () => {
-      const show = canvasElement.querySelector<HTMLButtonElement>(
-        'button[aria-label="Show labels"]',
-      );
-      if (!show) throw new Error("no show-labels button");
-      await userEvent.click(show);
-    };
 
     const leftClosed = barLeft();
     await expect(gutterNames()).toBe(0);
 
-    await clickShowLabels();
+    tapRail();
     await waitFor(() => expect(gutterNames()).toBeGreaterThan(0));
     await expect(peekNames()).toBe(0);
     await expect(barLeft()).toBeGreaterThan(leftClosed + 40);
@@ -2123,7 +2058,7 @@ export const ShowLabelsRecommitsAfterARailCollapse = meta.story({
     await waitFor(() => expect(gutterNames()).toBe(0));
     await expect(peekNames()).toBe(0);
 
-    await clickShowLabels();
+    tapRail();
     await waitFor(() => expect(gutterNames()).toBeGreaterThan(0));
     await expect(peekNames()).toBe(0);
     await expect(barLeft()).toBeGreaterThan(leftClosed + 40);
@@ -2131,12 +2066,12 @@ export const ShowLabelsRecommitsAfterARailCollapse = meta.story({
 });
 
 /**
- * Panning a hairline overview is not a time zoom. Show labels must stay, or
- * Fit would snap the window back to the top of the tree instead of naming
- * the rows you just scrolled to.
+ * Panning a hairline overview is not a time zoom: the rows scroll but the
+ * whole clock stays on screen. Fit must stay in the toolbar (never hidden or
+ * disabled away) so there is always a way back to row zero.
  */
-export const ShowLabelsSurvivesAVerticalPan = meta.story({
-  name: "(Test) Show Labels Survives A Vertical Pan",
+export const FitReturnsToTopAfterAVerticalPan = meta.story({
+  name: "(Test) Fit Returns To Top After A Vertical Pan",
   args: {
     roots: manySpans(800),
     box: DESKTOP,
@@ -2158,13 +2093,15 @@ export const ShowLabelsSurvivesAVerticalPan = meta.story({
       canvasElement.querySelector<HTMLElement>(
         '[data-testid="timeline-dense-readout"]',
       )?.textContent ?? "";
-    const show = () =>
+    const rows = () =>
+      canvasElement.querySelector<HTMLElement>('[data-testid="dense-rows"]')
+        ?.textContent ?? "";
+    const fitButton = () =>
       canvasElement.querySelector<HTMLButtonElement>(
-        'button[aria-label="Show labels"]',
+        'button[aria-label="Fit whole trace"]',
       );
 
     await expect(readout()).toContain("fitted");
-    await expect(show()).not.toBeNull();
 
     const rect = surface.getBoundingClientRect();
     surface.dispatchEvent(
@@ -2177,16 +2114,18 @@ export const ShowLabelsSurvivesAVerticalPan = meta.story({
       }),
     );
     await waitFor(() => expect(readout()).toContain("zoomed"));
+    // Only the row window moved — the rows are still hairline and the whole
+    // clock is still on screen.
     await expect(readout()).toMatch(/1\.0px rows/);
-    await expect(show()).not.toBeNull();
-    await expect(
-      canvasElement.querySelector('button[aria-label="Fit whole trace"]'),
-    ).toBeNull();
+    await waitFor(() => expect(rows()).not.toContain("rows 0.0"));
 
-    if (!show()) throw new Error("Show labels vanished after a vertical pan");
-    await userEvent.click(show()!);
-    await waitFor(() => expect(readout()).toContain("26.0px rows (labelled)"));
-    await expect(readout()).toContain("zoomed");
+    const fit = fitButton();
+    if (!fit) throw new Error("Fit disappeared after a vertical pan");
+    await expect(fit.disabled).toBe(false);
+    await userEvent.click(fit);
+
+    await waitFor(() => expect(readout()).toContain("fitted"));
+    await expect(rows()).toContain("rows 0.0");
   },
 });
 

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
@@ -49,7 +49,6 @@
  */
 
 import {
-  type CSSProperties,
   useCallback,
   useMemo,
   useRef,
@@ -58,11 +57,11 @@ import {
   type ReactNode,
 } from "react";
 import { useTheme } from "next-themes";
-import { Scan, Minus, Plus, UnfoldVertical } from "lucide-react";
+import { Scan, Minus, Plus } from "lucide-react";
 import { ItemBadge, type LangfuseItemType } from "@/src/components/ItemBadge";
 import {
   tooltipPlacement,
-  type TooltipPlacement,
+  tooltipStyle,
 } from "../../fns/timeline/tooltipPlacement";
 import { Layer } from "@/src/components/ui/layer";
 import { TimelineRowMetrics, type RowMetrics } from "./TimelineRowMetrics";
@@ -84,7 +83,6 @@ import {
   HUMAN_ROW_HEIGHT,
   anchorTimeToRows,
   canExpandRowsToReadable,
-  expandRowsToReadable,
   interpolateViewport,
   rowCountBounds,
   viewportsEqual,
@@ -105,19 +103,10 @@ import {
 } from "../../fns/timeline/viewport";
 
 /** Reuses ItemBadge's type→hue mapping, so a colour means what it already means. */
-const TYPE_COLOR: Record<string, string> = {
-  TRACE: "bg-dark-green",
-  GENERATION: "bg-muted-magenta",
-  EVENT: "bg-muted-green",
-  SPAN: "bg-muted-blue",
-  AGENT: "bg-purple-600",
-  TOOL: "bg-orange-600",
-  CHAIN: "bg-pink-600",
-  RETRIEVER: "bg-teal-600",
-  EMBEDDING: "bg-amber-600",
-  GUARDRAIL: "bg-red-600",
-};
-const FALLBACK_COLOR = "bg-muted-gray";
+import {
+  OBSERVATION_TYPE_COLOR as TYPE_COLOR,
+  OBSERVATION_TYPE_FALLBACK_COLOR as FALLBACK_COLOR,
+} from "@/src/features/traces/fns/observationTypeColors";
 /** Neutral mode's bar, when colour is not carrying type. */
 const NEUTRAL_COLOR = "bg-muted-foreground/60";
 /**
@@ -842,19 +831,6 @@ export function TimelineDense({
     [cancelTween],
   );
 
-  const showLabels = () => {
-    const { limits: live, extentOf } = layoutRef.current;
-    setLabelsPinned(true);
-    setOverride(null);
-    flyTo(
-      anchorTimeToRows(
-        expandRowsToReadable(viewportRef.current, live),
-        live,
-        extentOf,
-      ),
-    );
-  };
-
   const scheduleGesture = useCallback(() => {
     // Any gesture on the chart hands the space back: an expanded gutter is for
     // looking, and the moment you work in the chart it gets out of the way. It
@@ -1354,37 +1330,24 @@ export function TimelineDense({
         </ToolbarButton>
         <ToolbarButton
           label="Zoom in"
-          onClick={() =>
-            offerShowLabels
-              ? showLabels()
-              : zoomBy(2 ** BUTTON_ZOOM_LEVELS, 0.5, 0.5)
-          }
+          onClick={() => zoomBy(2 ** BUTTON_ZOOM_LEVELS, 0.5, 0.5)}
         >
           <Plus className="h-3 w-3" />
         </ToolbarButton>
-        {offerShowLabels ? (
-          <ToolbarButton label="Show labels" onClick={showLabels}>
-            <UnfoldVertical className="h-3 w-3" />
-            <span className="pr-0.5" style={{ fontSize: "10px" }}>
-              Show labels
-            </span>
-          </ToolbarButton>
-        ) : (
-          <ToolbarButton
-            label={fitSpent ? "Whole trace already fits" : "Fit whole trace"}
-            onClick={() => {
-              setLabelsPinned(false);
-              setOverride(null);
-              flyTo(fitViewport(limits));
-            }}
-            disabled={fitSpent}
-          >
-            {/* A viewfinder, not the diagonal arrows this used to wear: those
-                read as "fullscreen", so a control that was merely spent looked
-                broken. */}
-            <Scan className="h-3 w-3" />
-          </ToolbarButton>
-        )}
+        <ToolbarButton
+          label={fitSpent ? "Whole trace already fits" : "Fit whole trace"}
+          onClick={() => {
+            setLabelsPinned(false);
+            setOverride(null);
+            flyTo(fitViewport(limits));
+          }}
+          disabled={fitSpent}
+        >
+          {/* A viewfinder, not the diagonal arrows this used to wear: those
+              read as "fullscreen", so a control that was merely spent looked
+              broken. */}
+          <Scan className="h-3 w-3" />
+        </ToolbarButton>
         {/* Where you are, when you are somewhere — and nothing at all when the
             whole trace is in view. */}
         {!offerShowLabels && !fitted ? (
@@ -1694,7 +1657,7 @@ export function TimelineDense({
                 <div
                   key={node.id}
                   className={cn(
-                    "absolute inset-x-0",
+                    "absolute inset-x-0 cursor-pointer",
                     rowWashClass({
                       selected: node.id === selectedId,
                       focused: node.index === focusIndex,
@@ -1702,6 +1665,15 @@ export function TimelineDense({
                     }),
                   )}
                   style={{ top: `${y}px`, height: `${rowHeight}px` }}
+                  // The overlay floats OVER the chart rows, so without its own
+                  // click handler it swallowed row clicks: hovering the rail,
+                  // reading a name, and clicking it selected nothing. Mirror the
+                  // chart row's behavior (double-click guard included).
+                  onClick={(event) => {
+                    if (event.detail > 1 || focusedByTap.current) return;
+                    onSelect(node.id);
+                  }}
+                  onDoubleClick={() => focusRow(node.index)}
                 >
                   <GutterContent
                     node={node}
@@ -1812,16 +1784,6 @@ export function TimelineDense({
  * its name, indented by depth. Shared by the in-flow rail and the peek overlay so
  * the two cannot drift apart.
  */
-/** The placement as inline style. Split out so the geometry stays pure. */
-function tooltipStyle(placement: TooltipPlacement): CSSProperties {
-  return {
-    left: `${Math.round(placement.left)}px`,
-    top: `${Math.round(placement.top)}px`,
-    transform: placement.transform,
-    maxWidth: `${Math.round(placement.maxWidth)}px`,
-    fontSize: "10px",
-  };
-}
 
 function GutterContent({
   node,

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
@@ -82,7 +82,6 @@ import { traceSpaceOf, type Box } from "../../fns/timeline/viewTransform";
 import {
   HUMAN_ROW_HEIGHT,
   anchorTimeToRows,
-  canExpandRowsToReadable,
   interpolateViewport,
   rowCountBounds,
   viewportsEqual,
@@ -497,14 +496,6 @@ export function TimelineDense({
       : 0;
   const presentation = presentationForRowHeight(rowHeight);
   const fitted = isViewportFitted(current, limits);
-  const canShowLabels = canExpandRowsToReadable(current, limits);
-  const labelsShowing = committedOpen || (labelsPinned && peekWidth > 0);
-  // Replace Fit only while the whole clock is still on screen AND names are
-  // missing. Rows can be too short, or the pane too narrow to volunteer a
-  // gutter — both are the same ask. A time-zoomed hairline keeps Fit.
-  const clockFits = current.time.duration >= limits.traceSpace.duration - 0.5;
-  const offerShowLabels =
-    clockFits && !labelsShowing && (canShowLabels || canShowNames);
   const fitSpent = fitted && !labelsPinned;
   const barHeight = Math.max(Math.min(rowHeight - 1, MAX_BAR_HEIGHT), 1);
 
@@ -1350,7 +1341,7 @@ export function TimelineDense({
         </ToolbarButton>
         {/* Where you are, when you are somewhere — and nothing at all when the
             whole trace is in view. */}
-        {!offerShowLabels && !fitted ? (
+        {!fitted ? (
           <span
             className="text-muted-foreground truncate"
             style={{ fontSize: "10px" }}

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineRowMetrics.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineRowMetrics.tsx
@@ -57,7 +57,7 @@ function createClusterFitter(budgetPx: number, gapPx: number) {
 }
 
 export type RowMetrics = {
-  /** Already formatted, e.g. `∑ $0.02`. */
+  /** Already formatted, e.g. `$0.02` — plain cost, matching tree rows. */
   costText?: string | null;
 };
 

--- a/web/src/features/traces/components/VirtualizedTree.tsx
+++ b/web/src/features/traces/components/VirtualizedTree.tsx
@@ -140,7 +140,10 @@ export function VirtualizedTree<T extends { id: string; children: T[] }>({
   }, [selectedNodeId, flattenedItems, rowVirtualizer]);
 
   return (
-    <div ref={parentRef} className={cn("h-full overflow-y-auto", className)}>
+    <div
+      ref={parentRef}
+      className={cn("h-full overflow-y-auto pt-2", className)}
+    >
       <div
         style={{
           height: `${rowVirtualizer.getTotalSize()}px`,

--- a/web/src/features/traces/components/VirtualizedTreeNodeWrapper.tsx
+++ b/web/src/features/traces/components/VirtualizedTreeNodeWrapper.tsx
@@ -16,7 +16,7 @@
 
 import { type ReactNode } from "react";
 import { Button } from "@/src/components/ui/button";
-import { ItemBadge, type LangfuseItemType } from "@/src/components/ItemBadge";
+import { ItemIcon, type LangfuseItemType } from "@/src/components/ItemBadge";
 import { ChevronRight } from "lucide-react";
 import { cn } from "@/src/utils/tailwind";
 
@@ -132,17 +132,15 @@ export function VirtualizedTreeNodeWrapper({
         {/* 3. Icon + child connector: fixed width container */}
         <div className="relative flex w-6 shrink-0 flex-col py-1.5">
           <div className="relative z-10 flex h-4 items-center justify-center">
-            <ItemBadge type={nodeType} isSmall className="size-3!" />
+            <ItemIcon type={nodeType} className="size-3" />
           </div>
           {/* Vertical bar downwards if there are expanded children (skipped
               when children render capped at this same indent — the spine
-              would point at nothing) */}
+              would point at nothing). Starts BELOW the icon (22px = py-1.5 +
+              h-4): the icon renders without a masking background now, so the
+              spine must not run behind it. */}
           {hasChildren && !isCollapsed && !childrenAreCapped && (
-            <div className="bg-border-contrast absolute top-3 bottom-0 left-1/2 w-px" />
-          )}
-          {/* Root node downward connector */}
-          {depth === 0 && hasChildren && !isCollapsed && !childrenAreCapped && (
-            <div className="bg-border-contrast absolute top-3 bottom-0 left-1/2 w-px" />
+            <div className="bg-border-contrast absolute top-[22px] bottom-0 left-1/2 w-px" />
           )}
         </div>
 

--- a/web/src/features/traces/contexts/TraceGraphDataContext.tsx
+++ b/web/src/features/traces/contexts/TraceGraphDataContext.tsx
@@ -12,7 +12,9 @@ import { api } from "@/src/utils/api";
 import { type AgentGraphDataResponse } from "@/src/features/trace-graph-view/types";
 import { useReadPath } from "@/src/features/events/hooks/useReadPath";
 
-const MAX_NODES_FOR_GRAPH_UI = 5000;
+/** Also the lanes view's size cap (TraceLanesView) — one budget for the two
+ *  visualizations that lay out every observation instead of a scrollable list. */
+export const MAX_NODES_FOR_GRAPH_UI = 5000;
 
 interface TraceGraphDataContextValue {
   /** Agent graph data for visualization */

--- a/web/src/features/traces/fns/observationTypeColors.ts
+++ b/web/src/features/traces/fns/observationTypeColors.ts
@@ -1,0 +1,18 @@
+/**
+ * Observation-type bar colors shared by the timeline and lanes renderers.
+ * Hue carries TYPE and nothing else (focus/selection are wash + ring).
+ */
+export const OBSERVATION_TYPE_COLOR: Record<string, string> = {
+  TRACE: "bg-dark-green",
+  GENERATION: "bg-muted-magenta",
+  EVENT: "bg-muted-green",
+  SPAN: "bg-muted-blue",
+  AGENT: "bg-purple-600",
+  TOOL: "bg-orange-600",
+  CHAIN: "bg-pink-600",
+  RETRIEVER: "bg-teal-600",
+  EMBEDDING: "bg-amber-600",
+  GUARDRAIL: "bg-red-600",
+};
+
+export const OBSERVATION_TYPE_FALLBACK_COLOR = "bg-muted-gray";

--- a/web/src/features/traces/fns/observationTypeColors.ts
+++ b/web/src/features/traces/fns/observationTypeColors.ts
@@ -13,6 +13,8 @@ export const OBSERVATION_TYPE_COLOR: Record<string, string> = {
   RETRIEVER: "bg-teal-600",
   EMBEDDING: "bg-amber-600",
   GUARDRAIL: "bg-red-600",
+  // Same hue ItemBadge uses for evaluator items (text-primary-accent).
+  EVALUATOR: "bg-primary-accent",
 };
 
 export const OBSERVATION_TYPE_FALLBACK_COLOR = "bg-muted-gray";

--- a/web/src/features/traces/fns/timeline/tooltipPlacement.ts
+++ b/web/src/features/traces/fns/timeline/tooltipPlacement.ts
@@ -1,3 +1,4 @@
+import type React from "react";
 /**
  * Where a pointer-anchored tooltip goes, in viewport coordinates.
  *
@@ -59,5 +60,16 @@ export function tooltipPlacement(input: {
     top: clientY + (flipY ? -OFFSET_PX : OFFSET_PX),
     transform: `translate(${flipX ? "-100%" : "0"}, ${flipY ? "-100%" : "0"})`,
     maxWidth: Math.max(Math.min(MAX_WIDTH_PX, roomX), MIN_WIDTH_PX),
+  };
+}
+
+/** The placement as inline style. Split out so the geometry stays pure. */
+export function tooltipStyle(placement: TooltipPlacement): React.CSSProperties {
+  return {
+    left: `${Math.round(placement.left)}px`,
+    top: `${Math.round(placement.top)}px`,
+    transform: placement.transform,
+    maxWidth: `${Math.round(placement.maxWidth)}px`,
+    fontSize: "10px",
   };
 }

--- a/web/src/features/traces/hooks/useSelectTraceNode.ts
+++ b/web/src/features/traces/hooks/useSelectTraceNode.ts
@@ -6,7 +6,11 @@ import { useDesktopLayoutContextOptional } from "@/src/features/traces/component
 import { useMobileLayoutContextOptional } from "@/src/features/traces/components/TraceLayoutMobile";
 
 /** Which view is reporting the selection — the only thing that differs. */
-export type TraceNodeSelectionSource = "tree" | "timeline" | "timeline_compact";
+export type TraceNodeSelectionSource =
+  | "tree"
+  | "timeline"
+  | "timeline_compact"
+  | "lanes";
 
 /**
  * Selecting an observation is four things at once: record it, point the app at


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17083 app preview](https://pr-17083.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

| Change | Detail |
|---|---|
| Experimental "Tree+" lanes view | Behind the internal `laneTimelineView` flag; one lane per observation type |
| Timeline-style axis | Gridlines, idle-gap hatching, hover tooltip |
| Selection ring | Accent ring on the selected bar, matching tree/timeline selection color |
| Tree stays underneath | Lanes render above the tree so drill-down keeps its usual home |

## How to test

Preview: https://pr-17083.preview.langfuse.com (seed data: `pnpm run seed -- support-agent --v4` locally, or use preview seed traces)
1. Set `LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES=true` (needed for the flag to be selectable).
2. Open a trace, select the "Tree+" segment in the view switch, and confirm lanes render with gridlines, idle-gap hatching, hover tooltips, and a working selection ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a feature-gated Tree+ visualization that groups observations into type lanes, compresses idle periods, shares timeline colors and tooltip placement, and connects lane selection to the existing trace detail workflow. It also changes the regular tree and dense timeline presentation.

- Adds lane geometry, gridlines, idle-gap hatching, tooltips, and selected-bar styling.
- Adds the internal `laneTimelineView` flag and a Tree+ navigation segment.
- Reuses observation colors and tooltip placement across lanes and the compact timeline.
- Simplifies regular tree-row metrics and score presentation.
- Adds selection behavior to the compact timeline’s peek gutter.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

This PR is not safe to merge yet because Tree+ can lose observations through inconsistent time framing, and the regular tree no longer honors the token portion of its existing display preference.

The lanes view renders the complete observation set against bounds calculated from filtered roots without clamping, which can place valid bars outside the chart; separately, the non-experimental tree and search views stop rendering token usage while retaining the Cost/Tokens control. The lanes view also needs accessible bar names and a strategy for large traces.

**Files Needing Attention:** web/src/features/traces/components/TraceLanesView/TraceLanesView.tsx, web/src/features/traces/components/SpanContent.tsx
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Trace data] --> B[TraceDataContext]
  B --> C[Filtered roots and temporal frame]
  B --> D[Complete observations]
  E{Navigation view} --> F[Tree]
  E --> G[Timeline]
  E --> H[Graph]
  E --> I[Tree+ lanes]
  D --> I
  C --> I
  I --> J[Select lane bar]
  F --> K[Select tree row]
  G --> L[Select timeline row]
  H --> M[Select graph node]
  J --> N[Shared observation detail]
  K --> N
  L --> N
  M --> N
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/traces/components/TraceLanesView/TraceLanesView.tsx:116-125
**Filtered bounds hide bars**

The lanes frame uses `traceStartTime` and `traceDuration`, which are derived from level-filtered roots, but this loop renders every unfiltered observation. With the default filter hiding DEBUG observations, an excluded observation can start before the filtered origin or end after the filtered duration. Because `toX` does not clamp these values, the bar can appear outside the axis or entirely off-screen. If all observations are filtered out, the origin falls back to the current time and existing bars can disappear to the left. Build both the frame and bars from the same filtered set, or clamp or omit bars outside the selected frame.

### Issue 2
web/src/features/traces/components/SpanContent.tsx:93-96
**Token preference no longer works**

This removes token counts from every regular tree and trace-search row, not only from the feature-gated lanes view. The existing preference is still labeled “Show Cost/Tokens,” so enabling it now displays only cost even when an observation has token usage. Either retain token rendering on these production surfaces or rename or split the preference so its behavior matches the label.

### Issue 3
web/src/features/traces/components/TraceLanesView/TraceLanesView.tsx:346-378
**Lane buttons lack names**

Every lane bar is an interactive button, but `showBarLabels` is permanently false, leaving the button without text or an `aria-label`. The observation name is available only through a pointer-hover tooltip. Keyboard users can focus and activate these controls but cannot identify them, while screen readers announce unnamed buttons. Give each button an accessible name and provide equivalent details when it receives keyboard focus.

### Issue 4
web/src/features/traces/components/TraceLanesView/TraceLanesView.tsx:338-346
**Large traces mount every bar**

The justification for skipping virtualization considers only the roughly ten lane rows, but this mapping creates one focusable DOM button per observation. Supported traces can contain thousands or tens of thousands of observations, while the tree directly below is virtualized. Opening Tree+ on such a trace therefore mounts the entire observation set and can make the view slow or unresponsive. Virtualize or canvas-render the bars, or enforce a substantially smaller limit for this experimental view.

### Issue 5
web/src/features/traces/components/SpanContent.tsx:212-216
**Mixed score levels become ambiguous**

Passing `hideLevels` removes the trace-versus-observation level tag precisely when a row mixes score levels. This leaves same-named score chips ambiguous in the default tree and search views, and the detail panel does not resolve that ambiguity while users are scanning or selecting a row. Keep the level tags on mixed rows, as `GroupedScoreBadges` already does by default.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): trace view experimental tree ..."](https://github.com/langfuse/langfuse/commit/6e7cc42885428f7048930fb006446a07b7740837) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60452352)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Trace exploration workflows](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-exploration-workflows.md)
- Knowledge Base — [Product web application](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/product-web-application.md)

<!-- /greptile_comment -->