### PR TITLE
fix(evals): use radio group semantics for sample observation selection

### DIFF
--- a/web/src/components/design-system/RadioGroup/RadioGroup.tsx
+++ b/web/src/components/design-system/RadioGroup/RadioGroup.tsx
@@ -5,7 +5,7 @@ import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 
 type RadioGroupProps = Pick<
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>,
-  "children" | "defaultValue" | "onValueChange" | "value"
+  "children" | "className" | "defaultValue" | "onValueChange" | "value"
 >;
 
 const RadioGroupRoot = React.forwardRef<

--- a/web/src/components/design-system/RadioGroup/RadioGroup.tsx
+++ b/web/src/components/design-system/RadioGroup/RadioGroup.tsx
@@ -5,7 +5,12 @@ import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 
 type RadioGroupProps = Pick<
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>,
-  "children" | "className" | "defaultValue" | "onValueChange" | "value"
+  | "aria-label"
+  | "children"
+  | "className"
+  | "defaultValue"
+  | "onValueChange"
+  | "value"
 >;
 
 const RadioGroupRoot = React.forwardRef<

--- a/web/src/components/design-system/RadioGroup/RadioGroup.tsx
+++ b/web/src/components/design-system/RadioGroup/RadioGroup.tsx
@@ -2,30 +2,43 @@
 
 import * as React from "react";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { cva } from "class-variance-authority";
+import { cn } from "@/src/utils/tailwind";
+
+const radioGroupVariants = cva("grid gap-2", {
+  variants: {
+    layout: {
+      stack: "",
+      // RadioGroup.Root rendered as a layout-neutral wrapper (used when the
+      // radio items live inside a larger block, e.g. a data-table column)
+      inline: "contents",
+    },
+  },
+  defaultVariants: { layout: "stack" },
+});
 
 type RadioGroupProps = Pick<
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>,
-  | "aria-label"
-  | "children"
-  | "className"
-  | "defaultValue"
-  | "onValueChange"
-  | "value"
->;
+  "aria-label" | "children" | "defaultValue" | "onValueChange" | "value"
+> & { layout?: "stack" | "inline" };
 
 const RadioGroupRoot = React.forwardRef<
   React.ComponentRef<typeof RadioGroupPrimitive.Root>,
   RadioGroupProps
->((props, ref) => {
+>(({ layout, ...props }, ref) => {
   return (
-    <RadioGroupPrimitive.Root className="grid gap-2" {...props} ref={ref} />
+    <RadioGroupPrimitive.Root
+      className={cn(radioGroupVariants({ layout }))}
+      {...props}
+      ref={ref}
+    />
   );
 });
 RadioGroupRoot.displayName = RadioGroupPrimitive.Root.displayName;
 
 type RadioGroupItemProps = Pick<
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>,
-  "aria-controls" | "disabled" | "id" | "value"
+  "aria-controls" | "aria-label" | "disabled" | "id" | "value"
 >;
 
 const RadioGroupItem = React.forwardRef<

--- a/web/src/features/evals/v2/components/Evaluators/Testing/components/EvaluatorSampleObservationSelector/EvaluatorSampleObservationSelector.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/Testing/components/EvaluatorSampleObservationSelector/EvaluatorSampleObservationSelector.tsx
@@ -94,6 +94,7 @@ export function EvaluatorSampleObservationSelector({
       leadingColumns={leadingColumns}
       resolveSelection={resolveSelection}
       selectionControl="radio"
+      selectionControlLabel="Use an observation as sample"
       getRowClassName={(observation) =>
         observation.id === selectedObservationId ? "bg-muted/50" : ""
       }

--- a/web/src/features/evals/v2/components/Evaluators/Testing/components/EvaluatorSampleObservationSelector/EvaluatorSampleObservationSelector.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/Testing/components/EvaluatorSampleObservationSelector/EvaluatorSampleObservationSelector.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { Star } from "lucide-react";
 import type { FilterState } from "@langfuse/shared";
 
-import { Checkbox } from "@/src/components/design-system/Checkbox/Checkbox";
+import { RadioGroup } from "@/src/components/design-system/RadioGroup/RadioGroup";
 import type { LangfuseColumnDef } from "@/src/components/table/types";
 import type { AbsoluteTimeRange } from "@/src/utils/date-range-utils";
 import { compactNumberFormatter } from "@/src/utils/numbers";
@@ -64,12 +64,13 @@ export function EvaluatorSampleObservationSelector({
         cell: ({ row }) => (
           <label
             className="flex h-full w-full cursor-pointer items-center px-2"
+            htmlFor={`sample-selection-${row.original.id}`}
             onClick={(event) => event.stopPropagation()}
           >
-            <Checkbox
-              checked={selectedObservationId === row.original.id}
+            <RadioGroup.Item
+              id={`sample-selection-${row.original.id}`}
+              value={row.original.id}
               aria-label={`Use ${row.original.name ?? row.original.id} as sample`}
-              onCheckedChange={() => onSelect(row.original)}
             />
           </label>
         ),
@@ -92,6 +93,7 @@ export function EvaluatorSampleObservationSelector({
       onOpenTrace={onOpenTrace}
       leadingColumns={leadingColumns}
       resolveSelection={resolveSelection}
+      selectionControl="radio"
       getRowClassName={(observation) =>
         observation.id === selectedObservationId ? "bg-muted/50" : ""
       }

--- a/web/src/features/evals/v2/components/Evaluators/Testing/components/SampleObservationSelectorBase/SampleObservationSelectorBase.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/Testing/components/SampleObservationSelectorBase/SampleObservationSelectorBase.tsx
@@ -16,6 +16,7 @@ import { createDateTableColumn } from "@/src/components/design-system/table/colu
 import { createIOTableColumn } from "@/src/components/design-system/table/columns/createIOTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { DataTable } from "@/src/components/table/data-table";
+import { RadioGroup } from "@/src/components/design-system/RadioGroup/RadioGroup";
 import { DataTableColumnVisibilityFilter } from "@/src/components/table/data-table-column-visibility-filter";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 import type { LangfuseColumnDef } from "@/src/components/table/types";
@@ -144,6 +145,8 @@ export type SampleObservationSelectorBaseProps = {
     selectedObservationId: string | null,
   ) => SampleObservation | null | undefined;
   getRowClassName: ((observation: SampleObservation) => string) | undefined;
+  /** Rows are mutually exclusive; "radio" exposes the leading control to assistive tech as a radio group. */
+  selectionControl?: "checkbox" | "radio";
   filterDescription: string;
   filterTooltip: string;
   matchingDescription: string;
@@ -169,6 +172,7 @@ export function SampleObservationSelectorBase(
     leadingColumns,
     resolveSelection,
     getRowClassName,
+    selectionControl = "checkbox",
     filterDescription,
     filterTooltip,
     matchingDescription,
@@ -490,6 +494,50 @@ export function SampleObservationSelectorBase(
     }
   };
 
+  const observationTableArea = (
+    <div
+      ref={
+        selectionToReconcile !== undefined
+          ? (element) => {
+              // Commit fresh query results through the existing selection owner without a data-sync effect.
+              if (element) onSelect(selectionToReconcile);
+            }
+          : undefined
+      }
+      className="flex h-64 min-h-0 flex-col overflow-hidden rounded-md border"
+    >
+      <DataTable
+        tableName={tableName}
+        columns={columns}
+        data={
+          observationsPending && matchingObservations.length === 0
+            ? { isLoading: true, isError: false }
+            : observationsError
+              ? {
+                  isLoading: false,
+                  isError: true,
+                  error: observationsError.message,
+                }
+              : {
+                  isLoading: false,
+                  isError: false,
+                  data: matchingObservations,
+                }
+        }
+        hidePagination
+        onScroll={handleScroll}
+        columnVisibility={columnVisibility}
+        onColumnVisibilityChange={setColumnVisibility}
+        columnOrder={columnOrder}
+        onColumnOrderChange={setColumnOrder}
+        rowHeight={rowHeight}
+        onRowClick={onOpenTrace}
+        getRowClassName={getRowClassName}
+        noResultsMessage="No observations match the current filters and time range."
+      />
+    </div>
+  );
+
   return (
     <div className="flex shrink-0 flex-col gap-6">
       <section className="flex flex-col gap-2">
@@ -585,47 +633,22 @@ export function SampleObservationSelectorBase(
             />
           }
         />
-        <div
-          ref={
-            selectionToReconcile !== undefined
-              ? (element) => {
-                  // Commit fresh query results through the existing selection owner without a data-sync effect.
-                  if (element) onSelect(selectionToReconcile);
-                }
-              : undefined
-          }
-          className="flex h-64 min-h-0 flex-col overflow-hidden rounded-md border"
-        >
-          <DataTable
-            tableName={tableName}
-            columns={columns}
-            data={
-              observationsPending && matchingObservations.length === 0
-                ? { isLoading: true, isError: false }
-                : observationsError
-                  ? {
-                      isLoading: false,
-                      isError: true,
-                      error: observationsError.message,
-                    }
-                  : {
-                      isLoading: false,
-                      isError: false,
-                      data: matchingObservations,
-                    }
-            }
-            hidePagination
-            onScroll={handleScroll}
-            columnVisibility={columnVisibility}
-            onColumnVisibilityChange={setColumnVisibility}
-            columnOrder={columnOrder}
-            onColumnOrderChange={setColumnOrder}
-            rowHeight={rowHeight}
-            onRowClick={onOpenTrace}
-            getRowClassName={getRowClassName}
-            noResultsMessage="No observations match the current filters and time range."
-          />
-        </div>
+        {selectionControl === "radio" ? (
+          <RadioGroup
+            className="contents"
+            value={selectedObservationId ?? ""}
+            onValueChange={(observationId) => {
+              const observation = matchingObservations.find(
+                (item) => item.id === observationId,
+              );
+              if (observation) onSelect(observation);
+            }}
+          >
+            {observationTableArea}
+          </RadioGroup>
+        ) : (
+          observationTableArea
+        )}
       </section>
     </div>
   );

--- a/web/src/features/evals/v2/components/Evaluators/Testing/components/SampleObservationSelectorBase/SampleObservationSelectorBase.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/Testing/components/SampleObservationSelectorBase/SampleObservationSelectorBase.tsx
@@ -147,6 +147,8 @@ export type SampleObservationSelectorBaseProps = {
   getRowClassName: ((observation: SampleObservation) => string) | undefined;
   /** Rows are mutually exclusive; "radio" exposes the leading control to assistive tech as a radio group. */
   selectionControl?: "checkbox" | "radio";
+  /** Accessible name announced for the radio group when selectionControl is "radio". */
+  selectionControlLabel?: string;
   filterDescription: string;
   filterTooltip: string;
   matchingDescription: string;
@@ -173,6 +175,7 @@ export function SampleObservationSelectorBase(
     resolveSelection,
     getRowClassName,
     selectionControl = "checkbox",
+    selectionControlLabel,
     filterDescription,
     filterTooltip,
     matchingDescription,
@@ -636,6 +639,7 @@ export function SampleObservationSelectorBase(
         {selectionControl === "radio" ? (
           <RadioGroup
             className="contents"
+            aria-label={selectionControlLabel ?? "Sample observation selection"}
             value={selectedObservationId ?? ""}
             onValueChange={(observationId) => {
               const observation = matchingObservations.find(

--- a/web/src/features/evals/v2/components/Evaluators/Testing/components/SampleObservationSelectorBase/SampleObservationSelectorBase.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/Testing/components/SampleObservationSelectorBase/SampleObservationSelectorBase.tsx
@@ -638,7 +638,7 @@ export function SampleObservationSelectorBase(
         />
         {selectionControl === "radio" ? (
           <RadioGroup
-            className="contents"
+            layout="inline"
             aria-label={selectionControlLabel ?? "Sample observation selection"}
             value={selectedObservationId ?? ""}
             onValueChange={(observationId) => {


### PR DESCRIPTION
### What

The leading column of `EvaluatorSampleObservationSelector` rendered a `Checkbox` per row, but the selection is mutually exclusive (and always exactly one observation is selected — `resolveSelection` auto-selects the first match). This replaces the checkbox with a radio control so assistive technology is told the truth about the selection model.

- `SampleObservationSelectorBase` gains an optional `selectionControl: "checkbox" | "radio"` prop (default `"checkbox"`, so `RuleSampleObservationSelector` and every other consumer are unchanged). In radio mode the table area is wrapped in a `RadioGroup.Root` (radix items need the root context) and selection changes flow through the existing `onSelect`.
- `EvaluatorSampleObservationSelector` renders `RadioGroup.Item` and passes `selectionControl="radio"`.
- `RadioGroupProps` in the design-system `RadioGroup` now accepts `className` (the radix root already spread it; the Pick type just didn't include it), needed to make the wrapper layout-neutral (`display: contents`).

### Why

Reported in #17055: screen reader users hear `role="checkbox"` with `aria-checked` and are told rows are independently selectable, then selecting one silently deselects another. The ARIA Authoring Practices Guide assigns mutually exclusive selection to the radio pattern.

### How tested

- `pnpm --filter web run typecheck`: the three touched files produce no errors (the remaining local errors are pre-existing environment noise from missing generated artifacts, unrelated to this change; CI runs the full check).
- `prettier --check` on the touched files: clean.
- Existing behavior is unchanged for consumers that don't opt into `selectionControl="radio"`: the wrapper only mounts in radio mode.

A note on the issue's suggestion: the `RadioGroup` component lives at `web/src/components/design-system/RadioGroup/RadioGroup.tsx` (the issue's path was slightly off), and since radix `RadioGroup.Item` needs a `Root` ancestor, the change is not confined to the selector cell — hence the small `SampleObservationSelectorBase` addition.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes evaluator sample-observation selection from checkbox to radio semantics while preserving checkbox behavior for existing consumers.

- Adds an optional selection-control mode to the shared observation selector.
- Wraps the evaluator observation table in a controlled Radix radio group.
- Extends the design-system radio-group props to accept layout classes.
- The new radio group still needs an accessible group-level name.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after addressing the non-blocking accessibility omission on the new radio group.

Selection behavior remains correctly connected to the existing observation state, but the newly introduced radio group lacks a group-level accessible name, reducing the clarity of the intended screen-reader improvement.

**Files Needing Attention:** web/src/features/evals/v2/components/Evaluators/Testing/components/SampleObservationSelectorBase/SampleObservationSelectorBase.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/evals/v2/components/Evaluators/Testing/components/SampleObservationSelectorBase/SampleObservationSelectorBase.tsx:636-648
**Radio group lacks name**

The new `RadioGroup` provides `className`, `value`, and change handling, but no `aria-label` or `aria-labelledby`. The individual radio items are labeled, but assistive technology cannot announce what the group represents when a user enters it, reducing the clarity of the sample-selection control.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): use radio group semantics fo..."](https://github.com/langfuse/langfuse/commit/c5d7723c5024cf2824ecadfc53cd6b1350095189) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60720507)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Scores and evaluations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/scores-and-evaluations.md)

<!-- /greptile_comment -->