### PR TITLE
test(web): tolerate concurrent API key cache entries

### DIFF
--- a/web/src/__tests__/server/admin-api-keys.servertest.ts
+++ b/web/src/__tests__/server/admin-api-keys.servertest.ts
@@ -77,10 +77,12 @@ describe("Admin API keys route", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(res._getJSONData()).toEqual({
+    const responseBody = res._getJSONData();
+    expect(responseBody).toEqual({
       message: "All cached API keys invalidated",
-      invalidatedCount: 2,
+      invalidatedCount: expect.any(Number),
     });
+    expect(responseBody.invalidatedCount).toBeGreaterThanOrEqual(2);
     expect(await getRedisValue(redisClient, existingApiKeyCacheKey)).toBeNull();
     expect(await getRedisValue(redisClient, missingApiKeyCacheKey)).toBeNull();
     expect(await getRedisValue(redisClient, "other-cache:existing-key")).toBe(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17123 app preview](https://pr-17123.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Makes the admin API-key cache invalidation test parallel-safe by treating the reported invalidation count as a lower bound. Other server-test workers can legitimately add matching Redis keys before the endpoint scans the shared test database.

The existing per-key assertions still verify that both fixtures are removed and that unrelated Redis entries remain untouched.

Addresses the flaky test reported in #17119.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- Targeted Redis-backed test: 10 consecutive passes
- Pre-commit Prettier check: `All matched files use Prettier code style!`
- Pre-commit lint: `Tasks: 7 successful, 7 total`; `Cached: 0 cached, 7 total`

## Mandatory Tasks

- [x] Self-reviewed the code
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0c221c4-4d43-4150-bc13-694217e3ef23?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0c221c4-4d43-4150-bc13-694217e3ef23&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the admin API-key cache invalidation server test tolerate additional matching Redis entries created by concurrent test workers.
- Replaces the exact invalidation count assertion with a numeric lower bound of two.
- Preserves assertions that both fixture keys are removed and unrelated cache data remains untouched.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the relaxed count assertion accurately accommodates shared-test concurrency while preserving the substantive cache invalidation checks.

No actionable failures remain; the endpoint guarantees a numeric count, and the test continues to verify deletion of its fixtures and preservation of unrelated data.
</details>

<sub>Reviews (1): Last reviewed commit: ["test(web): tolerate concurrent API key c..."](https://github.com/langfuse/langfuse/commit/d7fdfc4d4670ae050966398e7aaf2a1b56d1a310) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61155166)</sub>

<!-- /greptile_comment -->