### PR TITLE
fix(otel): normalize official cache-write token usage

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -3065,6 +3065,7 @@ export class OtelIngestionProcessor {
       rawUsageDetails["input_cached_tokens"];
     const cacheCreationTokens =
       rawUsageDetails["cache_creation.input_tokens"] ??
+      rawUsageDetails["cache_write.input_tokens"] ??
       rawUsageDetails["cache_creation_input_tokens"] ??
       rawUsageDetails["cache_write_tokens"] ??
       rawUsageDetails["details.cache_write_tokens"] ??
@@ -3098,6 +3099,7 @@ export class OtelIngestionProcessor {
             "prompt_details.cache_read",
             "input_cached_tokens",
             "cache_creation.input_tokens",
+            "cache_write.input_tokens",
             "cache_creation_input_tokens",
             "cache_write_tokens",
             "details.cache_write_tokens",

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -8109,6 +8109,106 @@ describe("OTel Resource Span Mapping", () => {
       expect(usageDetails.output_reasoning_tokens).toBe(25);
       expect(usageDetails["reasoning.output_tokens"]).toBeUndefined();
     });
+    it.each<{
+      name: string;
+      aliases: Record<string, number>;
+      expectedCacheCreation: number;
+    }>([
+      {
+        name: "official cache-write attribute",
+        aliases: { "cache_write.input_tokens": 25 },
+        expectedCacheCreation: 25,
+      },
+      {
+        name: "existing dotted creation alias takes precedence",
+        aliases: {
+          "cache_creation.input_tokens": 7,
+          "cache_write.input_tokens": 25,
+        },
+        expectedCacheCreation: 7,
+      },
+      {
+        name: "zero in the existing dotted creation alias takes precedence",
+        aliases: {
+          "cache_creation.input_tokens": 0,
+          "cache_write.input_tokens": 25,
+        },
+        expectedCacheCreation: 0,
+      },
+      {
+        name: "zero in the official write alias takes precedence over flat creation",
+        aliases: {
+          "cache_write.input_tokens": 0,
+          cache_creation_input_tokens: 25,
+        },
+        expectedCacheCreation: 0,
+      },
+    ])(
+      "should normalize cache-write usage: $name",
+      async ({ aliases, expectedCacheCreation }) => {
+        const resourceSpan: ResourceSpan = {
+          resource: { attributes: [] },
+          scopeSpans: [
+            {
+              scope: { name: "test-genai" },
+              spans: [
+                {
+                  traceId: Buffer.from(
+                    "abcdef1234567890abcdef1234567890",
+                    "hex",
+                  ),
+                  spanId: Buffer.from("1234567890abcdef", "hex"),
+                  name: "cache-write-usage",
+                  kind: 1,
+                  startTimeUnixNano: {
+                    low: 1000000,
+                    high: 406528574,
+                  },
+                  endTimeUnixNano: {
+                    low: 2000000,
+                    high: 406528574,
+                  },
+                  attributes: Object.entries({
+                    input_tokens: 300,
+                    "cache_read.input_tokens": 40,
+                    ...aliases,
+                  }).map(([key, count]) => ({
+                    key: `gen_ai.usage.${key}`,
+                    value: {
+                      intValue: { low: count, high: 0, unsigned: false },
+                    },
+                  })),
+                  status: {},
+                },
+              ],
+            },
+          ],
+        };
+
+        const events = await convertOtelSpanToIngestionEvent(
+          resourceSpan,
+          new Set(),
+        );
+        const observation = events.find(
+          (event) =>
+            event.type === "generation-create" || event.type === "span-create",
+        );
+
+        expect(observation).toBeDefined();
+        const usageDetails = observation!.body.usageDetails;
+        expect(usageDetails).toEqual({
+          input: 300 - 40 - expectedCacheCreation,
+          input_cached_tokens: 40,
+          input_cache_creation: expectedCacheCreation,
+        });
+        expect(
+          Object.entries(usageDetails)
+            .filter(([key]) => key.toLowerCase().includes("input"))
+            .reduce((sum, [, value]) => sum + (value ?? 0), 0),
+        ).toBe(300);
+      },
+    );
+
     it("should normalize raw Anthropic cache_read_input_tokens / cache_creation_input_tokens into Langfuse canonical keys", async () => {
       // flat Anthropic cache spellings must map to cache aliases, not opaque passthrough buckets
       const traceId = "abcdef1234567890abcdef1234567893";

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -4,7 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Price } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
-import { createOrgProjectAndApiKey, logger } from "@langfuse/shared/src/server";
+import {
+  createOrgProjectAndApiKey,
+  logger,
+  OtelIngestionProcessor,
+  type ResourceSpan,
+} from "@langfuse/shared/src/server";
 
 import { IngestionService } from "../../IngestionService";
 import * as clickhouseWriteExports from "../../ClickhouseWriter";
@@ -78,6 +83,68 @@ const mockIngestionService = new IngestionService(
   clickhouseWriteExports.ClickhouseWriter.getInstance() as any,
   mockClickhouseClient as any,
 );
+
+describe("OTel cache-write pricing", () => {
+  it("prices official cache-write tokens after event normalization", () => {
+    const resourceSpan: ResourceSpan = {
+      resource: { attributes: [] },
+      scopeSpans: [
+        {
+          scope: { name: "test-genai" },
+          spans: [
+            {
+              traceId: Buffer.from("abcdef1234567890abcdef1234567890", "hex"),
+              spanId: Buffer.from("1234567890abcdef", "hex"),
+              name: "cache-write-pricing",
+              kind: 1,
+              startTimeUnixNano: {
+                low: 1000000,
+                high: 406528574,
+              },
+              endTimeUnixNano: {
+                low: 2000000,
+                high: 406528574,
+              },
+              attributes: Object.entries({
+                input_tokens: 300,
+                "cache_read.input_tokens": 40,
+                "cache_write.input_tokens": 25,
+              }).map(([key, count]) => ({
+                key: `gen_ai.usage.${key}`,
+                value: { intValue: { low: count, high: 0, unsigned: false } },
+              })),
+              status: {},
+            },
+          ],
+        },
+      ],
+    };
+    const processor = new OtelIngestionProcessor({
+      projectId: "test-project",
+      publicKey: "",
+      sdkName: "",
+      sdkVersion: "",
+    });
+    const events = processor.processToEvent([resourceSpan]);
+    expect(events).toHaveLength(1);
+
+    const costs = IngestionService.calculateUsageCosts(
+      [
+        { usageType: "input", price: new Decimal("0.01") },
+        { usageType: "input_cached_tokens", price: new Decimal("0.002") },
+        { usageType: "input_cache_creation", price: new Decimal("0.02") },
+      ],
+      { provided_cost_details: {} },
+      events[0].providedUsageDetails,
+    );
+
+    expect(costs.cost_details.input).toBe(2.35);
+    expect(costs.cost_details.input_cached_tokens).toBe(0.08);
+    expect(costs.cost_details.input_cache_creation).toBe(0.5);
+    expect(costs.cost_details.total).toBeCloseTo(2.93);
+    expect(costs.total_cost).toBeCloseTo(2.93);
+  });
+});
 
 describe("Token Cost Calculation", () => {
   let modelName: string;


### PR DESCRIPTION
## What does this PR do?

Fixes #17117.

Spans using `gen_ai.usage.cache_write.input_tokens` currently retain that attribute as an unrecognized usage bucket. Cache writes remain in the ordinary input count, inflate summed input usage, and miss the canonical cache-creation price.

Recognize this spelling in the existing cache-creation fallback chain and remove it from raw passthrough keys. Existing alias precedence and explicit zero values are preserved. For inclusive input 300, cache reads 40, and cache writes 25, normalized usage becomes `{input: 235, input_cached_tokens: 40, input_cache_creation: 25}`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Validation

Added four parameterized cases to the existing OTel mapping suite and one direct-event-to-pricing regression to the existing worker cost suite. All five failed before the production fix. Both complete files now pass:

- OTel mapping: `Tests 263 passed | 1 skipped (264)`. The skipped test predates this change.
- Worker cost calculation: `Tests 31 passed (31)`.
- Forced lint: `Tasks: 7 successful, 7 total`; `Cached: 0 cached, 7 total`.
- Typecheck: `Tasks: 8 successful, 8 total`; `Cached: 5 cached, 8 total`.
- `pnpm exec knip`: exit 0 (existing configuration hint).
- Changed-file Prettier check and `git diff --check`: passed.

The pricing regression feeds actual normalized event usage into the cost calculator, using synthetic prices. No API schema, default pricing, or storage migration changes. Full repository and live HTTP-to-storage tests were not run; validation covers both processor conversion paths and the actual pricing function.

## Mandatory Tasks

- [x] Self-reviewed and independently reviewed the code.

## Checklist

- [x] Read the contributing guide.
- [x] Added behavioral regression tests and confirmed pre-fix failures.
- [x] Checked formatting, lint, types, and unused code.
- [x] Checked documentation impact: no user-facing configuration or API contract changed.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR recognizes the official `gen_ai.usage.cache_write.input_tokens` OTel attribute as canonical cache-creation usage and prevents it from remaining as an opaque passthrough bucket.

- Preserves existing alias precedence and explicit-zero semantics.
- Subtracts cache-write usage from inclusive ordinary input usage.
- Adds mapping coverage for alias precedence and zero values.
- Adds an end-to-end normalization-to-pricing regression test.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the new alias follows the established normalization contract and is covered through mapping and pricing.

The official key reaches the shared normalization path under the expected spelling, both production conversion routes use that path, and no concrete correctness, security, or repository-rule failure remains.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A["gen_ai.usage.cache_write.input_tokens"] --> B["Strip gen_ai.usage prefix"]
  B --> C["cache_write.input_tokens"]
  C --> D["Cache-creation alias fallback"]
  D --> E["input_cache_creation"]
  F["Inclusive input tokens"] --> G["Subtract cache reads and cache writes"]
  E --> G
  G --> H["Canonical input usage"]
  E --> I["Cache-creation pricing"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): normalize official cache-writ..."](https://github.com/langfuse/langfuse/commit/34f703ad3c863cb5ef493d74f550a3a1514ea287) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61088118)</sub>

<!-- /greptile_comment -->