### PR TITLE
feat(public-api): add ?fromTimestamp / ?toTimestamp filters to GET /api/public/annotation-queues

### DIFF
--- a/fern/apis/server/definition/annotation-queues.yml
+++ b/fern/apis/server/definition/annotation-queues.yml
@@ -14,6 +14,22 @@ service:
       request:
         name: GetAnnotationQueuesRequest
         query-parameters:
+          fromTimestamp:
+            type: optional<datetime>
+            docs: |
+              Optional ISO-8601 lower bound on the annotation queue row's
+              `createdAt` (inclusive). Omit for an open-ended start.
+              Pattern matches `GET /api/public/comments`,
+              `GET /api/public/models`, `GET /api/public/datasets`, and
+              `GET /api/public/llm-connections`.
+          toTimestamp:
+            type: optional<datetime>
+            docs: |
+              Optional ISO-8601 upper bound on the annotation queue row's
+              `createdAt` (exclusive). Omit for an open-ended end.
+              Pattern matches `GET /api/public/comments`,
+              `GET /api/public/models`, `GET /api/public/datasets`, and
+              `GET /api/public/llm-connections`.
           page:
             type: optional<integer>
             docs: page number, starts at 1

--- a/web/src/__tests__/server/annotation-queues-api.servertest.ts
+++ b/web/src/__tests__/server/annotation-queues-api.servertest.ts
@@ -179,6 +179,164 @@ describe("Annotation Queues API Endpoints", () => {
       expect(firstPageResponse.body.data.length).toBe(limit);
       expect(secondPageResponse.body.data.length).toBe(limit);
     });
+
+    describe("GET /annotation-queues timestamp window", () => {
+      // Three annotation queues at deterministic, well-separated `createdAt`
+      // values so the half-open `[fromTimestamp, toTimestamp)` window can be
+      // exercised without relying on clock or ordering accidents. These
+      // are force-pinned via prisma so the time window is deterministic.
+      const OLD = new Date("2021-01-01T00:00:00.000Z");
+      const MID = new Date("2021-06-01T00:00:00.000Z");
+      const NEW = new Date("2022-01-01T00:00:00.000Z");
+
+      let oldName: string;
+      let midName: string;
+      let newName: string;
+
+      const createQueueAt = async (name: string, createdAt: Date) => {
+        await prisma.annotationQueue.create({
+          data: {
+            projectId,
+            name,
+            scoreConfigIds: [],
+            createdAt,
+            // updatedAt must satisfy `@updatedAt`; setting it equal to
+            // createdAt is fine for tests.
+            updatedAt: createdAt,
+          },
+        });
+      };
+
+      beforeEach(async () => {
+        oldName = `ts-old-${uuidv4()}`;
+        midName = `ts-mid-${uuidv4()}`;
+        newName = `ts-new-${uuidv4()}`;
+
+        await createQueueAt(oldName, OLD);
+        await createQueueAt(midName, MID);
+        await createQueueAt(newName, NEW);
+      });
+
+      it("omits the filter when neither timestamp is provided (existing behavior)", async () => {
+        const response = await makeZodVerifiedAPICall(
+          GetAnnotationQueuesResponse,
+          "GET",
+          "/api/public/annotation-queues?limit=50",
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(200);
+        const names = response.body.data.map((q) => q.name);
+        expect(names).toEqual(
+          expect.arrayContaining([oldName, midName, newName]),
+        );
+        // Includes the TOTAL_TEST_QUEUES seed plus the 3 timestamp-pinned.
+        expect(response.body.meta.totalItems).toBe(TOTAL_TEST_QUEUES + 3);
+      });
+
+      it("filters by fromTimestamp only (inclusive lower bound)", async () => {
+        // Anything on or after MID: the mid and new queues.
+        const response = await makeZodVerifiedAPICall(
+          GetAnnotationQueuesResponse,
+          "GET",
+          `/api/public/annotation-queues?fromTimestamp=${MID.toISOString()}&limit=50`,
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(200);
+        const names = response.body.data.map((q) => q.name);
+        expect(names).toEqual(expect.arrayContaining([midName, newName]));
+        expect(names).not.toContain(oldName);
+        expect(response.body.meta.totalItems).toBe(2);
+      });
+
+      it("filters by toTimestamp only (exclusive upper bound)", async () => {
+        // Anything strictly before NEW: the old and mid queues. The queue
+        // created exactly at NEW is excluded because the upper bound is `lt`.
+        const response = await makeZodVerifiedAPICall(
+          GetAnnotationQueuesResponse,
+          "GET",
+          `/api/public/annotation-queues?toTimestamp=${NEW.toISOString()}&limit=50`,
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(200);
+        const names = response.body.data.map((q) => q.name);
+        expect(names).toEqual(expect.arrayContaining([oldName, midName]));
+        expect(names).not.toContain(newName);
+        expect(response.body.meta.totalItems).toBe(2);
+      });
+
+      it("filters by a half-open [fromTimestamp, toTimestamp) window when both are provided", async () => {
+        // Window [OLD, NEW) -> exactly the mid queue.
+        const response = await makeZodVerifiedAPICall(
+          GetAnnotationQueuesResponse,
+          "GET",
+          `/api/public/annotation-queues?fromTimestamp=${OLD.toISOString()}&toTimestamp=${NEW.toISOString()}&limit=50`,
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(200);
+        const names = response.body.data.map((q) => q.name);
+        expect(names).toEqual([midName]);
+        expect(response.body.meta.totalItems).toBe(1);
+      });
+
+      it("returns 400 on an invalid fromTimestamp format", async () => {
+        const response = await makeAPICall(
+          "GET",
+          "/api/public/annotation-queues?fromTimestamp=not-a-date",
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(400);
+      });
+
+      it("returns 400 on an invalid toTimestamp format", async () => {
+        const response = await makeAPICall(
+          "GET",
+          "/api/public/annotation-queues?toTimestamp=2021-13-40T99:99:99Z",
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(400);
+      });
+
+      it("composes the time window with the existing project scope", async () => {
+        // Create a separate project + api key so we can prove the filter
+        // does not leak queues across the project boundary.
+        const other = await createOrgProjectAndApiKey();
+
+        await prisma.annotationQueue.create({
+          data: {
+            projectId: other.projectId,
+            name: `ts-other-project-${uuidv4()}`,
+            scoreConfigIds: [],
+            createdAt: NEW,
+            updatedAt: NEW,
+          },
+        });
+
+        const response = await makeZodVerifiedAPICall(
+          GetAnnotationQueuesResponse,
+          "GET",
+          `/api/public/annotation-queues?fromTimestamp=${NEW.toISOString()}&limit=50`,
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(200);
+        // Only `newName` belongs to `projectId` with createdAt >= NEW.
+        expect(response.body.meta.totalItems).toBe(1);
+        expect(response.body.data.map((q) => q.name)).toEqual([newName]);
+      });
+    });
   });
 
   describe("POST /annotation-queues", () => {

--- a/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
+++ b/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
@@ -119,15 +119,33 @@ const getAnnotationQueueRecordOrThrow = async ({
 
 export const listAnnotationQueuesForApi = async ({
   projectId,
+  fromTimestamp,
+  toTimestamp,
   page,
   limit,
 }: {
   projectId: string;
 } & GetAnnotationQueuesInput) => {
+  // Build the time-window filter on `createdAt`. Both params are
+  // independently optional; together they form a half-open
+  // `[fromTimestamp, toTimestamp)` range. The window composes with the
+  // existing project scope — it can only narrow the result set, never
+  // widen it.
+  const createdAtFilter =
+    fromTimestamp || toTimestamp
+      ? {
+          createdAt: {
+            ...(fromTimestamp ? { gte: new Date(fromTimestamp) } : {}),
+            ...(toTimestamp ? { lt: new Date(toTimestamp) } : {}),
+          },
+        }
+      : {};
+
   const [queues, totalItems] = await Promise.all([
     prisma.annotationQueue.findMany({
       where: {
         projectId,
+        ...createdAtFilter,
       },
       orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       take: limit,
@@ -136,6 +154,7 @@ export const listAnnotationQueuesForApi = async ({
     prisma.annotationQueue.count({
       where: {
         projectId,
+        ...createdAtFilter,
       },
     }),
   ]);

--- a/web/src/features/public-api/types/annotation-queues.ts
+++ b/web/src/features/public-api/types/annotation-queues.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   paginationMetaResponseZod,
   publicApiPaginationZod,
+  stringDateTime,
   AnnotationQueueObjectType,
   AnnotationQueueStatus,
 } from "@langfuse/shared";
@@ -44,6 +45,15 @@ export type AnnotationQueue = z.infer<typeof AnnotationQueueSchema>;
 // GET /annotation-queues
 export const GetAnnotationQueuesQuery = z
   .object({
+    // Optional ISO-8601 time window on the annotation queue row's
+    // `createdAt`. Both params are independently optional and compose into
+    // a half-open `[fromTimestamp, toTimestamp)` range. Omitting both
+    // preserves the historical "all queues" behavior. Pattern matches
+    // `GET /api/public/comments` (PR #15692), `GET /api/public/models`
+    // (PR #16952), `GET /api/public/datasets` (PR #17002), and
+    // `GET /api/public/llm-connections` (PR #17070).
+    fromTimestamp: stringDateTime,
+    toTimestamp: stringDateTime,
     ...publicApiPaginationZod,
   })
   .strict();

--- a/web/src/pages/api/public/annotation-queues/index.ts
+++ b/web/src/pages/api/public/annotation-queues/index.ts
@@ -21,6 +21,8 @@ export default withMiddlewares({
     fn: async ({ query, auth }) =>
       await listAnnotationQueuesForApi({
         projectId: auth.scope.projectId,
+        fromTimestamp: query.fromTimestamp,
+        toTimestamp: query.toTimestamp,
         page: query.page,
         limit: query.limit,
       }),


### PR DESCRIPTION
## Problem

`GET /api/public/annotation-queues` previously supported only pagination (`?page`, `?limit`). Customers managing project-owned annotation queues — especially teams that grow or re-organize their review pipelines over time — could not scope the list to a recent time window. Every page scan returned the full history of the project's queues.

The companion `GET /api/public/comments` (PR #15692), `GET /api/public/models` (PR #16952), `GET /api/public/datasets` (PR #17002), and `GET /api/public/llm-connections` (PR #17070) endpoints already accept `?fromTimestamp` / `?toTimestamp` on `createdAt`. The same pattern fits naturally on `/annotation-queues` since annotation queues are project-owned rows with a `createdAt` column.

Concretely:
- A team re-organizing its annotation pipeline needs "what queues were created this quarter?" — currently they must paginate through the full list and filter client-side.
- A reviewer onboarding audit asks "what queues were created since the last review cycle?" — no way to ask the API.
- An admin doing a one-off snapshot wants to scope to a recent window, not the entire history.

## Proposed solution

Extend `GetAnnotationQueuesQuery` to accept two optional ISO-8601 timestamp query params and pipe them through to the route handler as a Prisma `createdAt` range filter on `prisma.annotationQueue`.

- `?fromTimestamp=2026-08-01T00:00:00Z` → `createdAt >= fromTimestamp` (inclusive)
- `?toTimestamp=2026-08-31T23:59:59Z` → `createdAt < toTimestamp` (exclusive)
- Either param can be omitted (open-ended range). Both together form a half-open `[fromTimestamp, toTimestamp)` window.
- Filter composes with the existing `projectId` scope. Queues outside the project are still filtered out.
- The pagination count uses the same `where` clause so `totalItems` reflects the windowed result.
- `stringDateTime` (strict ISO-8601) ensures malformed wire values return 400, not 500.
- The `annotationQueues:read` RBAC action and the `annotation-queues` rate limit resource are preserved on the route handler.

## Files

- `web/src/features/public-api/types/annotation-queues.ts` — add `fromTimestamp` and `toTimestamp` (`stringDateTime`) on `GetAnnotationQueuesQuery`.
- `web/src/features/annotation-queues/server/publicAnnotationQueueService.ts` — destructure the two new params in `listAnnotationQueuesForApi`, build a `createdAtFilter` (`gte`/`lt`) that composes with the existing `projectId` clause, and apply the same `where` to the `count` query.
- `web/src/pages/api/public/annotation-queues/index.ts` — pass the new params from the route handler to the service.
- `web/src/__tests__/server/annotation-queues-api.servertest.ts` — new `describe("GET /annotation-queues timestamp window", ...)` block with 7 cases: omit both (existing behavior), fromTimestamp only, toTimestamp only, both params forming a half-open window, invalid fromTimestamp format (400), invalid toTimestamp format (400), and a project-scope composition test. Three annotation queues are force-pinned to deterministic `createdAt` values via `prisma.annotationQueue.create`.
- `fern/apis/server/definition/annotation-queues.yml` — document the two new query parameters on the `listQueues` endpoint.

## Compatibility

- Both params are optional. Existing API consumers see no change.
- `GetAnnotationQueuesQuery` is widened (more allowed keys), not narrowed, so no client breaks.
- The route handler is updated to pass the new params through; the Prisma query is the only behavior change.

## Verification

- `prettier --check` on the 4 source files and the Fern yml: clean.
- `tsc --noEmit` from `web/`: no new errors in the changed files.
- `npx fern-api check --api server`: `All checks passed`.
- Standalone structural smoke test (`stringDateTime` in Zod, `gte`+`lt` in service, route passes both params, Fern spec includes both, `createdAtFilter` spread into both `findMany` and `count`): all assertions pass.
- `pnpm --filter web exec vitest run web/src/__tests__/server/annotation-queues-api.servertest.ts` is blocked locally by a pre-existing storybook dep mismatch (`@typescript/typescript6` package-name issue in `.storybook/main.ts`); CI is expected to exercise the new cases on the standard test infrastructure.

## Risk

Minimal. The change adds a filter that narrows the result set; it cannot widen it. A malformed timestamp is caught by `stringDateTime` and returns 400, not 500. The `annotationQueues:read` RBAC action is preserved, so role-based access still works. The `plan: "cloud:hobby"` 1-queue limit logic in `createAnnotationQueueForApi` is unchanged and is not affected by the new list filter.

## Future work

- Mirror the same `?fromTimestamp` / `?toTimestamp` parameters on `?updatedAt` for re-organization audits.
- Extend the same pattern to `GET /api/public/score-configs` and `GET /api/public/media` (the other v1 list endpoints that still lack the filter).

Fixes #17089


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds optional creation-time bounds to the public annotation-queue list endpoint and applies the same project-scoped range to both retrieval and pagination counts.
- Adds `fromTimestamp` as an inclusive lower bound and `toTimestamp` as an exclusive upper bound.
- Extends the public query schema, route forwarding, service query, and Fern contract.
- Adds timestamp-window and project-isolation coverage, but several new assertions conflict with inherited fixtures or the inclusive lower-bound semantics.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The implementation appears sound, but the PR is not ready to merge because multiple newly added server tests deterministically fail.

The nested timestamp tests share ten current-date fixtures from the enclosing setup, invalidating lower-bound-only counts, and the half-open-window test contradicts the service’s inclusive lower-bound behavior.

**Files Needing Attention:** web/src/__tests__/server/annotation-queues-api.servertest.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/annotation-queues-api.servertest.ts:252
**Inherited fixtures break counts**

These timestamp tests inherit the parent `beforeEach`, which creates 10 queues with current timestamps in the same project. Those queues satisfy each lower-bound-only filter, so the `fromTimestamp=MID` case returns 12 items instead of 2, and the project-scope case returns 11 instead of 1. These assertions will deterministically fail; isolate the timestamp fixtures or use bounds that exclude the inherited queues.

### Issue 2
web/src/__tests__/server/annotation-queues-api.servertest.ts:285-286
**Inclusive boundary breaks test**

This test creates the old queue exactly at `OLD` and then requests `[OLD, NEW)`. Because `fromTimestamp` uses inclusive `gte`, the response contains both the old and middle queues and reports `totalItems` as 2, not 1. The assertions will deterministically fail; use a lower bound after `OLD` or expect both records.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add ?fromTimestamp / ?..."](https://github.com/langfuse/langfuse/commit/8e0b1ff469c46cf93960d0777e3494ccdca6c387) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60553250)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->