### PR TITLE
feat(public-api): add ?fromTimestamp / ?toTimestamp filters to GET /api/public/score-configs

### DIFF
--- a/fern/apis/server/definition/score-configs.yml
+++ b/fern/apis/server/definition/score-configs.yml
@@ -19,6 +19,24 @@ service:
       request:
         name: GetScoreConfigsRequest
         query-parameters:
+          fromTimestamp:
+            type: optional<datetime>
+            docs: |
+              Optional ISO-8601 lower bound on the score config row's
+              `createdAt` (inclusive). Omit for an open-ended start.
+              Pattern matches `GET /api/public/comments`,
+              `GET /api/public/models`, `GET /api/public/datasets`,
+              `GET /api/public/llm-connections`, and
+              `GET /api/public/annotation-queues`.
+          toTimestamp:
+            type: optional<datetime>
+            docs: |
+              Optional ISO-8601 upper bound on the score config row's
+              `createdAt` (exclusive). Omit for an open-ended end.
+              Pattern matches `GET /api/public/comments`,
+              `GET /api/public/models`, `GET /api/public/datasets`,
+              `GET /api/public/llm-connections`, and
+              `GET /api/public/annotation-queues`.
           page:
             type: optional<integer>
             docs: Page number, starts at 1.

--- a/packages/shared/src/server/repositories/score-configs.ts
+++ b/packages/shared/src/server/repositories/score-configs.ts
@@ -8,26 +8,46 @@ import { traceException } from "../instrumentation";
 
 export const listScoreConfigs = async ({
   projectId,
+  fromTimestamp,
+  toTimestamp,
   page,
   limit,
 }: {
   projectId: string;
+  fromTimestamp?: Date;
+  toTimestamp?: Date;
   page: number;
   limit: number;
 }) => {
+  // Build the time-window filter on `createdAt`. Both params are
+  // independently optional; together they form a half-open
+  // `[fromTimestamp, toTimestamp)` range. The window composes with the
+  // existing project scope — it can only narrow the result set, never
+  // widen it.
+  const createdAtFilter =
+    fromTimestamp || toTimestamp
+      ? {
+          createdAt: {
+            ...(fromTimestamp ? { gte: fromTimestamp } : {}),
+            ...(toTimestamp ? { lt: toTimestamp } : {}),
+          },
+        }
+      : {};
+
+  const where = {
+    projectId,
+    ...createdAtFilter,
+  };
+
   const [rawConfigs, totalItems] = await Promise.all([
     prisma.scoreConfig.findMany({
-      where: {
-        projectId,
-      },
+      where,
       orderBy: [{ createdAt: "desc" }, { id: "asc" }],
       take: limit,
       skip: (page - 1) * limit,
     }),
     prisma.scoreConfig.count({
-      where: {
-        projectId,
-      },
+      where,
     }),
   ]);
 

--- a/web/src/__tests__/server/score-configs.servertest.ts
+++ b/web/src/__tests__/server/score-configs.servertest.ts
@@ -473,6 +473,162 @@ describe("/api/public/score-configs API Endpoint", () => {
     });
   });
 
+  describe("GET /api/public/score-configs timestamp window", () => {
+    // Three score configs at deterministic, well-separated `createdAt`
+    // values so the half-open `[fromTimestamp, toTimestamp)` window can
+    // be exercised without relying on clock or ordering accidents.
+    const OLD = new Date("2021-01-01T00:00:00.000Z");
+    const MID = new Date("2021-06-01T00:00:00.000Z");
+    const NEW = new Date("2022-01-01T00:00:00.000Z");
+
+    let oldId: string;
+    let midId: string;
+    let newId: string;
+
+    const createConfigAt = async (name: string, createdAt: Date) => {
+      return prisma.scoreConfig.create({
+        data: {
+          projectId,
+          name,
+          dataType: ScoreConfigDataType.NUMERIC,
+          minValue: 0,
+          maxValue: 1,
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+    };
+
+    beforeEach(async () => {
+      const oldConfig = await createConfigAt(`ts-old-${v4()}`, OLD);
+      const midConfig = await createConfigAt(`ts-mid-${v4()}`, MID);
+      const newConfig = await createConfigAt(`ts-new-${v4()}`, NEW);
+      oldId = oldConfig.id;
+      midId = midConfig.id;
+      newId = newConfig.id;
+    });
+
+    it("omits the filter when neither timestamp is provided (existing behavior)", async () => {
+      const response = await makeZodVerifiedAPICall(
+        GetScoreConfigsResponse,
+        "GET",
+        "/api/public/score-configs?limit=50",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const ids = response.body.data.map((c) => c.id);
+      expect(ids).toEqual(expect.arrayContaining([oldId, midId, newId]));
+      expect(response.body.meta.totalItems).toBeGreaterThanOrEqual(3);
+    });
+
+    it("filters by fromTimestamp only (inclusive lower bound)", async () => {
+      // Anything on or after MID: the mid and new configs.
+      const response = await makeZodVerifiedAPICall(
+        GetScoreConfigsResponse,
+        "GET",
+        `/api/public/score-configs?fromTimestamp=${MID.toISOString()}&limit=50`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const ids = response.body.data.map((c) => c.id);
+      expect(ids).toEqual(expect.arrayContaining([midId, newId]));
+      expect(ids).not.toContain(oldId);
+      expect(response.body.meta.totalItems).toBe(2);
+    });
+
+    it("filters by toTimestamp only (exclusive upper bound)", async () => {
+      // Anything strictly before NEW: the old and mid configs. The
+      // config created exactly at NEW is excluded because the upper
+      // bound is `lt`.
+      const response = await makeZodVerifiedAPICall(
+        GetScoreConfigsResponse,
+        "GET",
+        `/api/public/score-configs?toTimestamp=${NEW.toISOString()}&limit=50`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const ids = response.body.data.map((c) => c.id);
+      expect(ids).toEqual(expect.arrayContaining([oldId, midId]));
+      expect(ids).not.toContain(newId);
+      expect(response.body.meta.totalItems).toBe(2);
+    });
+
+    it("filters by a half-open [fromTimestamp, toTimestamp) window when both are provided", async () => {
+      // Window [OLD, NEW) -> exactly the mid config.
+      const response = await makeZodVerifiedAPICall(
+        GetScoreConfigsResponse,
+        "GET",
+        `/api/public/score-configs?fromTimestamp=${OLD.toISOString()}&toTimestamp=${NEW.toISOString()}&limit=50`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const ids = response.body.data.map((c) => c.id);
+      expect(ids).toEqual([midId]);
+      expect(response.body.meta.totalItems).toBe(1);
+    });
+
+    it("returns 400 on an invalid fromTimestamp format", async () => {
+      const response = await makeAPICall(
+        "GET",
+        "/api/public/score-configs?fromTimestamp=not-a-date",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 on an invalid toTimestamp format", async () => {
+      const response = await makeAPICall(
+        "GET",
+        "/api/public/score-configs?toTimestamp=2021-13-40T99:99:99Z",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("composes the time window with the existing project scope", async () => {
+      // Create a separate project + api key so we can prove the filter
+      // does not leak configs across the project boundary.
+      const other = await createOrgProjectAndApiKey();
+
+      await prisma.scoreConfig.create({
+        data: {
+          projectId: other.projectId,
+          name: `ts-other-project-${v4()}`,
+          dataType: ScoreConfigDataType.NUMERIC,
+          minValue: 0,
+          maxValue: 1,
+          createdAt: NEW,
+          updatedAt: NEW,
+        },
+      });
+
+      const response = await makeZodVerifiedAPICall(
+        GetScoreConfigsResponse,
+        "GET",
+        `/api/public/score-configs?fromTimestamp=${NEW.toISOString()}&limit=50`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      // Only `newId` belongs to `projectId` with createdAt >= NEW.
+      expect(response.body.meta.totalItems).toBe(1);
+      expect(response.body.data.map((c) => c.id)).toEqual([newId]);
+    });
+  });
+
   describe("PATCH /api/public/score-configs/:configId", () => {
     it("should successfully archive a score config", async () => {
       const { id: configId } = (await prisma.scoreConfig.findFirst({

--- a/web/src/features/public-api/types/score-configs.ts
+++ b/web/src/features/public-api/types/score-configs.ts
@@ -8,6 +8,7 @@ import {
   publicApiPaginationZod,
   ScoreConfigCategory,
   ScoreConfigNameSchema,
+  stringDateTime,
   validateCategories,
   validateNumericRangeFields,
 } from "@langfuse/shared";
@@ -149,6 +150,16 @@ export const PutScoreConfigResponse = APIScoreConfig;
 
 // GET /score-configs
 export const GetScoreConfigsQuery = z.object({
+  // Optional ISO-8601 time window on the score config row's `createdAt`.
+  // Both params are independently optional and compose into a half-open
+  // `[fromTimestamp, toTimestamp)` range. Omitting both preserves the
+  // historical "all configs" behavior. Pattern matches
+  // `GET /api/public/comments` (PR #15692), `GET /api/public/models`
+  // (PR #16952), `GET /api/public/datasets` (PR #17002),
+  // `GET /api/public/llm-connections` (PR #17070), and
+  // `GET /api/public/annotation-queues` (PR #17090).
+  fromTimestamp: stringDateTime,
+  toTimestamp: stringDateTime,
   ...publicApiPaginationZod,
 });
 

--- a/web/src/pages/api/public/score-configs/index.ts
+++ b/web/src/pages/api/public/score-configs/index.ts
@@ -30,9 +30,11 @@ export default withMiddlewares({
     querySchema: GetScoreConfigsQuery,
     responseSchema: GetScoreConfigsResponse,
     fn: async ({ query, auth }) => {
-      const { page, limit } = query;
+      const { page, limit, fromTimestamp, toTimestamp } = query;
       return await listScoreConfigs({
         projectId: auth.scope.projectId,
+        fromTimestamp: fromTimestamp ? new Date(fromTimestamp) : undefined,
+        toTimestamp: toTimestamp ? new Date(toTimestamp) : undefined,
         page,
         limit,
       });


### PR DESCRIPTION
## Problem

`GET /api/public/score-configs` previously supported only pagination (`?page`, `?limit`). Customers managing project-owned score configurations — especially teams that build up custom eval configs over time — could not scope the list to a recent time window. Every page scan returned the full history of the project's score configs.

The companion `GET /api/public/comments` (PR #15692), `GET /api/public/models` (PR #16952), `GET /api/public/datasets` (PR #17002), `GET /api/public/llm-connections` (PR #17070), and `GET /api/public/annotation-queues` (PR #17090) endpoints already accept `?fromTimestamp` / `?toTimestamp` on `createdAt`. The same pattern fits naturally on `/score-configs` since score configs are project-owned rows with a `createdAt` column.

Concretely:
- A team iterating on its eval suite needs "what score configs were added this quarter?" — currently they must paginate through the full list and filter client-side.
- An audit asking "what scoring rules were created since the last compliance review?" has no way to ask the API.
- An admin doing a one-off snapshot wants to scope to a recent window, not the entire history.

## Proposed solution

Extend `GetScoreConfigsQuery` to accept two optional ISO-8601 timestamp query params and pipe them through to the shared `listScoreConfigs` repository function as a Prisma `createdAt` range filter.

- `?fromTimestamp=2026-08-01T00:00:00Z` → `createdAt >= fromTimestamp` (inclusive)
- `?toTimestamp=2026-08-31T23:59:59Z` → `createdAt < toTimestamp` (exclusive)
- Either param can be omitted (open-ended range). Both together form a half-open `[fromTimestamp, toTimestamp)` window.
- Filter composes with the existing `projectId` scope. Score configs outside the project are still filtered out.
- The pagination count uses the same `where` clause so `totalItems` reflects the windowed result.
- `stringDateTime` (strict ISO-8601) ensures malformed wire values return 400, not 500.
- The shared `listScoreConfigs` function takes optional `Date` parameters with safe `undefined` defaults, so existing internal callers are unaffected.
- The `scoreConfigs:read` RBAC action on the route handler is preserved.

## Files

- `web/src/features/public-api/types/score-configs.ts` — add `fromTimestamp` and `toTimestamp` (`stringDateTime`) on `GetScoreConfigsQuery`.
- `packages/shared/src/server/repositories/score-configs.ts` — extend `listScoreConfigs` to accept the two new optional `Date` parameters, build a `createdAtFilter` (`gte`/`lt`) that composes with the existing `projectId` clause, and apply the same `where` to the `count` query.
- `web/src/pages/api/public/score-configs/index.ts` — destructure the two new params in the route handler, convert the ISO-8601 strings to `Date` objects, and pass them through to the shared `listScoreConfigs` function.
- `web/src/__tests__/server/score-configs.servertest.ts` — new `describe("GET /api/public/score-configs timestamp window", ...)` block with 7 cases: omit both (existing behavior), fromTimestamp only, toTimestamp only, both params forming a half-open window, invalid fromTimestamp format (400), invalid toTimestamp format (400), and a project-scope composition test. Three score configs are force-pinned to deterministic `createdAt` values via `prisma.scoreConfig.create`.
- `fern/apis/server/definition/score-configs.yml` — document the two new query parameters on the `get` endpoint.

## Compatibility

- Both params are optional. Existing API consumers see no change.
- `GetScoreConfigsQuery` is widened (more allowed keys), not narrowed, so no client breaks.
- The shared `listScoreConfigs` function is extended with two new optional parameters; existing callers that do not pass them see no behavior change.
- The route handler is updated to pass the new params through; the Prisma query is the only behavior change.

## Verification

- `prettier --check` on the 4 source files and the Fern yml: clean.
- `tsc --noEmit` from `web/`: no new errors in the changed files.
- `npx fern-api check --api server`: `All checks passed`.
- Standalone structural smoke test (`stringDateTime` in Zod, `gte`+`lt` in shared repo, route converts strings to Date objects, Fern spec includes both, `where` shared between findMany and count): all assertions pass.
- `pnpm --filter web exec vitest run web/src/__tests__/server/score-configs.servertest.ts` is blocked locally by a pre-existing storybook dep mismatch (`@typescript/typescript6` package-name issue in `.storybook/main.ts`); CI is expected to exercise the new cases on the standard test infrastructure.

## Risk

Minimal. The change adds a filter that narrows the result set; it cannot widen it. A malformed timestamp is caught by `stringDateTime` and returns 400, not 500. The shared `listScoreConfigs` function is internal — its existing callers are unaffected because the new parameters are optional with safe `undefined` defaults. The `scoreConfigs:read` RBAC action is preserved, so role-based access still works.

## Future work

- Mirror the same `?fromTimestamp` / `?toTimestamp` parameters on `?updatedAt` for change audits.
- Extend the same pattern to `GET /api/public/media` and `GET /api/public/projects` (the other v1 list endpoints that still lack the filter).

Fixes #17099


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds optional creation-time filtering to the public score-config list endpoint.
- Validates `fromTimestamp` and `toTimestamp` as ISO-8601 query parameters.
- Applies an inclusive lower bound and exclusive upper bound while retaining project scoping.
- Uses the same filtered predicate for pagination results and totals.
- Documents the parameters in Fern and adds server coverage, although several new assertions conflict with the test fixtures and range semantics.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The endpoint implementation appears sound, but the PR should not merge until the deterministically failing server-test assertions are corrected.

The inclusive lower-bound implementation necessarily includes the fixture at `OLD`, while shared outer fixtures also fall within two open-ended ranges, contradicting three exact assertions in the added test block.

**Files Needing Attention:** web/src/__tests__/server/score-configs.servertest.ts
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant API as GET /api/public/score-configs
  participant Schema as GetScoreConfigsQuery
  participant Repo as listScoreConfigs
  participant DB as PostgreSQL

  Client->>API: page, limit, fromTimestamp?, toTimestamp?
  API->>Schema: Validate query
  Schema-->>API: Valid ISO timestamps
  API->>Repo: projectId + Date bounds
  Repo->>DB: findMany where projectId and createdAt range
  Repo->>DB: count using same where clause
  DB-->>Repo: configs and filtered total
  Repo-->>Client: data + pagination metadata
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/score-configs.servertest.ts:574
**Timestamp tests cannot pass**

The new timestamp-window tests conflict with their own fixtures. The `[OLD, NEW)` request includes `oldId` because `OLD` is an inclusive lower bound, so the response cannot equal `[midId]`. The outer `beforeEach` also creates three 2024 configs in the same project, making the exact totals in the `fromTimestamp`-only and project-scope cases 5 and 4 rather than 2 and 1. These assertions will therefore fail in CI unless the fixtures or expectations are corrected.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add ?fromTimestamp / ?..."](https://github.com/langfuse/langfuse/commit/4df10a477f0607b5b9c469f945916159cfef235d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60725787)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->