### PR TITLE
docs(api): advertise self-hosted API reference

### DIFF
--- a/fern/apis/server/definition/api.yml
+++ b/fern/apis/server/definition/api.yml
@@ -10,6 +10,7 @@ docs: |
   ## Exports
 
   - OpenAPI spec: https://cloud.langfuse.com/generated/api/openapi.yml
+  - Self-hosted deployments: interactive API reference at `/api/docs` and OpenAPI spec at `/api/openapi.yaml`
 
 error-discrimination:
   strategy: status-code

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -20,6 +20,9 @@ info:
 
 
     - OpenAPI spec: https://cloud.langfuse.com/generated/api/openapi.yml
+
+    - Self-hosted deployments: interactive API reference at `/api/docs` and
+    OpenAPI spec at `/api/openapi.yaml`
 paths:
   /api/public/annotation-queues:
     get:


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17084 app preview](https://pr-17084.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- advertise the built-in self-hosted API reference in the top-level OpenAPI description
- point users to `/api/docs` and `/api/openapi.yaml`
- regenerate the served OpenAPI specification

## Testing

- `pnpm --filter web run test api-spec-route.servertest.ts`
- `pnpm exec turbo run lint --force`
- repeated `pnpm run openapi:export` produces an unchanged file


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the main Fern API description and regenerated OpenAPI artifact to advertise the built-in self-hosted API reference and specification endpoints.

- Adds `/api/docs` and `/api/openapi.yaml` guidance to the Fern source.
- Keeps the generated OpenAPI description aligned with that source.
- The guidance does not account for supported deployments configured under a base path.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking documentation correction recommended for self-hosted base-path deployments.

The source and generated specification remain aligned, and the advertised routes exist, but the root-relative wording sends users of supported base-path deployments to URLs that do not contain their configured prefix.

**Files Needing Attention:** fern/apis/server/definition/api.yml
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
fern/apis/server/definition/api.yml:13
**Paths ignore deployment base**

These root-relative paths only work when `NEXT_PUBLIC_BASE_PATH` is unset. On self-hosted deployments configured under a base path, the endpoints are exposed at `<base-path>/api/docs` and `<base-path>/api/openapi.yaml`; following the advertised paths instead reaches the host root and returns 404. Please describe them as relative to the configured Langfuse base path.

```suggestion
  - Self-hosted deployments: interactive API reference at `<base-path>/api/docs` and OpenAPI spec at `<base-path>/api/openapi.yaml`
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(api): advertise self-hosted API ref..."](https://github.com/langfuse/langfuse/commit/8b1a2c69d8123c942ebcb2b05742d33f42de6a05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60453270)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->