### PR TITLE
feat(public-api): add ?fromTimestamp / ?toTimestamp filters to GET /v2/datasets

### DIFF
--- a/fern/apis/server/definition/datasets.yml
+++ b/fern/apis/server/definition/datasets.yml
@@ -19,6 +19,12 @@ service:
           limit:
             type: optional<integer>
             docs: limit of items per page
+          fromTimestamp:
+            type: optional<datetime>
+            docs: Optional filter to only include datasets created on or after this timestamp.
+          toTimestamp:
+            type: optional<datetime>
+            docs: Optional filter to only include datasets created before this timestamp.
       response: PaginatedDatasets
     get:
       method: GET

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -2200,4 +2200,83 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     });
     expect(runAfterSecond?.createdAt).toEqual(customCreatedAt); // Still original timestamp
   });
+
+  it("should filter GET /api/public/v2/datasets by fromTimestamp and toTimestamp", async () => {
+    const prefix = `v2-filter-test-${v4()}`;
+    const d1 = await prisma.dataset.create({
+      data: {
+        id: v4(),
+        name: `${prefix}-1`,
+        projectId,
+        createdAt: new Date("2026-08-10T00:00:00.000Z"),
+      },
+    });
+    const d2 = await prisma.dataset.create({
+      data: {
+        id: v4(),
+        name: `${prefix}-2`,
+        projectId,
+        createdAt: new Date("2026-08-20T00:00:00.000Z"),
+      },
+    });
+    const d3 = await prisma.dataset.create({
+      data: {
+        id: v4(),
+        name: `${prefix}-3`,
+        projectId,
+        createdAt: new Date("2026-08-30T00:00:00.000Z"),
+      },
+    });
+
+    // 1. fromTimestamp filter
+    const fromRes = await makeZodVerifiedAPICall(
+      GetDatasetsV2Response,
+      "GET",
+      `/api/public/v2/datasets?fromTimestamp=2026-08-20T00:00:00.000Z`,
+      undefined,
+      auth,
+    );
+    expect(fromRes.status).toBe(200);
+    const fromNames = fromRes.body.data.map((d) => d.name);
+    expect(fromNames).toContain(`${prefix}-2`);
+    expect(fromNames).toContain(`${prefix}-3`);
+    expect(fromNames).not.toContain(`${prefix}-1`);
+
+    // 2. toTimestamp filter (exclusive)
+    const toRes = await makeZodVerifiedAPICall(
+      GetDatasetsV2Response,
+      "GET",
+      `/api/public/v2/datasets?toTimestamp=2026-08-20T00:00:00.000Z`,
+      undefined,
+      auth,
+    );
+    expect(toRes.status).toBe(200);
+    const toNames = toRes.body.data.map((d) => d.name);
+    expect(toNames).toContain(`${prefix}-1`);
+    expect(toNames).not.toContain(`${prefix}-2`);
+    expect(toNames).not.toContain(`${prefix}-3`);
+
+    // 3. half-open interval [fromTimestamp, toTimestamp)
+    const rangeRes = await makeZodVerifiedAPICall(
+      GetDatasetsV2Response,
+      "GET",
+      `/api/public/v2/datasets?fromTimestamp=2026-08-15T00:00:00.000Z&toTimestamp=2026-08-25T00:00:00.000Z`,
+      undefined,
+      auth,
+    );
+    expect(rangeRes.status).toBe(200);
+    const rangeNames = rangeRes.body.data.map((d) => d.name);
+    expect(rangeNames).toContain(`${prefix}-2`);
+    expect(rangeNames).not.toContain(`${prefix}-1`);
+    expect(rangeNames).not.toContain(`${prefix}-3`);
+
+    // 4. Invalid timestamp returns 400
+    const invalidRes = await makeAPICall(
+      "GET",
+      "/api/public/v2/datasets?fromTimestamp=invalid-date",
+      undefined,
+      auth,
+    );
+    expect(invalidRes.status).toBe(400);
+  });
 });

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -327,10 +327,20 @@ export const listDatasetsForApi = async ({
   name,
   page,
   limit,
+  fromTimestamp,
+  toTimestamp,
 }: ListDatasetsInput) => {
   const where: Prisma.DatasetWhereInput = {
     projectId,
     ...(name ? { name: { contains: name, mode: "insensitive" } } : {}),
+    ...(fromTimestamp || toTimestamp
+      ? {
+          createdAt: {
+            ...(fromTimestamp ? { gte: new Date(fromTimestamp) } : {}),
+            ...(toTimestamp ? { lt: new Date(toTimestamp) } : {}),
+          },
+        }
+      : {}),
   };
 
   const [datasets, totalItems] = await Promise.all([

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -164,6 +164,8 @@ export const PostDatasetsV2Response = APIDataset.strict();
 // GET /v2/datasets
 export const GetDatasetsV2Query = z.object({
   ...publicApiPaginationZod,
+  fromTimestamp: stringDateTime.nullish(),
+  toTimestamp: stringDateTime.nullish(),
 });
 export const GetDatasetsV2Response = z
   .object({

--- a/web/src/pages/api/public/v2/datasets/index.ts
+++ b/web/src/pages/api/public/v2/datasets/index.ts
@@ -33,41 +33,10 @@ export default withMiddlewares({
     responseSchema: GetDatasetsV2Response,
     rateLimitResource: "datasets",
     fn: async ({ query, auth }) => {
-      const datasets = await prisma.dataset.findMany({
-        select: {
-          name: true,
-          description: true,
-          metadata: true,
-          inputSchema: true,
-          expectedOutputSchema: true,
-          projectId: true,
-          createdAt: true,
-          updatedAt: true,
-          id: true,
-        },
-        where: {
-          projectId: auth.scope.projectId,
-        },
-        orderBy: [{ createdAt: "desc" }, { id: "asc" }],
-        take: query.limit,
-        skip: (query.page - 1) * query.limit,
+      return await listDatasetsForApi({
+        ...query,
+        projectId: auth.scope.projectId,
       });
-
-      const totalItems = await prisma.dataset.count({
-        where: {
-          projectId: auth.scope.projectId,
-        },
-      });
-
-      return {
-        data: datasets,
-        meta: {
-          page: query.page,
-          limit: query.limit,
-          totalItems,
-          totalPages: Math.ceil(totalItems / query.limit),
-        },
-      };
     },
   }),
 });


### PR DESCRIPTION
## Problem
Customers using the \GET /v2/datasets\ endpoint could not filter the dataset collection to a recent time window, requiring full-history scans and client-side filtering.

This PR adds \?fromTimestamp\ and \?toTimestamp\ query filters to \GET /v2/datasets\, matching the standard timestamp-filtering interface established across the public API.

## Changes
- **\web/src/features/public-api/types/datasets.ts\**: Added \romTimestamp\ and \	oTimestamp\ as optional \stringDateTime\ fields to \GetDatasetsV2Query\.
- **\web/src/features/datasets/server/publicDatasetService.ts\**: Piped \romTimestamp\ and \	oTimestamp\ to Prisma \where.createdAt\ in \listDatasetsForApi\ and the corresponding count query.
- **\web/src/pages/api/public/v2/datasets/index.ts\**: Routed GET endpoint to \listDatasetsForApi\ with the validated query.
- **\ern/apis/server/definition/datasets.yml\**: Updated Fern API definition with the two optional timestamp parameters.
- **\web/src/__tests__/server/datasets-api.servertest.ts\**: Added comprehensive integration test coverage for \romTimestamp\, \	oTimestamp\, and half-open interval \[fromTimestamp, toTimestamp)\.

Closes #17106

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds creation-time filtering to the public v2 dataset-list endpoint.
- Adds optional `fromTimestamp` and `toTimestamp` parameters to the runtime and Fern API schemas.
- Applies inclusive lower and exclusive upper bounds to both dataset retrieval and counting.
- Reuses the shared dataset-list service without changing existing pagination, ordering, or response behavior.
- Adds integration coverage for individual bounds, half-open ranges, and invalid timestamps.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the timestamp contract consistently implemented and tested across the API schema, route, and database queries.

No actionable failures remain; both retrieval and pagination counts use the same project-scoped half-open timestamp range, while existing selection, ordering, pagination, and response behavior are preserved.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add ?fromTimestamp / ?..."](https://github.com/langfuse/langfuse/commit/2269c1744c928df5ef05703e63b01e58ee48b39c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60962121)</sub>

<!-- /greptile_comment -->