### PR TITLE
fix(monitors): clarify threshold units and display preview in monitor form

### DIFF
--- a/scripts/agents/sync-agent-shims.mjs
+++ b/scripts/agents/sync-agent-shims.mjs
@@ -10,9 +10,10 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import process from "node:process";
 
-const repoRoot = resolve(new URL("../..", import.meta.url).pathname);
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 const sourcePath = resolve(repoRoot, ".agents/config.json");
 const config = JSON.parse(readFileSync(sourcePath, "utf8"));
 const servers = config.mcpServers;

--- a/web/src/features/monitors/components/MonitorForm.clienttest.ts
+++ b/web/src/features/monitors/components/MonitorForm.clienttest.ts
@@ -18,6 +18,8 @@ const {
   nameOrPlaceholder,
   resolveViewChangePatch,
   monitorCreateAnalyticsProperties,
+  getMonitorThresholdUnitPresentation,
+  formatThresholdDescription,
 } = __test;
 
 describe("createDefaults", () => {
@@ -179,5 +181,105 @@ describe("monitorToDefaults", () => {
     };
     const defaults = monitorToDefaults(monitor);
     expect(defaults.triggerIds).toEqual(["t-a", "t-b"]);
+  });
+});
+
+describe("getMonitorThresholdUnitPresentation", () => {
+  it("resolves millisecond unit and 'ms' label for latency measure", () => {
+    expect(
+      getMonitorThresholdUnitPresentation({
+        view: "observations",
+        metric: { measure: "latency", aggregation: "p95" },
+      }),
+    ).toEqual({
+      unit: "millisecond",
+      unitLabel: "ms",
+    });
+  });
+
+  it("resolves USD unit for totalCost measure", () => {
+    expect(
+      getMonitorThresholdUnitPresentation({
+        view: "observations",
+        metric: { measure: "totalCost", aggregation: "sum" },
+      }),
+    ).toEqual({
+      unit: "USD",
+      unitLabel: "USD",
+    });
+  });
+
+  it("returns empty object for count aggregation", () => {
+    expect(
+      getMonitorThresholdUnitPresentation({
+        view: "observations",
+        metric: { measure: "latency", aggregation: "count" },
+      }),
+    ).toEqual({});
+  });
+
+  it("returns empty object for uniq aggregation", () => {
+    expect(
+      getMonitorThresholdUnitPresentation({
+        view: "observations",
+        metric: { measure: "user", aggregation: "uniq" },
+      }),
+    ).toEqual({});
+  });
+});
+
+describe("formatThresholdDescription", () => {
+  it("formats millisecond guidance when empty", () => {
+    expect(
+      formatThresholdDescription({
+        value: null,
+        unit: "millisecond",
+      }),
+    ).toBe("Threshold is measured in milliseconds (ms).");
+  });
+
+  it("formats millisecond equivalent for sub-second values", () => {
+    expect(
+      formatThresholdDescription({
+        value: 500,
+        unit: "millisecond",
+      }),
+    ).toBe("Measured in milliseconds (ms) — equivalent to 500ms");
+  });
+
+  it("formats millisecond equivalent for second values", () => {
+    expect(
+      formatThresholdDescription({
+        value: 50000,
+        unit: "millisecond",
+      }),
+    ).toBe("Measured in milliseconds (ms) — equivalent to 50s");
+  });
+
+  it("formats USD guidance when empty", () => {
+    expect(
+      formatThresholdDescription({
+        value: null,
+        unit: "USD",
+      }),
+    ).toBe("Threshold is measured in USD ($).");
+  });
+
+  it("formats USD equivalent for monetary values", () => {
+    expect(
+      formatThresholdDescription({
+        value: 5,
+        unit: "USD",
+      }),
+    ).toBe("Measured in USD ($) — equivalent to $5.00");
+  });
+
+  it("returns undefined when no unit is present", () => {
+    expect(
+      formatThresholdDescription({
+        value: 10,
+        unit: undefined,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/web/src/features/monitors/components/MonitorForm.tsx
+++ b/web/src/features/monitors/components/MonitorForm.tsx
@@ -46,6 +46,7 @@ import { partitionWidgetUiTableFiltersToView } from "@/src/features/dashboard/li
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics";
 import { resolveMonitorNameForSave } from "@/src/features/monitors/fns/resolveMonitorNameForSave";
 import { cn } from "@/src/utils/tailwind";
+import { valueFormatter } from "@/src/features/widgets/chart-library/utils";
 
 import {
   CreateMonitorSchema,
@@ -161,6 +162,67 @@ const monitorCreateAnalyticsProperties = (
   aggregation: monitor.metric.aggregation,
   window: monitor.window,
 });
+
+/** getMonitorThresholdUnitPresentation resolves the measure unit and UI unit label for a monitor's metric. */
+const getMonitorThresholdUnitPresentation = (params: {
+  view?: string;
+  metric?: { measure?: string; aggregation?: string };
+}): {
+  unit?: string;
+  unitLabel?: string;
+} => {
+  const isCount =
+    params.metric?.aggregation === "count" ||
+    params.metric?.aggregation === "uniq";
+  if (isCount) return {};
+
+  const view = (params.view ??
+    "observations") as keyof (typeof viewDeclarations)["v2"];
+  const measureName = params.metric?.measure ?? "count";
+  const measureDef = viewDeclarations.v2[view]?.measures[measureName];
+  const unit = measureDef?.unit;
+
+  if (!unit) return {};
+
+  if (unit === "millisecond") {
+    return { unit, unitLabel: "ms" };
+  }
+
+  return { unit, unitLabel: unit };
+};
+
+/** formatThresholdDescription provides clarifying helper text explaining the unit and equivalent human representation. */
+const formatThresholdDescription = (params: {
+  value?: number | null;
+  unit?: string;
+}): string | undefined => {
+  const { value, unit } = params;
+
+  if (unit === "millisecond") {
+    if (value != null && Number.isFinite(value)) {
+      const formatted = valueFormatter(value, "millisecond");
+      return `Measured in milliseconds (ms) — equivalent to ${formatted}`;
+    }
+    return "Threshold is measured in milliseconds (ms).";
+  }
+
+  if (unit === "USD") {
+    if (value != null && Number.isFinite(value)) {
+      const formatted = valueFormatter(value, "USD");
+      return `Measured in USD ($) — equivalent to ${formatted}`;
+    }
+    return "Threshold is measured in USD ($).";
+  }
+
+  if (unit) {
+    if (value != null && Number.isFinite(value)) {
+      return `Threshold: ${value.toLocaleString("en-US")} ${unit}`;
+    }
+    return `Threshold is measured in ${unit}.`;
+  }
+
+  return undefined;
+};
 
 /** MonitorForm renders the create/edit form for a Monitor. */
 export const MonitorForm = ({
@@ -387,6 +449,34 @@ export const MonitorForm = ({
   );
 
   namePlaceholderRef.current = namePlaceholder;
+
+  /** thresholdUnit resolves the measure unit (e.g. "millisecond", "USD") and input badge label (e.g. "ms", "USD"). */
+  const thresholdUnit = useMemo(
+    () =>
+      getMonitorThresholdUnitPresentation({
+        view: watched.view,
+        metric: watched.metric,
+      }),
+    [watched.view, watched.metric],
+  );
+
+  const alertThresholdDescription = useMemo(
+    () =>
+      formatThresholdDescription({
+        value: watched.alertThreshold,
+        unit: thresholdUnit.unit,
+      }),
+    [watched.alertThreshold, thresholdUnit.unit],
+  );
+
+  const warningThresholdDescription = useMemo(
+    () =>
+      formatThresholdDescription({
+        value: watched.warningThreshold,
+        unit: thresholdUnit.unit,
+      }),
+    [watched.warningThreshold, thresholdUnit.unit],
+  );
 
   /** previewFilters strips unsupported rows from the picked view's filters for the preview query. */
   const previewFilters = useMemo<FilterState>(
@@ -664,7 +754,17 @@ export const MonitorForm = ({
                             disabled={!hasAccess}
                           />
                         </FormControl>
+                        {thresholdUnit.unitLabel && (
+                          <span className="text-muted-foreground shrink-0 text-xs">
+                            {thresholdUnit.unitLabel}
+                          </span>
+                        )}
                       </div>
+                      {alertThresholdDescription && (
+                        <FormDescription className="text-muted-foreground text-xs">
+                          {alertThresholdDescription}
+                        </FormDescription>
+                      )}
                       <FormMessage />
                     </FormItem>
                   )}
@@ -708,7 +808,17 @@ export const MonitorForm = ({
                             disabled={!hasAccess}
                           />
                         </FormControl>
+                        {thresholdUnit.unitLabel && (
+                          <span className="text-muted-foreground shrink-0 text-xs">
+                            {thresholdUnit.unitLabel}
+                          </span>
+                        )}
                       </div>
+                      {warningThresholdDescription && (
+                        <FormDescription className="text-muted-foreground text-xs">
+                          {warningThresholdDescription}
+                        </FormDescription>
+                      )}
                       <FormMessage />
                     </FormItem>
                   )}
@@ -1121,4 +1231,6 @@ export const __test = {
   nameOrPlaceholder,
   resolveViewChangePatch,
   monitorCreateAnalyticsProperties,
+  getMonitorThresholdUnitPresentation,
+  formatThresholdDescription,
 };


### PR DESCRIPTION
### Summary

Fixes #16630.

When configuring alerts on measures that have specific units (such as latency in milliseconds or total cost in USD), the threshold inputs (`alertThreshold` and `warningThreshold`) previously displayed only a bare numeric input without any unit suffix or indication of what scale was expected.

Meanwhile, the adjacent Live Preview time-series chart automatically formats durations into human-readable units (e.g. `49s` for `49,000` ms). This caused users configuring latency monitors to assume the threshold input expected seconds (e.g. entering `500` for 500s), while the backend evaluates against raw milliseconds (`49,000 > 500`), triggering alerts unexpectedly and making it appear as if server-side filters were being ignored.

### Changes

- Added `getMonitorThresholdUnitPresentation` helper resolving the measure unit (e.g. `millisecond`, `USD`, `tokens`) and its UI badge label (`ms`, `USD`, `tokens`).
- Added `formatThresholdDescription` helper providing clear contextual guidance and equivalent formatted representations (e.g. `Measured in milliseconds (ms) — equivalent to 500ms` or `Measured in milliseconds (ms) — equivalent to 50s`).
- Displayed unit badge suffix next to `alertThreshold` and `warningThreshold` numeric inputs.
- Displayed `FormDescription` below threshold inputs explaining the measurement unit and live human-readable translation.
- Fixed `fileURLToPath` decoding in `scripts/agents/sync-agent-shims.mjs` so workspaces on paths containing spaces resolve correctly.
- Added comprehensive unit and client test suite covering latency, cost, count/uniq, and description formatting.

### Verification

- Client tests: `pnpm --filter web run test-client src/features/monitors` (`Tests  87 passed (87)`)
- Shared tests: `pnpm --filter @langfuse/shared run test src/features/monitors` (`Tests  280 passed (280)`)
- Lint: `pnpm --filter web run lint` (`0 errors, 0 warnings`)
- Pre-commit: `turbo run lint` (`Tasks: 7 successful, 7 total`)
- Typecheck: `pnpm --filter web run typecheck` (passed)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR clarifies monitor threshold units by adding input suffixes and human-readable descriptions, expands monitor-form unit tests, and fixes repository path decoding in the agent shim synchronization script.
- Resolves threshold units from the selected monitor metric.
- Adds unit badges and formatted threshold descriptions for latency, cost, and other unit-bearing measures.
- Adds tests for unit resolution and threshold descriptions.
- Uses `fileURLToPath` so agent shim synchronization works from paths containing spaces.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, though the threshold description should preserve precision rather than displaying a rounded equivalent for valid cost thresholds.

Unit resolution and path decoding align with their underlying contracts; the only identified issue is non-blocking misleading rounding in the newly added helper text.

**Files Needing Attention:** web/src/features/monitors/components/MonitorForm.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/monitors/components/MonitorForm.tsx:211
**Equivalent value loses precision**

The description passes the exact threshold through a chart formatter that rounds some valid values. For example, a USD threshold of `5.001` is displayed as “equivalent to $5.00,” even though monitor evaluation still compares against `5.001`. This makes the new guidance inaccurate for realistic sub-cent cost thresholds; the equivalent value should preserve the entered threshold’s significant precision.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(monitors): display unit and preview ..."](https://github.com/langfuse/langfuse/commit/5bd643d46e632457055d46f021e37a5de6f3996e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61159973)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Dashboards, metrics, and monitors](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/dashboards-metrics-and-monitors.md)

<!-- /greptile_comment -->