### PR TITLE
feat(ingestion): index native Bedrock Converse tools

### DIFF
--- a/packages/shared/src/server/ingestion/extractToolsBackend.ts
+++ b/packages/shared/src/server/ingestion/extractToolsBackend.ts
@@ -235,7 +235,7 @@ function isMessageLike(value: unknown): boolean {
 
 /**
  * Helper to add a tool call from content-array parts.
- * Handles Anthropic `tool_use` and AI SDK `tool-call` parts.
+ * Handles Anthropic `tool_use`, AI SDK `tool-call`, and Bedrock `toolUse` parts.
  */
 function addToolArgumentFromContentPart(
   args: ClickhouseToolArgument[],
@@ -252,6 +252,23 @@ function addToolArgumentFromContentPart(
 
   if (part.type === "tool-call") {
     addToolArgument(args, part);
+  }
+
+  const toolUse = part.toolUse;
+  if (
+    isPlainRecord(toolUse) &&
+    typeof toolUse.toolUseId === "string" &&
+    toolUse.toolUseId.length > 0 &&
+    typeof toolUse.name === "string" &&
+    toolUse.name.length > 0 &&
+    toolUse.input !== undefined
+  ) {
+    addToolArgument(args, {
+      id: toolUse.toolUseId,
+      name: toolUse.name,
+      arguments: JSON.stringify(toolUse.input),
+      type: "function",
+    });
   }
 }
 
@@ -272,6 +289,27 @@ function extractToolsFromRawInput(
   if (Array.isArray(obj.tools)) {
     for (const tool of obj.tools) {
       addToolDefinition(definitions, tool);
+    }
+  }
+
+  // Bedrock Converse keeps tool definitions under toolConfig and wraps the
+  // JSON schema in inputSchema.json. Cache points have no toolSpec.
+  if (isPlainRecord(obj.toolConfig) && Array.isArray(obj.toolConfig.tools)) {
+    for (const tool of obj.toolConfig.tools) {
+      if (!isPlainRecord(tool) || !isPlainRecord(tool.toolSpec)) continue;
+      const { name, description, inputSchema } = tool.toolSpec;
+      if (
+        typeof name !== "string" ||
+        name.length === 0 ||
+        !isPlainRecord(inputSchema) ||
+        inputSchema.json === undefined
+      )
+        continue;
+      addToolDefinition(definitions, {
+        name,
+        description: typeof description === "string" ? description : undefined,
+        parameters: inputSchema.json,
+      });
     }
   }
 
@@ -351,17 +389,16 @@ function extractToolCallsFromRawOutput(
     }
   }
 
-  // Tool calls in content arrays: Anthropic `tool_use`, AI SDK `tool-call`
+  // Bedrock Converse response envelope: {output: {message: {content: [...]}}}.
+  if (isPlainRecord(obj.output) && isPlainRecord(obj.output.message)) {
+    extractToolCallsFromMessage(obj.output.message, args);
+  }
+
+  // Tool calls in provider content arrays.
   if (Array.isArray(obj.content)) {
     for (const part of obj.content) {
-      if (
-        part &&
-        typeof part === "object" &&
-        ["tool_use", "tool-call"].includes(
-          (part as Record<string, unknown>).type as string,
-        )
-      ) {
-        addToolArgumentFromContentPart(args, part as Record<string, unknown>);
+      if (isPlainRecord(part)) {
+        addToolArgumentFromContentPart(args, part);
       }
     }
   }
@@ -385,17 +422,11 @@ function extractToolCallsFromMessage(
     parseArrayIfString(msg.tool_calls) ?? parseArrayIfString(msg.toolCalls);
   addToolArguments(args, messageToolCalls);
 
-  // Tool calls in content arrays: Anthropic `tool_use`, AI SDK `tool-call`
+  // Tool calls in provider content arrays.
   if (Array.isArray(msg.content)) {
     for (const part of msg.content) {
-      if (
-        part &&
-        typeof part === "object" &&
-        ["tool_use", "tool-call"].includes(
-          (part as Record<string, unknown>).type as string,
-        )
-      ) {
-        addToolArgumentFromContentPart(args, part as Record<string, unknown>);
+      if (isPlainRecord(part)) {
+        addToolArgumentFromContentPart(args, part);
       }
     }
   }

--- a/worker/src/__tests__/extractToolsBackend.test.ts
+++ b/worker/src/__tests__/extractToolsBackend.test.ts
@@ -7,6 +7,197 @@ import {
 } from "@langfuse/shared/src/server";
 
 describe("extractToolsFromObservation", () => {
+  describe("Native Bedrock Converse observations", () => {
+    const parameters = {
+      type: "object",
+      properties: { order_id: { type: "string" } },
+      required: ["order_id"],
+    };
+    const toolSpec = {
+      name: "lookup_order",
+      description: "Look up an order",
+      inputSchema: { json: parameters },
+    };
+    const toolUse = {
+      toolUseId: "tool-1",
+      name: "lookup_order",
+      input: { order_id: "demo-42" },
+    };
+
+    it.each([false, true])(
+      "indexes definitions and parallel calls while preserving raw I/O (JSON strings: %s)",
+      (serialized) => {
+        const rawInput = {
+          messages: [{ role: "user", content: [{ text: "Find my orders" }] }],
+          toolConfig: {
+            tools: [{ toolSpec }, { cachePoint: { type: "default" } }],
+          },
+        };
+        const rawOutput = {
+          output: {
+            message: {
+              role: "assistant",
+              content: [
+                { text: "I will look up both orders." },
+                { toolUse },
+                {
+                  toolUse: {
+                    ...toolUse,
+                    toolUseId: "tool-2",
+                    input: { order_id: "demo-43" },
+                  },
+                },
+              ],
+            },
+          },
+          stopReason: "tool_use",
+          usage: { inputTokens: 12, outputTokens: 8, totalTokens: 20 },
+        };
+        const input = serialized ? JSON.stringify(rawInput) : rawInput;
+        const output = serialized ? JSON.stringify(rawOutput) : rawOutput;
+        const metadata = { environment: "test", custom: { keep: true } };
+        const originals = structuredClone({ input, output, metadata });
+
+        const result = normalizeToolsForObservation(input, output, metadata);
+
+        expect(result.toolDefinitions).toEqual({
+          lookup_order: JSON.stringify({
+            description: "Look up an order",
+            parameters: JSON.stringify(parameters),
+          }),
+        });
+        expect(result.toolCallNames).toEqual(["lookup_order", "lookup_order"]);
+        expect(result.toolCalls.map((call) => JSON.parse(call))).toEqual([
+          {
+            id: "tool-1",
+            arguments: JSON.stringify({ order_id: "demo-42" }),
+            type: "function",
+            index: 0,
+          },
+          {
+            id: "tool-2",
+            arguments: JSON.stringify({ order_id: "demo-43" }),
+            type: "function",
+            index: 0,
+          },
+        ]);
+        expect({
+          input: result.input,
+          output: result.output,
+          metadata: result.metadata,
+        }).toEqual(originals);
+        expect({ input, output, metadata }).toEqual(originals);
+      },
+    );
+
+    it.each([false, true])(
+      "extracts calls from an assistant message and deduplicates IDs (message array: %s)",
+      (asArray) => {
+        const message = {
+          role: "assistant",
+          content: [{ toolUse }, { toolUse }],
+        };
+        const result = extractToolsFromObservation(
+          null,
+          asArray ? [message] : message,
+        );
+
+        expect(result.toolArguments).toEqual([
+          {
+            id: "tool-1",
+            name: "lookup_order",
+            arguments: JSON.stringify(toolUse.input),
+            type: "function",
+          },
+        ]);
+      },
+    );
+
+    it.each([null, "literal input"])(
+      "preserves the JSON value of native tool input (%s)",
+      (input) => {
+        const result = normalizeToolsForObservation(
+          null,
+          { role: "assistant", content: [{ toolUse: { ...toolUse, input } }] },
+          {},
+        );
+
+        expect(JSON.parse(result.toolCalls[0]).arguments).toBe(
+          JSON.stringify(input),
+        );
+      },
+    );
+
+    it("ignores tool results and prior input history when indexing output calls", () => {
+      const result = normalizeToolsForObservation(
+        { messages: [{ role: "assistant", content: [{ toolUse }] }] },
+        {
+          output: {
+            message: {
+              role: "user",
+              content: [
+                {
+                  toolResult: {
+                    toolUseId: "tool-1",
+                    content: [{ json: { status: "shipped" } }],
+                  },
+                },
+                { text: "Thank you" },
+              ],
+            },
+          },
+        },
+        {},
+      );
+
+      expect(result.toolCalls).toEqual([]);
+      expect(result.toolCallNames).toEqual([]);
+      expect(result.toolDefinitions).toEqual({});
+    });
+
+    it("skips invalid native blocks without discarding later valid tools", () => {
+      const result = extractToolsFromObservation(
+        {
+          toolConfig: {
+            tools: [
+              null,
+              { toolSpec: null },
+              { toolSpec: { name: 7 } },
+              { toolSpec: { name: "missing_schema" } },
+              { toolSpec },
+            ],
+          },
+        },
+        {
+          output: {
+            message: {
+              role: "assistant",
+              content: [
+                null,
+                { toolUse: null },
+                { toolUse: { ...toolUse, name: 7 } },
+                { toolUse: { ...toolUse, toolUseId: 7 } },
+                { toolUse: { name: "missing_id", input: {} } },
+                { toolUse: { name: "missing_input", toolUseId: "partial" } },
+                { toolUse },
+              ],
+            },
+          },
+        },
+      );
+
+      expect(result.toolDefinitions).toEqual([
+        {
+          name: "lookup_order",
+          description: "Look up an order",
+          parameters: JSON.stringify(parameters),
+        },
+      ]);
+      expect(result.toolArguments).toHaveLength(1);
+      expect(result.toolArguments[0].id).toBe("tool-1");
+    });
+  });
+
   describe("Tool metadata normalization", () => {
     it("moves AI SDK tools from metadata to input and removes duplicate metadata", () => {
       const input = [


### PR DESCRIPTION
## What does this PR do?

Index native Amazon Bedrock Converse tools during observation ingestion. A raw Converse response can contain a model-requested tool call while `tool_calls` and `tool_call_names` are empty, so the existing Called Tool Names / Tool Call Count filters and tool-call evaluator data miss it. The shared normalization path used by legacy and OTLP ingestion now recognizes the native request and response shapes.

Closes #17091.

- Extract definitions from `toolConfig.tools[].toolSpec`, unwrapping `inputSchema.json` into the existing stored schema format.
- Extract calls from `output.message.content[].toolUse` and extracted assistant messages. Preserve call IDs, parallel-call order, JSON argument values, and existing deduplication.
- Preserve original input/output and unrelated metadata. Skip cache points, tool results, input conversation history, and malformed partial blocks.

This slice uses the existing production extractor. It does not change API/database schemas, model execution, streaming event assembly, or ChatML rendering.

## Before / after evidence

The regression fixture extends the minimal example in #17091 to two parallel `lookup_order` calls with IDs `tool-1` and `tool-2`.

| Indexed value | Before | After |
| --- | --- | --- |
| `toolDefinitions.lookup_order` | missing | description and unwrapped JSON input schema |
| `toolCallNames` | `[]` | `["lookup_order", "lookup_order"]` |
| call IDs | none | `tool-1`, `tool-2` |
| raw I/O and custom metadata | retained | retained unchanged |

The new entrypoint tests were run before the implementation: the definition/call cases failed with empty indexed output. Tests also cover raw objects versus JSON strings, extracted messages versus message arrays, deduplication, mixed text/tool content, JSON null/string arguments, malformed blocks, and tool-result/history exclusion. No live Bedrock invocation was used.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Self-review and a second coding agent's review of the production diff and regression tests completed. No separate human review is claimed.

## Validation

With Node 24, pnpm 12.3.1, and the frozen lockfile:

- `pnpm --filter worker run test src/__tests__/extractToolsBackend.test.ts --maxWorkers=1 --no-file-parallelism`: **62 passed**, including 8 added cases. This final run uses the repository's Vitest configuration and the built shared package, with no custom import aliases.
- `pnpm --filter @langfuse/shared run build`: passed.
- `pnpm --filter @langfuse/shared run typecheck` and `pnpm --filter worker run typecheck`: passed.
- `pnpm tc --concurrency=2`: passed across the monorepo (**8/8 tasks successful, 2 cached**).
- `pnpm exec knip`: passed; one configuration hint about an existing `ignoreFiles` entry.
- `pnpm --filter @langfuse/shared run lint` and `pnpm --filter worker run lint`: passed with zero warnings, after building the repository's ESLint plugin.
- Web package ESLint also passed with zero warnings in 149 seconds, using the repository configuration and cache over `.`, `--max-warnings 0 --concurrency off`, and `NODE_OPTIONS=--max-old-space-size=6144`. Only execution resources changed; rules and file scope were unchanged.
- `pnpm run format:check`: passed across the repository; `git diff --check`: passed.

Full integration tests were not run: Docker/Podman and the required local PostgreSQL/Redis/ClickHouse services are unavailable. No live Bedrock or browser-preview verification has been performed.

The [PR preview](https://pr-17092.preview.langfuse.com) currently returns HTTP 404. The before/after evidence above is from the ingestion normalization regression tests.

## AI assistance

Implementation, regression tests, and this description were developed with Codex assistance. All stated checks were executed by the coding agent. The contributor license agreement has not been signed on the account holder's behalf.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends shared observation normalization to index native Amazon Bedrock Converse tool definitions and calls while preserving the original observation payload.

- Unwraps `toolConfig.tools[].toolSpec.inputSchema.json` into the existing normalized definition format.
- Recognizes `toolUse` blocks in Bedrock response envelopes and extracted message content.
- Preserves call IDs and content order while applying existing call deduplication.
- Adds regression coverage for serialized and object payloads, parallel calls, malformed blocks, tool results, and raw-data preservation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or repository-rule violations identified.

The native Bedrock shapes are normalized consistently with existing stored contracts, valid provider payloads retain call order and IDs, and the added tests cover the principal extraction and exclusion paths.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  I[Raw observation input] --> TC[Bedrock toolConfig.tools]
  TC --> TS[Validate toolSpec]
  TS --> D[Normalized tool definitions]
  O[Raw observation output] --> BM[output.message.content]
  BM --> TU[Validate toolUse blocks]
  TU --> C[Normalized tool calls]
  D --> N[Shared observation normalization]
  C --> N
  N --> CH[Indexed ClickHouse tool columns]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ingestion): index native Bedrock Co..."](https://github.com/langfuse/langfuse/commit/137a1edd852e18cd8036029ab047f68cee131a96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60673825)</sub>

**Context used:**

- Knowledge Base — [Trace and observation ingestion](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-observation-ingestion.md)

<!-- /greptile_comment -->
