### PR TITLE
fix(redis): disconnect per-queue clients on shutdown so the worker process exits

### DIFF
--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -235,6 +235,44 @@ const createRedisSentinelInstance = (
   return instance;
 };
 
+/**
+ * Every connection handed out by createNewRedisInstance, so that a shutdown can
+ * release all of them. Each queue owns a dedicated client, and those clients
+ * retry forever; left connected they keep the event loop alive and the process
+ * never exits.
+ */
+const activeRedisInstances = new Set<Redis | Cluster>();
+
+const trackRedisInstance = <T extends Redis | Cluster | null>(
+  instance: T,
+): T => {
+  if (instance) {
+    activeRedisInstances.add(instance);
+    instance.once("end", () => activeRedisInstances.delete(instance));
+  }
+  return instance;
+};
+
+/**
+ * Disconnect every client created by createNewRedisInstance.
+ *
+ * `redis.disconnect()` on the shared client only covers that one connection.
+ * Returns how many were closed, for shutdown logging.
+ */
+export const disconnectAllRedisInstances = (): number => {
+  let closed = 0;
+  for (const instance of activeRedisInstances) {
+    try {
+      instance.disconnect();
+      closed++;
+    } catch (error) {
+      logRedisError("Failed to disconnect Redis instance on shutdown", error);
+    }
+  }
+  activeRedisInstances.clear();
+  return closed;
+};
+
 export const createNewRedisInstance = (
   additionalOptions: Partial<RedisOptions> = {},
 ): Redis | Cluster | null => {
@@ -249,11 +287,11 @@ export const createNewRedisInstance = (
   }
 
   if (env.REDIS_CLUSTER_ENABLED === "true") {
-    return createRedisClusterInstance(additionalOptions);
+    return trackRedisInstance(createRedisClusterInstance(additionalOptions));
   }
 
   if (env.REDIS_SENTINEL_ENABLED === "true") {
-    return createRedisSentinelInstance(additionalOptions);
+    return trackRedisInstance(createRedisSentinelInstance(additionalOptions));
   }
 
   const tlsOptions = buildTlsOptions();
@@ -280,7 +318,7 @@ export const createNewRedisInstance = (
     logRedisError("Redis error", error);
   });
 
-  return instance;
+  return trackRedisInstance(instance);
 };
 
 /**

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -254,10 +254,9 @@ const trackRedisInstance = <T extends Redis | Cluster | null>(
 };
 
 /**
- * Disconnect every client created by createNewRedisInstance.
- *
- * `redis.disconnect()` on the shared client only covers that one connection.
- * Returns how many were closed, for shutdown logging.
+ * Disconnect every client created by createNewRedisInstance, including the
+ * shared `redis` client, which is created through the same path. Returns how
+ * many were closed, for shutdown logging.
  */
 export const disconnectAllRedisInstances = (): number => {
   let closed = 0;

--- a/worker/src/utils/shutdown.ts
+++ b/worker/src/utils/shutdown.ts
@@ -1,5 +1,8 @@
 import { ClickHouseClientManager, logger } from "@langfuse/shared/src/server";
-import { redis } from "@langfuse/shared/src/server";
+import {
+  redis,
+  disconnectAllRedisInstances,
+} from "@langfuse/shared/src/server";
 
 import { ClickhouseWriter } from "../services/ClickhouseWriter";
 import { setSigtermReceived } from "../features/health";
@@ -93,7 +96,12 @@ export const onShutdown: NodeJS.SignalsListener = async (signal) => {
   logger.info("Clickhouse writer has been shut down.");
 
   redis?.disconnect();
-  logger.info("Redis connection has been closed.");
+  // Each queue holds its own client; without this they stay connected, retry
+  // forever, and keep the event loop alive so the process never exits.
+  const closedRedisConnections = disconnectAllRedisInstances();
+  logger.info(
+    `Redis connections have been closed (${closedRedisConnections} clients).`,
+  );
 
   await prisma.$disconnect();
   logger.info("Prisma connection has been closed.");

--- a/worker/src/utils/shutdown.ts
+++ b/worker/src/utils/shutdown.ts
@@ -1,8 +1,5 @@
 import { ClickHouseClientManager, logger } from "@langfuse/shared/src/server";
-import {
-  redis,
-  disconnectAllRedisInstances,
-} from "@langfuse/shared/src/server";
+import { disconnectAllRedisInstances } from "@langfuse/shared/src/server";
 
 import { ClickhouseWriter } from "../services/ClickhouseWriter";
 import { setSigtermReceived } from "../features/health";
@@ -95,8 +92,8 @@ export const onShutdown: NodeJS.SignalsListener = async (signal) => {
   await ClickhouseWriter.getInstance().shutdown();
   logger.info("Clickhouse writer has been shut down.");
 
-  redis?.disconnect();
-  // Each queue holds its own client; without this they stay connected, retry
+  // Closes the shared client and every per-queue client in one pass. Each
+  // queue holds its own client; without this they stay connected, retry
   // forever, and keep the event loop alive so the process never exits.
   const closedRedisConnections = disconnectAllRedisInstances();
   logger.info(


### PR DESCRIPTION
Fixes #17096

## Problem

The worker completes its shutdown sequence in ~20ms and logs `Shutdown complete, exiting process...`, but the process never exits. On Kubernetes this means every worker rollout burns the entire `terminationGracePeriodSeconds` before the pod is SIGKILLed — 300s in our case, and #8156 reported ~1 hour.

`process._getActiveHandles()` five seconds after that log shows 60 undestroyed Redis sockets — every handle except stdout/stderr:

```
[handle-dump] ===== active handles: 62 =====
  - Socket {"fd":2,"destroyed":false}
  - Socket {"fd":1,"destroyed":false}
  - Socket {"localPort":47266,"remote":"<redis>:6379","destroyed":false}
  ... 59 more, all to :6379
[handle-dump] by type: {"Socket":62}
[handle-dump] active requests: 0
```

`onShutdown` closes only the shared client:

```ts
redis?.disconnect();
```

but each queue owns a dedicated client from `createNewRedisInstance()` (introduced in #3052). Those are never closed, and because `redisQueueRetryOptions.retryStrategy` retries forever they keep reconnecting — the log keeps emitting `Redis connection error` well after `Shutdown complete`. Those sockets hold the event loop open.

## Change

Track each instance handed out by `createNewRedisInstance()` and disconnect them together during shutdown.

- `activeRedisInstances` set, populated by a small `trackRedisInstance()` wrapper covering all three paths (standalone, cluster, sentinel)
- instances remove themselves on `"end"`, so the set does not grow across reconnects
- `disconnectAllRedisInstances()` is exported and called from `onShutdown`, returning the count for the log line

This keeps the change in one place instead of touching ~30 queue modules.

## Verification

Eight queue clients against a local Redis, with no timers held so the process exits as soon as the event loop drains:

| | result |
|---|---|
| with `disconnectAllRedisInstances()` | `closed 9` → **exit 0, process ends on its own** |
| without it (current behaviour) | **exit 124 — still running after a 25s timeout** |

Reproduced the original symptom first: sending SIGTERM to the worker container (`docker kill --signal=SIGTERM`, no force) left it `running` for the full 320s I watched. On Kubernetes, three pods were SIGTERMed at 14:07:32, logged `Shutdown complete` at 14:07:32, and were removed at 14:12:34 — all three at the same instant, which is grace expiry rather than independent clean exits.

## Checks

| check | result |
|---|---|
| `turbo run lint --force` (shared, worker) | pass — 5/5, 0 cached |
| `turbo run typecheck --force` (shared, worker) | pass — 5/5, 0 cached |
| `packages/shared/src/server/redis/redis.test.ts` | pass — 25/25 |
| `prettier --check` | pass (via pre-commit hook) |
| full `pnpm run test` | **not run** — needs the compose stack and a seeded DB |

Happy to add a unit test for `disconnectAllRedisInstances()` if you'd like it in this PR.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tracks dedicated Redis clients created for queues and disconnects the tracked clients during worker shutdown, allowing the Node.js event loop to drain instead of waiting for Kubernetes to force termination.
- Adds centralized tracking and cleanup for standalone, cluster, and sentinel clients.
- Removes clients from the registry when they reach the ended state.
- Invokes bulk Redis cleanup after workers and writers have shut down.
- The lifecycle behavior currently lacks focused regression coverage.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with the non-blocking concern that its shutdown regression fix is not protected by a focused test.

The cleanup is called after Redis-dependent worker shutdown and covers all factory branches, with no concrete functional or security failure identified; only missing regression coverage remains.

**Files Needing Attention:** packages/shared/src/server/redis/redis.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createNewRedisInstance] --> B[Create standalone, cluster, or sentinel client]
    B --> C[Add client to activeRedisInstances]
    C --> D[Queue or worker uses client]
    D --> E{Client emits end?}
    E -->|Yes| F[Remove client from registry]
    E -->|No| G[Worker shutdown begins]
    G --> H[Close workers and background services]
    H --> I[disconnectAllRedisInstances]
    I --> J[Disconnect each tracked client]
    J --> K[Clear registry]
    K --> L[Event loop can drain]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/redis/redis.ts:259-274
**Shutdown cleanup lacks tests**

The new process-wide client registry and disconnect-all shutdown path have no regression test. Please add a focused test that creates tracked clients, verifies each is disconnected exactly once, confirms ended clients are removed, and confirms a second cleanup is empty. Without this coverage, later lifecycle changes could silently restore the worker shutdown hang.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(redis): disconnect per-queue clients..."](https://github.com/langfuse/langfuse/commit/0f0ecd0665456b698e9bcb5cec16fddc832750ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60695762)</sub>

<!-- /greptile_comment -->