### PR TITLE
docs: small accuracy fixes (anchor slug, stale Next.js version, duplicated word)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ We recommend checking out DeepWiki to familiarize yourself with the project:
 ### Technologies we use
 
 - Application (this repository)
-  - NextJS 14, pages router
+  - Next.js (pages router)
   - NextAuth.js / Auth.js
   - tRPC: Frontend APIs
   - Prisma ORM

--- a/packages/shared/src/features/scores/interfaces/shared.ts
+++ b/packages/shared/src/features/scores/interfaces/shared.ts
@@ -4,7 +4,7 @@ import { NonEmptyString } from "../../../utils/zod";
 
 /**
  * Foundation schema for all score types. Used for ingestion and public API. Supports trace, observation and session scores.
- * Needs to be extended with with score data specific schema (numeric, categorical, boolean)
+ * Needs to be extended with score data specific schema (numeric, categorical, boolean)
  * @see {@link NumericData}, {@link CategoricalData}, {@link BooleanData}
  */
 export const PostScoreBodyFoundationSchema = z.object({

--- a/worker/src/scripts/replayIngestionEventsV2/README.md
+++ b/worker/src/scripts/replayIngestionEventsV2/README.md
@@ -19,8 +19,8 @@ events.csv ──► replay script ──► POST /api/admin/ingestion-replay
 
 ## Prerequisites
 
-- **S3 server access logging** enabled on the Langfuse events bucket (see [Initial setup](#1-initial-setup-one-time))
-- **Athena** configured to query the access logs (see [Initial setup](#1-initial-setup-one-time))
+- **S3 server access logging** enabled on the Langfuse events bucket (see [Initial setup](#1-initial-setup-one-time-on-aws))
+- **Athena** configured to query the access logs (see [Initial setup](#1-initial-setup-one-time-on-aws))
 - **Node.js 18+** with `npx tsx` available (no repo clone or `pnpm` needed)
 - **`events.csv`** exported from Athena (see [Export events](#2-export-events-from-athena))
 - **`LANGFUSE_HOST`** URL of the target Langfuse instance (e.g. `https://cloud.langfuse.com`)


### PR DESCRIPTION
Three tiny docs fixes, each verified:

1. **worker/src/scripts/replayIngestionEventsV2/README.md** — both `Initial setup` links pointed at `#1-initial-setup-one-time`; the heading `## 1. Initial setup (one-time, on AWS)` slugifies to `#1-initial-setup-one-time-on-aws`, so the links did not scroll.
2. **CONTRIBUTING.md** — stack list said `NextJS 14, pages router`; `web/package.json` pins `next`: `16.3.3`. Reworded to `Next.js (pages router)` (version-free, still accurate).
3. **packages/shared/src/features/scores/interfaces/shared.ts** — dropped a duplicated `with` in the score-schema doc comment.

Docs/comments only; no code paths touched.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects two documentation inaccuracies and one duplicated word.
- Updates two replay-script links to the full generated heading anchor.
- Removes a stale Next.js version while retaining the accurate Pages Router description.
- Fixes a duplicated word in a score-schema doc comment.
- Also unintentionally normalizes the entirety of `CONTRIBUTING.md` from CRLF to LF.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation corrections are safe, with only non-blocking whole-file line-ending churn in CONTRIBUTING.md needing cleanup.

The substantive edits are accurate and do not alter runtime behavior, but the CONTRIBUTING.md edit unnecessarily replaces the full file through CRLF-to-LF normalization.

**Files Needing Attention:** CONTRIBUTING.md
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
CONTRIBUTING.md:64
**Whole-file line-ending churn**

This one-line documentation update also converts all 595 lines of `CONTRIBUTING.md` from CRLF to LF, despite there being no explicit repository line-ending policy. That makes the entire file appear replaced and adds avoidable review, blame, cherry-pick, and merge-conflict noise. Please revert the unrelated normalization or separate it into an intentional formatting change.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: small accuracy fixes (anchor slug,..."](https://github.com/langfuse/langfuse/commit/e2c4b0fb033e924dd8d1199344ffde3a1b4da1ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60476377)</sub>

<!-- /greptile_comment -->