### PR TITLE
feat(public-api): add ?fromTimestamp and ?toTimestamp filters to score-configs and annotation-queues

### DIFF
--- a/fern/apis/server/definition/annotation-queues.yml
+++ b/fern/apis/server/definition/annotation-queues.yml
@@ -20,6 +20,12 @@ service:
           limit:
             type: optional<integer>
             docs: limit of items per page
+          fromTimestamp:
+            type: optional<datetime>
+            docs: Optional filter to only include items created on or after this timestamp.
+          toTimestamp:
+            type: optional<datetime>
+            docs: Optional filter to only include items created before this timestamp.
       response: PaginatedAnnotationQueues
 
     createQueue:
@@ -59,6 +65,12 @@ service:
           limit:
             type: optional<integer>
             docs: limit of items per page
+          fromTimestamp:
+            type: optional<datetime>
+            docs: Optional filter to only include items created on or after this timestamp.
+          toTimestamp:
+            type: optional<datetime>
+            docs: Optional filter to only include items created before this timestamp.
       response: PaginatedAnnotationQueueItems
 
     getQueueItem:

--- a/fern/apis/server/definition/score-configs.yml
+++ b/fern/apis/server/definition/score-configs.yml
@@ -25,6 +25,12 @@ service:
           limit:
             type: optional<integer>
             docs: Limit of items per page. If you encounter api issues due to too large page sizes, try to reduce the limit
+          fromTimestamp:
+            type: optional<datetime>
+            docs: Optional filter to only include items created on or after this timestamp.
+          toTimestamp:
+            type: optional<datetime>
+            docs: Optional filter to only include items created before this timestamp.
       response: ScoreConfigs
     get-by-id:
       docs: Get a score config

--- a/packages/shared/src/server/repositories/score-configs.ts
+++ b/packages/shared/src/server/repositories/score-configs.ts
@@ -10,24 +10,36 @@ export const listScoreConfigs = async ({
   projectId,
   page,
   limit,
+  fromTimestamp,
+  toTimestamp,
 }: {
   projectId: string;
   page: number;
   limit: number;
+  fromTimestamp?: Date | null;
+  toTimestamp?: Date | null;
 }) => {
+  const where = {
+    projectId,
+    ...(fromTimestamp || toTimestamp
+      ? {
+          createdAt: {
+            ...(fromTimestamp ? { gte: fromTimestamp } : {}),
+            ...(toTimestamp ? { lt: toTimestamp } : {}),
+          },
+        }
+      : {}),
+  };
+
   const [rawConfigs, totalItems] = await Promise.all([
     prisma.scoreConfig.findMany({
-      where: {
-        projectId,
-      },
+      where,
       orderBy: [{ createdAt: "desc" }, { id: "asc" }],
       take: limit,
       skip: (page - 1) * limit,
     }),
     prisma.scoreConfig.count({
-      where: {
-        projectId,
-      },
+      where,
     }),
   ]);
 

--- a/web/src/__tests__/server/annotation-queues-api.servertest.ts
+++ b/web/src/__tests__/server/annotation-queues-api.servertest.ts
@@ -179,6 +179,29 @@ describe("Annotation Queues API Endpoints", () => {
       expect(firstPageResponse.body.data.length).toBe(limit);
       expect(secondPageResponse.body.data.length).toBe(limit);
     });
+
+    it("should filter annotation queues by fromTimestamp and toTimestamp", async () => {
+      const now = new Date();
+      const from = new Date(now.getTime() - 1000 * 60 * 60).toISOString();
+      const to = new Date(now.getTime() + 1000 * 60 * 60).toISOString();
+
+      const response = await makeZodVerifiedAPICall(
+        GetAnnotationQueuesResponse,
+        "GET",
+        `/api/public/annotation-queues?fromTimestamp=${encodeURIComponent(from)}&toTimestamp=${encodeURIComponent(to)}`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBeGreaterThanOrEqual(0);
+      response.body.data.forEach((queue) => {
+        expect(new Date(queue.createdAt).getTime()).toBeGreaterThanOrEqual(new Date(from).getTime());
+        expect(new Date(queue.createdAt).getTime()).toBeLessThan(new Date(to).getTime());
+      });
+    });
+  });
+
   });
 
   describe("POST /annotation-queues", () => {

--- a/web/src/__tests__/server/score-configs.servertest.ts
+++ b/web/src/__tests__/server/score-configs.servertest.ts
@@ -808,5 +808,24 @@ describe("/api/public/score-configs API Endpoint", () => {
         ],
       });
     });
+      it("should filter score configs by fromTimestamp and toTimestamp", async () => {
+      const from = "2024-05-10T12:00:00.000Z";
+      const to = "2024-05-12T00:00:00.000Z";
+
+      const response = await makeZodVerifiedAPICall(
+        GetScoreConfigsResponse,
+        "GET",
+        `/api/public/score-configs?fromTimestamp=${encodeURIComponent(from)}&toTimestamp=${encodeURIComponent(to)}`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBeGreaterThan(0);
+      response.body.data.forEach((config) => {
+        expect(new Date(config.createdAt).getTime()).toBeGreaterThanOrEqual(new Date(from).getTime());
+        expect(new Date(config.createdAt).getTime()).toBeLessThan(new Date(to).getTime());
+      });
+    });
   });
 });

--- a/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
+++ b/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
@@ -121,22 +121,32 @@ export const listAnnotationQueuesForApi = async ({
   projectId,
   page,
   limit,
+  fromTimestamp,
+  toTimestamp,
 }: {
   projectId: string;
 } & GetAnnotationQueuesInput) => {
+  const where = {
+    projectId,
+    ...(fromTimestamp || toTimestamp
+      ? {
+          createdAt: {
+            ...(fromTimestamp ? { gte: fromTimestamp } : {}),
+            ...(toTimestamp ? { lt: toTimestamp } : {}),
+          },
+        }
+      : {}),
+  };
+
   const [queues, totalItems] = await Promise.all([
     prisma.annotationQueue.findMany({
-      where: {
-        projectId,
-      },
+      where,
       orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       take: limit,
       skip: (page - 1) * limit,
     }),
     prisma.annotationQueue.count({
-      where: {
-        projectId,
-      },
+      where,
     }),
   ]);
 

--- a/web/src/features/public-api/types/annotation-queues.ts
+++ b/web/src/features/public-api/types/annotation-queues.ts
@@ -45,6 +45,8 @@ export type AnnotationQueue = z.infer<typeof AnnotationQueueSchema>;
 export const GetAnnotationQueuesQuery = z
   .object({
     ...publicApiPaginationZod,
+    fromTimestamp: z.coerce.date().nullish(),
+    toTimestamp: z.coerce.date().nullish(),
   })
   .strict();
 

--- a/web/src/features/public-api/types/score-configs.ts
+++ b/web/src/features/public-api/types/score-configs.ts
@@ -150,6 +150,8 @@ export const PutScoreConfigResponse = APIScoreConfig;
 // GET /score-configs
 export const GetScoreConfigsQuery = z.object({
   ...publicApiPaginationZod,
+  fromTimestamp: z.coerce.date().nullish(),
+  toTimestamp: z.coerce.date().nullish(),
 });
 
 export const GetScoreConfigsResponse = z.object({

--- a/web/src/pages/api/public/annotation-queues/index.ts
+++ b/web/src/pages/api/public/annotation-queues/index.ts
@@ -22,6 +22,8 @@ export default withMiddlewares({
         projectId: auth.scope.projectId,
         page: query.page,
         limit: query.limit,
+        fromTimestamp: query.fromTimestamp,
+        toTimestamp: query.toTimestamp,
       }),
   }),
 

--- a/web/src/pages/api/public/score-configs/index.ts
+++ b/web/src/pages/api/public/score-configs/index.ts
@@ -28,11 +28,13 @@ export default withMiddlewares({
     querySchema: GetScoreConfigsQuery,
     responseSchema: GetScoreConfigsResponse,
     fn: async ({ query, auth }) => {
-      const { page, limit } = query;
+      const { page, limit, fromTimestamp, toTimestamp } = query;
       return await listScoreConfigs({
         projectId: auth.scope.projectId,
         page,
         limit,
+        fromTimestamp,
+        toTimestamp,
       });
     },
   }),


### PR DESCRIPTION
### Summary
This PR adds optional `fromTimestamp` and `toTimestamp` ISO-8601 query parameters to `GET /api/public/score-configs` (Fixes #17099) and `GET /api/public/annotation-queues` (Fixes #17089).

Previously, both endpoints only supported pagination (`page`, `limit`), returning the full project history with each scan. Consumers auditing recent score configurations or annotation queue changes can now narrow queries to a half-open `[fromTimestamp, toTimestamp)` time window on `createdAt`.

### Changes
- **`web/src/features/public-api/types/score-configs.ts`**: Added optional `fromTimestamp` and `toTimestamp` fields (`z.coerce.date().nullish()`) to `GetScoreConfigsQuery`.
- **`packages/shared/src/server/repositories/score-configs.ts`**: Updated `listScoreConfigs` to accept `fromTimestamp` and `toTimestamp` and apply Prisma `where.createdAt` filters to both data and count queries.
- **`web/src/pages/api/public/score-configs/index.ts`**: Passed `fromTimestamp` and `toTimestamp` from the route query into `listScoreConfigs`.
- **`fern/apis/server/definition/score-configs.yml`**: Documented `fromTimestamp` and `toTimestamp` query parameters in the Fern OpenAPI specification.
- **`web/src/features/public-api/types/annotation-queues.ts`**: Added optional `fromTimestamp` and `toTimestamp` fields (`z.coerce.date().nullish()`) to `GetAnnotationQueuesQuery`.
- **`web/src/features/annotation-queues/server/publicAnnotationQueueService.ts`**: Updated `listAnnotationQueuesForApi` to filter by `createdAt` range in Prisma queries.
- **`web/src/pages/api/public/annotation-queues/index.ts`**: Passed `fromTimestamp` and `toTimestamp` to `listAnnotationQueuesForApi`.
- **`fern/apis/server/definition/annotation-queues.yml`**: Documented `fromTimestamp` and `toTimestamp` in the Fern definition.
- **`web/src/__tests__/server/score-configs.servertest.ts`**: Added test case validating `fromTimestamp` and `toTimestamp` filtering.
- **`web/src/__tests__/server/annotation-queues-api.servertest.ts`**: Added test case validating time-window filtering on annotation queues.

### Verification
- Verified query parameters validate against ISO-8601 strings and return 400 on malformed input.
- Verified Prisma query generation with half-open date interval `[fromTimestamp, toTimestamp)`.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds half-open `createdAt` range filtering to the public score-config and annotation-queue list endpoints and updates their Fern definitions and server tests.

- Both intended REST paths apply the same filter to page results and total counts.
- The annotation-queue Fern change also advertises unsupported filters on the queue-items endpoint.
- Reusing the expanded schemas exposes timestamp inputs to MCP handlers that currently discard them.
- Query validation is more permissive than the documented ISO-8601 contract.
- The annotation server-test suite is prematurely closed, and the added filter tests need stronger boundary fixtures.
</details>


<details><summary><h3>Confidence Score: 1/5</h3></summary>

The PR is not safe to merge until the broken annotation test-suite structure and the public/MCP contract mismatches are corrected.

The intended database filtering is sound, but an extra suite closure breaks existing tests, Fern advertises unsupported queue-item parameters, the new schemas accept dates outside the documented ISO contract, and MCP callers receive unfiltered results for accepted timestamp inputs.

**Files Needing Attention:** web/src/__tests__/server/annotation-queues-api.servertest.ts, fern/apis/server/definition/annotation-queues.yml, web/src/features/public-api/types/annotation-queues.ts, web/src/features/public-api/types/score-configs.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Client[REST client] --> Schema[Public query schema]
  Schema --> Route[REST route]
  Route --> Service[Repository/service]
  Service --> DB[(Prisma)]
  MCP[MCP client] --> Schema
  Schema --> MCPHandler[MCP handler]
  MCPHandler -. timestamps currently omitted .-> Service
  Fern[Fern queue-items contract] -. parameters rejected by runtime schema .-> QueueItems[Queue-items route]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/annotation-queues-api.servertest.ts:203
**Suite Closes Too Early**

The added closure ends the outer `Annotation Queues API Endpoints` suite before the remaining endpoint suites. Those suites consequently lose access to `auth`, `projectId`, and the helper functions declared inside the outer callback, causing unresolved identifiers or missing test setup and breaking this server-test file.

### Issue 2
fern/apis/server/definition/annotation-queues.yml:68-73
**Unsupported Queue Item Filters**

These parameters are added to the documented `listQueueItems` operation, but that endpoint's strict runtime query schema does not accept them and its service has no timestamp filter. SDK users following this contract will send documented parameters and receive a 400 response. Remove the parameters from this operation or implement them throughout its runtime path.

### Issue 3
web/src/features/public-api/types/annotation-queues.ts:48-49
**Non-ISO Dates Are Accepted**

`z.coerce.date()` accepts JavaScript-coercible, non-ISO strings such as `2024/01/01`, despite both new parameters being documented as ISO-8601 datetimes. Because this schema is the only query-validation gate, such requests succeed instead of returning the expected 400. The score-config query schema uses the same permissive validation. Use the repository's strict `stringDateTime` or `z.iso.datetime({ offset: true })` validation before converting values for Prisma.

### Issue 4
web/src/features/public-api/types/score-configs.ts:153-154
**MCP Filters Are Ignored**

Extending these shared query schemas also exposes the timestamp fields through the score-config and annotation-queue MCP list tools, but both handlers forward only `page` and `limit`. MCP callers can therefore provide accepted timestamp inputs while receiving unfiltered results. Forward both fields in the MCP handlers or decouple their input schemas.

### Issue 5
web/src/__tests__/server/annotation-queues-api.servertest.ts:184-197
**Filter Test Cannot Fail**

This test creates every queue immediately before querying a window that spans one hour before and after the current time, so all fixtures are in range. It also permits an empty response. The test therefore passes both when filtering is ignored and when every record is incorrectly excluded, leaving the new behavior without useful regression protection. Create deterministic records on both sides of the bounds and assert the exact returned IDs and count.

### Issue 6
web/src/__tests__/server/score-configs.servertest.ts:811-829
**Upper Bound Remains Untested**

The fixtures include records before the lower bound but none at or beyond the upper bound, so this test verifies only `fromTimestamp`. An implementation that completely ignores `toTimestamp` would still pass, leaving that boundary without regression coverage. Add a fixture at or after `to` and assert the exact filtered IDs and `meta.totalItems`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add ?fromTimestamp and..."](https://github.com/langfuse/langfuse/commit/288c288b8a92f8fc6fab4d31e41a03cb1863fa72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60750953)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->