### PR TITLE
fix(chatml): render reasoning for empty completions

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/generic.ts
+++ b/packages/shared/src/utils/chatml/adapters/generic.ts
@@ -64,8 +64,28 @@ function normalizeGoogleMessage(msg: unknown): Record<string, unknown> {
   return normalized;
 }
 
-function preprocessData(data: unknown): unknown {
+function preprocessData(data: unknown, kind: "input" | "output"): unknown {
   if (!data) return data;
+
+  // Legacy completions use this exact shape to carry a model's visible output
+  // alongside its reasoning. Other objects with a `completion` field remain
+  // JSON so that their additional fields are preserved.
+  if (
+    kind === "output" &&
+    typeof data === "object" &&
+    !Array.isArray(data) &&
+    Object.keys(data).length === 2 &&
+    "completion" in data &&
+    "reasoning" in data &&
+    typeof data.completion === "string" &&
+    typeof data.reasoning === "string"
+  ) {
+    return {
+      role: "assistant",
+      content: data.completion,
+      thinking: [{ type: "thinking", content: data.reasoning }],
+    };
+  }
 
   // Handle Google output format: {candidates: [{content: {parts, role}}]}
   if (
@@ -154,9 +174,9 @@ export const genericAdapter: ProviderAdapter = {
 
   preprocess(
     data: unknown,
-    _kind: "input" | "output",
+    kind: "input" | "output",
     _ctx: NormalizerContext,
   ): unknown {
-    return preprocessData(data);
+    return preprocessData(data, kind);
   },
 };

--- a/web/src/features/traces/hooks/useChatMLParser.clienttest.ts
+++ b/web/src/features/traces/hooks/useChatMLParser.clienttest.ts
@@ -29,6 +29,33 @@ const parserImplementations = [
 ] as const;
 
 describe("useChatMLParser", () => {
+  it("displays reasoning when a legacy completion is empty", () => {
+    const result = parseChatML(
+      [{ role: "user", content: "Explain your answer" }],
+      {
+        completion: "",
+        reasoning: "The evidence supports this conclusion.",
+      },
+      undefined,
+      undefined,
+    );
+
+    expect(result.canDisplayAsChat).toBe(true);
+    expect(result.allMessages).toEqual([
+      { role: "user", content: "Explain your answer" },
+      {
+        role: "assistant",
+        content: "",
+        thinking: [
+          {
+            type: "thinking",
+            content: "The evidence supports this conclusion.",
+          },
+        ],
+      },
+    ]);
+  });
+
   it.each(parserImplementations)(
     "$name parser groups output-side tool call arguments by tool name",
     ({ parse, expectedArguments }) => {

--- a/worker/src/__tests__/chatml/adapters/generic.test.ts
+++ b/worker/src/__tests__/chatml/adapters/generic.test.ts
@@ -42,6 +42,42 @@ describe("Generic Adapter", () => {
     );
   });
 
+  it("normalizes an empty legacy completion with reasoning as an assistant message", () => {
+    const output = {
+      completion: "",
+      reasoning: "The model considered the constraints before answering.",
+    };
+
+    const result = normalizeOutput(output);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual([
+      {
+        role: "assistant",
+        content: "",
+        thinking: [
+          {
+            type: "thinking",
+            content: "The model considered the constraints before answering.",
+          },
+        ],
+      },
+    ]);
+    expect(normalizeInput(output).success).toBe(false);
+  });
+
+  it("keeps completion objects with additional fields as JSON", () => {
+    const output = {
+      completion: "answer",
+      reasoning: "internal rationale",
+      model: "example-model",
+    };
+    const result = normalizeOutput(output);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual([expect.objectContaining({ json: output })]);
+  });
+
   it("should not display non-ChatML formats as chat", () => {
     const input = {
       job_request: {


### PR DESCRIPTION
## What does this PR do?

Fixes #15343

Legacy output shaped exactly as `{ completion: "", reasoning: "..." }` is currently normalized as JSON-only data, so the trace UI cannot render its reasoning block.

This change normalizes that exact output shape into an assistant ChatML message with a `thinking` block. Objects with additional fields remain on the existing JSON path, preserving their complete payload. Input normalization is unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] This change requires a documentation update

## Testing

- `pnpm --filter worker run test src/__tests__/chatml/adapters/generic.test.ts` — 9 passed
- `pnpm --filter web run test-client src/features/traces/hooks/useChatMLParser.clienttest.ts` — 6 passed
- `pnpm --filter @langfuse/shared run typecheck`
- Prettier check on all changed files
- `git diff --check`

## Mandatory Tasks

- [x] Self-reviewed the code and verified the regression test fails against the original implementation.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates generic output normalization so the exact legacy `{ completion, reasoning }` shape becomes an assistant ChatML message, allowing reasoning to render when completion text is empty.
- Applies the conversion only to output normalization, leaving input behavior unchanged.
- Preserves objects with additional fields as JSON.
- Adds adapter-level and trace-parser regression coverage for empty completions and payload preservation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the new legacy-output shape is accepted throughout normalization and rendering, with focused regression coverage.

No actionable failures remain: output-only conversion preserves the reasoning block, empty content is valid downstream, and objects with additional payload fields retain their existing JSON representation.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chatml): render reasoning for empty ..."](https://github.com/langfuse/langfuse/commit/12bdc7ea11bd872bf210a74d54c84251529035a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60479225)</sub>

**Context used:**

- Knowledge Base — [Trace exploration workflows](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-exploration-workflows.md)

<!-- /greptile_comment -->