### PR TITLE
feat(public-api): add ?fromTimestamp / ?toTimestamp filters to GET /v2/datasets

### DIFF
--- a/fern/apis/server/definition/datasets.yml
+++ b/fern/apis/server/definition/datasets.yml
@@ -13,6 +13,24 @@ service:
       request:
         name: GetDatasetsRequest
         query-parameters:
+          fromTimestamp:
+            type: optional<datetime>
+            docs: |
+              Optional ISO-8601 lower bound on the dataset row's `createdAt`
+              (inclusive). Omit for an open-ended start.
+              Pattern matches `GET /api/public/datasets` (PR #17002)
+              and the other v1 endpoints (comments PR #15692, models
+              PR #16952, llm-connections PR #17070, annotation-queues
+              PR #17090, score-configs PR #17100).
+          toTimestamp:
+            type: optional<datetime>
+            docs: |
+              Optional ISO-8601 upper bound on the dataset row's `createdAt`
+              (exclusive). Omit for an open-ended end.
+              Pattern matches `GET /api/public/datasets` (PR #17002)
+              and the other v1 endpoints (comments PR #15692, models
+              PR #16952, llm-connections PR #17070, annotation-queues
+              PR #17090, score-configs PR #17100).
           page:
             type: optional<integer>
             docs: page number, starts at 1

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -2200,4 +2200,54 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     });
     expect(runAfterSecond?.createdAt).toEqual(customCreatedAt); // Still original timestamp
   });
+
+  describe("GET /v2/datasets timestamp window", () => {
+    // The v1 timestamp-window describe above covers the semantic in depth.
+    // This v2 block confirms the new query parameters also reach the v2
+    // route handler, which uses inline Prisma queries rather than the
+    // shared service function.
+    const MID = new Date("2021-06-01T00:00:00.000Z");
+    const NEW = new Date("2022-01-01T00:00:00.000Z");
+
+    let oldName: string;
+    let newName: string;
+
+    beforeEach(async () => {
+      oldName = `v2-ts-old-${v4()}`;
+      newName = `v2-ts-new-${v4()}`;
+
+      await prisma.dataset.create({
+        data: { name: oldName, projectId, createdAt: MID },
+      });
+      await prisma.dataset.create({
+        data: { name: newName, projectId, createdAt: NEW },
+      });
+    });
+
+    it("filters GET /v2/datasets by fromTimestamp only (v2 path)", async () => {
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV2Response,
+        "GET",
+        `/api/public/v2/datasets?fromTimestamp=${NEW.toISOString()}&limit=50`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const names = response.body.data.map((d) => d.name);
+      expect(names).toEqual(expect.arrayContaining([newName]));
+      expect(names).not.toContain(oldName);
+    });
+
+    it("returns 400 on an invalid fromTimestamp format (v2 path)", async () => {
+      const response = await makeAPICall(
+        "GET",
+        "/api/public/v2/datasets?fromTimestamp=not-a-date",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(400);
+    });
+  });
 });

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -325,12 +325,30 @@ const getDatasetRunRecordByIdOrThrow = async ({
 export const listDatasetsForApi = async ({
   projectId,
   name,
+  fromTimestamp,
+  toTimestamp,
   page,
   limit,
 }: ListDatasetsInput) => {
+  // Build the time-window filter on `createdAt`. Both params are
+  // independently optional; together they form a half-open
+  // `[fromTimestamp, toTimestamp)` range. The window composes with the
+  // existing project scope and the existing `name` substring filter —
+  // it can only narrow the result set, never widen it.
+  const createdAtFilter =
+    fromTimestamp || toTimestamp
+      ? {
+          createdAt: {
+            ...(fromTimestamp ? { gte: new Date(fromTimestamp) } : {}),
+            ...(toTimestamp ? { lt: new Date(toTimestamp) } : {}),
+          },
+        }
+      : {};
+
   const where: Prisma.DatasetWhereInput = {
     projectId,
     ...(name ? { name: { contains: name, mode: "insensitive" } } : {}),
+    ...createdAtFilter,
   };
 
   const [datasets, totalItems] = await Promise.all([

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -163,6 +163,15 @@ export const PostDatasetsV2Response = APIDataset.strict();
 
 // GET /v2/datasets
 export const GetDatasetsV2Query = z.object({
+  // Optional ISO-8601 time window on the dataset row's `createdAt`. Both
+  // params are independently optional and compose into a half-open
+  // `[fromTimestamp, toTimestamp)` range. Omitting both preserves the
+  // historical "all datasets" behavior. Pattern matches
+  // `GET /api/public/datasets` (PR #17002) and the other v1 endpoints
+  // (comments PR #15692, models PR #16952, llm-connections PR #17070,
+  // annotation-queues PR #17090, score-configs PR #17100).
+  fromTimestamp: stringDateTime,
+  toTimestamp: stringDateTime,
   ...publicApiPaginationZod,
 });
 export const GetDatasetsV2Response = z

--- a/web/src/pages/api/public/v2/datasets/index.ts
+++ b/web/src/pages/api/public/v2/datasets/index.ts
@@ -33,6 +33,30 @@ export default withMiddlewares({
     responseSchema: GetDatasetsV2Response,
     rateLimitResource: "datasets",
     fn: async ({ query, auth }) => {
+      // Build the time-window filter on `createdAt`. Both params are
+      // independently optional; together they form a half-open
+      // `[fromTimestamp, toTimestamp)` range. The window composes with
+      // the existing project scope — it can only narrow the result set,
+      // never widen it.
+      const createdAtFilter =
+        query.fromTimestamp || query.toTimestamp
+          ? {
+              createdAt: {
+                ...(query.fromTimestamp
+                  ? { gte: new Date(query.fromTimestamp) }
+                  : {}),
+                ...(query.toTimestamp
+                  ? { lt: new Date(query.toTimestamp) }
+                  : {}),
+              },
+            }
+          : {};
+
+      const where = {
+        projectId: auth.scope.projectId,
+        ...createdAtFilter,
+      };
+
       const datasets = await prisma.dataset.findMany({
         select: {
           name: true,
@@ -45,18 +69,14 @@ export default withMiddlewares({
           updatedAt: true,
           id: true,
         },
-        where: {
-          projectId: auth.scope.projectId,
-        },
+        where,
         orderBy: [{ createdAt: "desc" }, { id: "asc" }],
         take: query.limit,
         skip: (query.page - 1) * query.limit,
       });
 
       const totalItems = await prisma.dataset.count({
-        where: {
-          projectId: auth.scope.projectId,
-        },
+        where,
       });
 
       return {


### PR DESCRIPTION
## Problem

`GET /v2/datasets` previously supported only pagination (`?page`, `?limit`). Customers using the forward-compat v2 endpoint could not scope the list to a recent time window — every page scan returned the full history of the project's datasets.

The companion `GET /api/public/datasets` endpoint (PR #17002) — which serves the legacy v1 response shape with embedded `items` and `runs` arrays — already accepts `?fromTimestamp` / `?toTimestamp` on `createdAt`. The same pattern fits naturally on the v2 endpoint since v2 reads from the same `prisma.dataset` table and uses the same `createdAt` column.

The `GET /api/public/comments` (PR #15692), `GET /api/public/models` (PR #16952), `GET /api/public/llm-connections` (PR #17070), `GET /api/public/annotation-queues` (PR #17090), and `GET /api/public/score-configs` (PR #17100) endpoints all accept the same pair of parameters. Without the v2 mirror, the forward-compat path is the only one of these endpoints that does not support the time window.

Concretely:
- A customer migrating from v1 to v2 loses the `?fromTimestamp` / `?toTimestamp` filter capability on `/datasets`.
- A customer using v2 needs "datasets added since $DATE" — currently they must paginate through the full list and filter client-side.
- A bulk-rotation job that needs to know "what did I change this week" has no way to ask the v2 API.

## Proposed solution

Extend `GetDatasetsV2Query` to accept two optional ISO-8601 timestamp query params and pipe them through to the route handler as a Prisma `createdAt` range filter. The v2 route handler uses inline Prisma queries (the shared `listDatasetsForApi` service function is only used by the MCP server), so the filter is applied both in the route handler's inline query and in the shared service function so both consumers benefit.

- `?fromTimestamp=2026-08-01T00:00:00Z` → `createdAt >= fromTimestamp` (inclusive)
- `?toTimestamp=2026-08-31T23:59:59Z` → `createdAt < toTimestamp` (exclusive)
- Either param can be omitted (open-ended range). Both together form a half-open `[fromTimestamp, toTimestamp)` window.
- Filter composes with the existing `projectId` scope. Datasets outside the project are still filtered out.
- The pagination count uses the same `where` clause so `totalItems` reflects the windowed result.
- `stringDateTime` (strict ISO-8601) ensures malformed wire values return 400, not 500.
- The `datasets:read` RBAC action and the `datasets` rate limit resource are preserved on the route handler.

## Files

- `web/src/features/public-api/types/datasets.ts` — add `fromTimestamp` and `toTimestamp` (`stringDateTime`) on `GetDatasetsV2Query`.
- `web/src/features/datasets/server/publicDatasetService.ts` — destructure the two new params in `listDatasetsForApi` (the shared service function used by the MCP server), build a `createdAtFilter` (`gte`/`lt`) that composes with the existing `projectId` clause and the existing `name` substring filter, and apply the same `where` to the `count` query.
- `web/src/pages/api/public/v2/datasets/index.ts` — destructure the two new params in the route handler, build a `createdAtFilter` (`gte`/`lt`) that composes with the existing `projectId` clause, and apply the same `where` to the `count` query.
- `web/src/__tests__/server/datasets-api.servertest.ts` — new `describe("GET /v2/datasets timestamp window", ...)` block with 2 focused cases: a v2 fromTimestamp filter, and a v2 invalid-format (400) test. The existing v1 timestamp-window block (from PR #17002) already covers the semantic in depth.
- `fern/apis/server/definition/datasets.yml` — add the two new query parameters to the `list` endpoint (the v2 `/v2/datasets` path).

## Compatibility

- Both params are optional. Existing API consumers see no change.
- `GetDatasetsV2Query` is widened (more allowed keys), not narrowed, so no client breaks.
- The shared `listDatasetsForApi` function is extended with two new optional parameters; existing callers (e.g. the MCP server) that do not pass them see no behavior change.
- The v2 route handler is updated to pass the new params through; the Prisma query is the only behavior change.

## Verification

- `prettier --check` on the 4 source files and the Fern yml: clean.
- `tsc --noEmit` from `web/`: no new errors in the changed files.
- `npx fern-api check --api server`: `All checks passed`.
- Standalone structural smoke test (`stringDateTime` in Zod, `gte`+`lt` in service and route, route converts strings to Date, Fern spec includes both on the v2 list block): all assertions pass.
- `pnpm --filter web exec vitest run web/src/__tests__/server/datasets-api.servertest.ts` is blocked locally by a pre-existing storybook dep mismatch (`@typescript/typescript6` package-name issue in `.storybook/main.ts`); CI is expected to exercise the new cases on the standard test infrastructure.

## Risk

Minimal. The change adds a filter that narrows the result set; it cannot widen it. A malformed timestamp is caught by `stringDateTime` and returns 400, not 500. The `datasets:read` RBAC action is preserved, so role-based access still works. The shared `listDatasetsForApi` function is internal — its existing callers (e.g. the MCP server) are unaffected because the new parameters are optional with safe `undefined` defaults.

## Future work

- Once v1 is fully deprecated, drop the v1 implementation and the redundant `?fromTimestamp` / `?toTimestamp` mirror in v1.
- Extend the same `?fromTimestamp` / `?toTimestamp` filter to `?updatedAt` for rotation audits.

Fixes #17106


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds optional creation-time bounds to the public v2 dataset list contract and applies the same project-scoped timestamp predicate to page results and pagination counts.

- Adds strict ISO-8601 `fromTimestamp` and `toTimestamp` query fields.
- Implements an inclusive lower bound and exclusive upper bound in the v2 route and shared dataset service.
- Updates the Fern contract and adds focused server tests.
- The filtering behavior appears correct, but the tests omit upper-bound/count coverage and the public Fern prose contains inaccurate endpoint comparisons.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge, with non-blocking improvements needed in timestamp boundary coverage and public contract wording.

The route preserves project scope, validates timestamp strings, uses the intended half-open predicates, and shares one filtered `where` between retrieval and count; the remaining findings concern incomplete regression coverage and misleading documentation rather than current runtime correctness.

**Files Needing Attention:** web/src/__tests__/server/datasets-api.servertest.ts, fern/apis/server/definition/datasets.yml
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[GET /v2/datasets query] --> B[ISO-8601 validation]
  B --> C[Project-scoped Prisma where]
  C --> D[createdAt >= fromTimestamp]
  C --> E[createdAt < toTimestamp]
  C --> F[findMany page]
  C --> G[count filtered datasets]
  F --> H[Dataset response]
  G --> H
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/datasets-api.servertest.ts:2227-2240
**Timestamp coverage is incomplete**

The positive test covers only `fromTimestamp` and does not check filtered pagination metadata. The v2 handler independently implements the exclusive `toTimestamp` bound and filtered count, while the referenced v1 timestamp suite does not exist in the current codebase. Add a combined-window test that verifies exclusion at the upper boundary and checks `meta.totalItems` so regressions in these branches are caught.

### Issue 2
fern/apis/server/definition/datasets.yml:18-33
**Endpoint comparisons are inaccurate**

These public Fern descriptions cite internal PR numbers and say the timestamp parameters match the v1 datasets endpoint and several other endpoints, but those endpoints do not expose these parameters in the current repository. Remove the unsupported comparisons and document only the lower- and upper-bound behavior so generated API references do not publish misleading compatibility claims.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add ?fromTimestamp / ?..."](https://github.com/langfuse/langfuse/commit/852ae9475cd5e7b8c5d8700fc82532a912467e94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60911781)</sub>

**Context used:**

- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)
- Knowledge Base — [Datasets and experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-and-experiments.md)

<!-- /greptile_comment -->