### PR TITLE
fix(redis): stop sending "undefined" as the password when REDIS_AUTH is unset

### DIFF
--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -301,7 +301,7 @@ export const getQueuePrefix = (queueName: string): string | undefined => {
   }
 
   // Non-cluster mode: Return prefix or undefined
-  return redisKeyPrefix || undefined;
+  return redisKeyPrefix ?? undefined;
 };
 
 const getBullMQOptionsForRedisConnection = (

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -269,7 +269,7 @@ export const createNewRedisInstance = (
           host: String(env.REDIS_HOST),
           port: Number(env.REDIS_PORT),
           username: env.REDIS_USERNAME || undefined,
-          password: String(env.REDIS_AUTH),
+          password: env.REDIS_AUTH || undefined,
           ...defaultRedisOptions,
           ...additionalOptions,
           ...tlsOptions,
@@ -301,7 +301,7 @@ export const getQueuePrefix = (queueName: string): string | undefined => {
   }
 
   // Non-cluster mode: Return prefix or undefined
-  return redisKeyPrefix ?? undefined;
+  return redisKeyPrefix || undefined;
 };
 
 const getBullMQOptionsForRedisConnection = (


### PR DESCRIPTION
Fixes #17093

## What

One line in `packages/shared/src/server/redis/redis.ts`:

```diff
-          password: String(env.REDIS_AUTH),
+          password: env.REDIS_AUTH || undefined,
```

## Why

The cluster and sentinel clients already use `env.REDIS_AUTH || undefined`; only the single-node client wrapped the value in `String()`. `REDIS_AUTH` is declared `z.string().nullish()`, so when it is unset `String(undefined)` produces the literal string `"undefined"`, and that is sent as the `AUTH` password to a server that requires none. The single-node line predates the cluster and sentinel clients, so this reads as drift rather than an intentional difference.

Verified with ioredis 5.10.1 (the version pinned here) against Redis 7 and Valkey, neither configured with `requirepass`: `MONITOR` shows `"auth" "(redacted)"` on the wire, the server rejects it, ioredis surfaces the rejection as a warning, and the connection stays up. Same result with `enableReadyCheck` on and off. So the impact is log noise plus one unnecessary round trip per connection, not a connection failure — this corrects a statement in the issue body, see [this comment](https://github.com/langfuse/langfuse/issues/17093#issuecomment-5549332195).

An empty value is easy to hit by accident: a compose file passing `REDIS_AUTH: ${REDIS_AUTH}` injects an empty string whenever the variable is not filled in. `removeEmptyEnvVariables` strips that empty string before Zod parsing, so it arrives as `undefined` and lands on the same `String(undefined)` path.

## Scope narrowed after review

This PR originally carried a second change: `getQueuePrefix()` from `??` to `||`, on the theory that `REDIS_KEY_PREFIX=""` could reach BullMQ as an explicit empty prefix. Review flagged that it broke the existing "handles empty string prefix" test, and checking that turned up the larger point that the change was not needed at all. `removeEmptyEnvVariables` in `packages/shared/src/utils/environment.ts` deletes empty-string env vars before Zod parsing, and both `packages/shared/src/env.ts` and `worker/src/env.ts` parse via `EnvSchema.parse(removeEmptyEnvVariables(process.env))`. `REDIS_KEY_PREFIX=""` therefore never reaches `getQueuePrefix()` as `""` — it arrives as `undefined`, which `??` already handles, and the existing test documents exactly that contract. My BullMQ measurements had been taken by passing `""` to BullMQ directly, which is not a state the env pipeline can produce. That change is reverted in a follow-up commit, and the PR is now the `REDIS_AUTH` fix alone. `REDIS_AUTH` is not saved by the same mechanism, because `String(undefined)` still yields the string `"undefined"`.

## Checks

Run locally against the final state of the branch:

- `worker/src/__tests__/getQueuePrefix.test.ts` — 7/7 passing. This is the file review flagged; I confirmed it fails on the reverted `||` (`expected undefined to be ''`) and passes on the restored `??`.
- `packages/shared/src/server/redis/redis.test.ts` — 25/25 passing
- `worker/src/__tests__/bullmqVersionCheckOptions.test.ts` — passing
- `turbo run lint --force` — 7/7 tasks, 0 cached
- `turbo run typecheck --force` — 8/8 tasks, 0 cached
- `prettier --check` — clean, via the pre-commit hook

Not run, to be explicit about the gaps:

- The full `pnpm run test` suite. It needs the Postgres / ClickHouse / Redis stack from `docker-compose.dev.yml` plus a seeded database, which I did not stand up.
- `worker/src/__tests__/workerManager.test.ts`. It opens a real Redis connection and times out without a server running, so I could not exercise it here. It is the only test I found that reaches `createNewRedisInstance`, and the changed line has no direct unit coverage today. Happy to add one in this PR if you'd like it.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR normalizes nullish or empty Redis configuration values before passing them to Redis and BullMQ.
- Omits single-node Redis authentication when `REDIS_AUTH` is empty or unset.
- Lets BullMQ use its default queue prefix when `REDIS_KEY_PREFIX` is empty.
- Leaves an existing empty-prefix test assertion inconsistent with the new behavior.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation should not merge until the existing empty-prefix test is updated to match the intended behavior.

The Redis option normalization is otherwise consistent, but the changed `getQueuePrefix` result directly contradicts an existing test and causes that suite to fail.

**Files Needing Attention:** packages/shared/src/server/redis/redis.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/redis/redis.ts:304
**Empty-prefix test now fails**

When `REDIS_KEY_PREFIX` is empty, this line now returns `undefined`, but the existing test in `worker/src/__tests__/getQueuePrefix.test.ts` expects `""`. That assertion will fail until the test is updated to reflect the intended BullMQ default-prefix behavior.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(redis): stop leaking empty/unset nul..."](https://github.com/langfuse/langfuse/commit/8c4e178081aadae4b347b45f46ee460d83b605bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60681596)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
