### PR TITLE
fix(dashboard): sort unique dimensions deterministically for consistent chart colors

### DIFF
--- a/web/src/features/widgets/chart-library/utils.clienttest.ts
+++ b/web/src/features/widgets/chart-library/utils.clienttest.ts
@@ -4,6 +4,7 @@ import {
   formatMetric,
   getDimensionSummaries,
   getEvenTickInterval,
+  getUniqueDimensions,
 } from "@/src/features/widgets/chart-library/utils";
 import { type DataPoint } from "@/src/features/widgets/chart-library/chart-props";
 
@@ -280,5 +281,34 @@ describe("getEvenTickInterval", () => {
   it("honors a custom max tick target", () => {
     expect(getEvenTickInterval(12, 6)).toBe(1);
     expect(getEvenTickInterval(6, 6)).toBe(0);
+  });
+});
+
+describe("getUniqueDimensions", () => {
+  it("returns unique dimensions in deterministic alphabetical order regardless of input order", () => {
+    const dataSet1: DataPoint[] = [
+      { time_dimension: "t1", dimension: "zebra", metric: 10 },
+      { time_dimension: "t1", dimension: "alpha", metric: 20 },
+      { time_dimension: "t2", dimension: "beta", metric: 30 },
+      { time_dimension: "t2", dimension: "alpha", metric: 15 },
+    ];
+
+    const dataSet2: DataPoint[] = [
+      { time_dimension: "t1", dimension: "beta", metric: 5 },
+      { time_dimension: "t1", dimension: "zebra", metric: 25 },
+      { time_dimension: "t2", dimension: "alpha", metric: 40 },
+    ];
+
+    expect(getUniqueDimensions(dataSet1)).toEqual(["alpha", "beta", "zebra"]);
+    expect(getUniqueDimensions(dataSet2)).toEqual(["alpha", "beta", "zebra"]);
+  });
+
+  it("ignores data points without a dimension", () => {
+    const data: DataPoint[] = [
+      { time_dimension: "t1", dimension: undefined, metric: 10 },
+      { time_dimension: "t2", dimension: "alpha", metric: 20 },
+    ];
+
+    expect(getUniqueDimensions(data)).toEqual(["alpha"]);
   });
 });

--- a/web/src/features/widgets/chart-library/utils.ts
+++ b/web/src/features/widgets/chart-library/utils.ts
@@ -56,7 +56,7 @@ export const getUniqueDimensions = (data: DataPoint[]) => {
       uniqueDimensions.add(item.dimension);
     }
   });
-  return Array.from(uniqueDimensions);
+  return Array.from(uniqueDimensions).sort((a, b) => a.localeCompare(b));
 };
 
 /**


### PR DESCRIPTION
## Summary
Fixes #15836 by deterministically sorting dimensions in `getUniqueDimensions`.

### Problem
In multi-series time-series dashboard charts (`LineChartTimeSeries`, `AreaChartTimeSeries`, `VerticalBarChartTimeSeries`), series colors are assigned based on the dimension's index in the unique dimensions array (`seriesColor(index)`). 

Because database queries return grouped rows in non-deterministic order, `getUniqueDimensions` previously collected dimensions into a `Set` in arrival order. As a result, the same tag or configuration could appear at different indices across different widgets on the same dashboard (or across subsequent query refreshes), causing it to be assigned different colors in each chart.

### Fix
- Updated `getUniqueDimensions` in `web/src/features/widgets/chart-library/utils.ts` to sort unique dimensions alphabetically (`Array.from(uniqueDimensions).sort((a, b) => a.localeCompare(b))`). This ensures all widgets displaying the same dimension set assign identical, consistent color slots to each series.
- Added client unit tests in `web/src/features/widgets/chart-library/utils.clienttest.ts` covering deterministic sorting regardless of data point encounter order, and ignoring points with missing dimensions.

### Verification
- `pnpm --filter web run test-client src/features/widgets/chart-library/utils.clienttest.ts` -> `Tests 21 passed (21)`
- `pnpm --filter web run test-client widgets` -> `Test Files 15 passed (15), Tests 402 passed (402)`
- `turbo run lint` -> `Tasks: 7 successful, 7 total`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR alphabetically sorts unique chart dimensions and adds unit coverage for reordered input and absent dimensions.
- Deterministic sorting removes dependence on database row arrival order.
- Positional color assignment remains unstable when independently queried widgets or refreshes contain overlapping but non-identical dimension sets.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge as the complete color-consistency fix because shared series can still change colors when widget or refresh dimension sets differ.

Chart colors remain tied to each label’s position within the current dimension set, so adding or removing an earlier label changes colors for otherwise unchanged series.

**Files Needing Attention:** web/src/features/widgets/chart-library/utils.ts, web/src/features/widgets/chart-library/utils.clienttest.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/widgets/chart-library/utils.ts:59
**Dimension sets still shift colors**

Sorting by label only stabilizes colors when every chart has exactly the same dimension set. If one independently filtered widget or refresh omits an alphabetically earlier dimension, each later shared dimension shifts index and receives a different `seriesColor`. For example, `zebra` uses chart color 3 in `[alpha, beta, zebra]` but chart color 2 in `[alpha, zebra]`, so colors remain inconsistent across widgets and refreshes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): sort unique dimensions d..."](https://github.com/langfuse/langfuse/commit/c406fcf188923a20f2ffd9043fb57af288540f4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61126163)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->