### PR TITLE
ci(docker): build Cloud and preview images from WizOS

### DIFF
--- a/.agents/skills/git-workflow/SKILL.md
+++ b/.agents/skills/git-workflow/SKILL.md
@@ -92,5 +92,11 @@ operations.
   or the GitHub "Latest release" badge. At the next major GA (v5), repeat
   the flip: move the gate to `refs/tags/v5` on `main`, then disable it and
   set `makeLatest: false` on the new `v4` maintenance branch.
+- Langfuse Cloud and PR-preview images must be built from a digest-pinned
+  WizOS Node base via the account's ECR pull-through cache
+  (`scripts/ci/wizos-base-image.sh`, `.github/actions/wizos-node-base`).
+  OSS tag releases keep the Dockerfile default `node:24-alpine`. Do not pass
+  `NODE_BASE_IMAGE` to the Docker Hub/GHCR release job, and do not add an
+  Alpine fallback in `_deploy_ecs_service.yml` or `preview-build.yml`.
 - Do not change release/versioning flow without updating this skill and the
   impacted package guides.

--- a/.github/actions/wizos-node-base/action.yml
+++ b/.github/actions/wizos-node-base/action.yml
@@ -1,0 +1,43 @@
+name: Resolve WizOS Node base
+description: >
+  Fail closed unless Cloud/preview builds FROM a digest-pinned WizOS Node image
+  pulled through this account's ECR cache. OSS releases must not use this action.
+
+inputs:
+  ecr-registry:
+    description: ECR registry host from amazon-ecr-login (account.dkr.ecr.region.amazonaws.com)
+    required: true
+  wizos-ecr-repository:
+    description: Pull-through repository path starting with wizos/
+    required: true
+  wizos-node-tag:
+    description: Upstream WizOS Node tag
+    required: true
+  wizos-node-digest:
+    description: sha256 digest of the WizOS Node image
+    required: true
+  wizos-os-release-id:
+    description: Expected /etc/os-release ID (must not be alpine)
+    required: true
+
+outputs:
+  node-base-image:
+    description: Digest-pinned ECR pull-through ref to pass as NODE_BASE_IMAGE
+    value: ${{ steps.resolve.outputs.node-base-image }}
+
+runs:
+  using: composite
+  steps:
+    - name: Pull and verify WizOS Node base
+      id: resolve
+      shell: bash
+      env:
+        ECR_REGISTRY: ${{ inputs.ecr-registry }}
+        WIZOS_ECR_REPOSITORY: ${{ inputs.wizos-ecr-repository }}
+        WIZOS_NODE_TAG: ${{ inputs.wizos-node-tag }}
+        WIZOS_NODE_DIGEST: ${{ inputs.wizos-node-digest }}
+        WIZOS_OS_RELEASE_ID: ${{ inputs.wizos-os-release-id }}
+      run: |
+        set -euo pipefail
+        image="$(bash "${GITHUB_WORKSPACE}/scripts/ci/wizos-base-image.sh" pull-base)"
+        echo "node-base-image=${image}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/_deploy_ecs_service.yml
+++ b/.github/workflows/_deploy_ecs_service.yml
@@ -47,11 +47,27 @@ jobs:
       - name: Login to AWS ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+      # Cloud images must FROM a digest-pinned WizOS Node image via this
+      # account's ECR pull-through cache (prefix wizos/ → registry.os.wiz.io).
+      # Required GitHub variables: WIZOS_ECR_REPOSITORY, WIZOS_NODE_TAG,
+      # WIZOS_NODE_DIGEST, WIZOS_OS_RELEASE_ID. Missing values fail closed;
+      # there is no Alpine fallback.
+      - name: Resolve WizOS Node base
+        id: wizos-node-base
+        uses: ./.github/actions/wizos-node-base
+        with:
+          ecr-registry: ${{ steps.login-ecr.outputs.registry }}
+          wizos-ecr-repository: ${{ vars.WIZOS_ECR_REPOSITORY }}
+          wizos-node-tag: ${{ vars.WIZOS_NODE_TAG }}
+          wizos-node-digest: ${{ vars.WIZOS_NODE_DIGEST }}
+          wizos-os-release-id: ${{ vars.WIZOS_OS_RELEASE_ID }}
       - name: Build, tag, and push Docker image
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ steps.split.outputs._0 }}
           IMAGE_TAG: ${{ github.sha }}
+          NODE_BASE_IMAGE: ${{ steps.wizos-node-base.outputs.node-base-image }}
+          WIZOS_OS_RELEASE_ID: ${{ vars.WIZOS_OS_RELEASE_ID }}
           STEPS_SPLIT_OUTPUTS__0: ${{ steps.split.outputs._0 }}
           VARS_NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: ${{ vars.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION }}
           VARS_NEXT_LANGFUSE_TRACING_SAMPLE_RATE: ${{ vars.NEXT_LANGFUSE_TRACING_SAMPLE_RATE }}
@@ -71,6 +87,7 @@ jobs:
           docker build \
             -t $REGISTRY/$REPOSITORY:$IMAGE_TAG \
             -f ./${STEPS_SPLIT_OUTPUTS__0}/Dockerfile \
+            --build-arg NODE_BASE_IMAGE="${NODE_BASE_IMAGE}" \
             --build-arg NEXT_PUBLIC_LANGFUSE_CLOUD_REGION=${VARS_NEXT_PUBLIC_LANGFUSE_CLOUD_REGION} \
             --build-arg NEXT_LANGFUSE_TRACING_SAMPLE_RATE=${VARS_NEXT_LANGFUSE_TRACING_SAMPLE_RATE} \
             --build-arg NEXT_PUBLIC_SENTRY_ENVIRONMENT=${VARS_NEXT_PUBLIC_SENTRY_ENVIRONMENT} \
@@ -87,6 +104,7 @@ jobs:
             --build-arg NEXT_PUBLIC_LANGFUSE_TRACING_SAMPLE_RATE=${VARS_NEXT_PUBLIC_LANGFUSE_TRACING_SAMPLE_RATE} \
             --build-arg NEXT_PUBLIC_ASSET_PREFIX=${VARS_NEXT_PUBLIC_ASSET_PREFIX} \
             .
+          bash scripts/ci/wizos-base-image.sh verify-image "${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}"
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
       - name: Render AWS ECS Task Definition
         id: render-task-definition

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -320,6 +320,19 @@ jobs:
       - name: run eslint-plugin tests
         run: pnpm --filter @repo/eslint-plugin run test
 
+  test-wizos-cloud-base-guardrails:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    needs:
+      - pre-job
+    if: ${{ !cancelled() && (github.event_name != 'push' || needs.pre-job.outputs.should_skip != 'true') }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run WizOS Cloud base guardrail tests
+        run: bash "scripts/ci/wizos-base-image.test.sh"
+
   tests-in-app-agent-sandbox-runtime:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
@@ -1241,6 +1254,7 @@ jobs:
         knip,
         prettier-check,
         tests-eslint-plugin,
+        test-wizos-cloud-base-guardrails,
         tests-in-app-agent-sandbox-runtime,
         tests-storybook,
         tests-shared,

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -195,13 +195,30 @@ jobs:
           role-to-assume: ${{ vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN }}
 
       - name: Login to AWS ECR
+        id: login-ecr
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+
+      # Preview images follow the Cloud base: digest-pinned WizOS Node via this
+      # account's ECR pull-through cache. Required GitHub variables:
+      # WIZOS_ECR_REPOSITORY, WIZOS_NODE_TAG, WIZOS_NODE_DIGEST,
+      # WIZOS_OS_RELEASE_ID. Missing values fail closed; no Alpine fallback.
+      - name: Resolve WizOS Node base
+        id: wizos-node-base
+        uses: ./.github/actions/wizos-node-base
+        with:
+          ecr-registry: ${{ steps.login-ecr.outputs.registry }}
+          wizos-ecr-repository: ${{ vars.WIZOS_ECR_REPOSITORY }}
+          wizos-node-tag: ${{ vars.WIZOS_NODE_TAG }}
+          wizos-node-digest: ${{ vars.WIZOS_NODE_DIGEST }}
+          wizos-os-release-id: ${{ vars.WIZOS_OS_RELEASE_ID }}
 
       - name: Build and push ${{ matrix.target }} image
         env:
           COMMIT_SHA: ${{ needs.meta.outputs.commit_sha }}
           IMAGE: ${{ matrix.image }}
           DOCKERFILE: ${{ matrix.dockerfile }}
+          NODE_BASE_IMAGE: ${{ steps.wizos-node-base.outputs.node-base-image }}
+          WIZOS_OS_RELEASE_ID: ${{ vars.WIZOS_OS_RELEASE_ID }}
           # Static, workflow-defined literal (per-target flags) — no user input.
           EXTRA_BUILD_ARGS: ${{ matrix.extra_build_args }}
           TARGET: ${{ matrix.target }}
@@ -260,11 +277,13 @@ jobs:
           # shellcheck disable=SC2086
           docker build \
             --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
+            --build-arg NODE_BASE_IMAGE="${NODE_BASE_IMAGE}" \
             ${EXTRA_BUILD_ARGS} \
             "${preview_meta_args[@]}" \
             -f "${DOCKERFILE}" \
             -t "${IMAGE}" \
             .
+          bash scripts/ci/wizos-base-image.sh verify-image "${IMAGE}"
           docker push "${IMAGE}"
 
   # Single authoritative status comment once both builds settle, updating the

--- a/scripts/ci/wizos-base-image.sh
+++ b/scripts/ci/wizos-base-image.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Resolve and verify the WizOS Node base used for Langfuse Cloud and PR-preview
+# image builds. OSS release builds must not call this script: they keep the
+# Dockerfile default (node:24-alpine) and need no private registry.
+#
+# Required environment:
+#   ECR_REGISTRY            Account ECR host from amazon-ecr-login (construct/pull-base)
+#   WIZOS_ECR_REPOSITORY    Pull-through repository path, must start with wizos/
+#   WIZOS_NODE_TAG          Upstream tag (no digest, no slash)
+#   WIZOS_NODE_DIGEST       sha256:<64 lowercase hex>
+#   WIZOS_OS_RELEASE_ID     /etc/os-release ID of the WizOS image (not alpine)
+#
+# Commands:
+#   construct                         Print the digest-pinned Node base ref
+#   pull-base                         Pull that ref and check its os-release
+#   verify-image <image>              Check a built image's os-release
+#   check-os-release-file <file>      Check a local os-release fixture
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 construct|pull-base|verify-image <image>|check-os-release-file <file>" >&2
+  exit 2
+}
+
+is_blank() {
+  [[ -z "${1:-}" || "${1}" =~ ^[[:space:]]*$ ]]
+}
+
+require_env() {
+  local name="$1"
+  if is_blank "${!name:-}"; then
+    echo "::error::${name} is required for Cloud/preview image builds. Set the GitHub Actions variable and retry. Alpine fallback is not allowed." >&2
+    exit 1
+  fi
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "${value}"
+}
+
+os_release_id() {
+  local file="$1"
+  awk -F= '
+    /^ID=/ {
+      value=$2
+      gsub(/\r/, "", value)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      gsub(/^"/, "", value)
+      gsub(/"$/, "", value)
+      print value
+      exit
+    }
+  ' "${file}"
+}
+
+check_os_release_file() {
+  local file="$1"
+  local expected
+  expected="$(trim "${WIZOS_OS_RELEASE_ID:-}")"
+  if is_blank "${expected}"; then
+    echo "::error::WIZOS_OS_RELEASE_ID is required for Cloud/preview image builds. Alpine fallback is not allowed." >&2
+    exit 1
+  fi
+  if [[ "${expected}" == "alpine" ]]; then
+    echo "::error::WIZOS_OS_RELEASE_ID cannot be alpine." >&2
+    exit 1
+  fi
+  if [[ ! -f "${file}" ]]; then
+    echo "::error::os-release file not found: ${file}" >&2
+    exit 1
+  fi
+
+  local actual
+  actual="$(os_release_id "${file}")"
+  if is_blank "${actual}"; then
+    echo "::error::Could not parse ID= from ${file}" >&2
+    exit 1
+  fi
+  if [[ "${actual}" == "alpine" ]]; then
+    echo "::error::Image OS ID is alpine; Cloud/preview images must be built from WizOS." >&2
+    exit 1
+  fi
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "::error::Image OS ID is '${actual}', expected '${expected}'." >&2
+    exit 1
+  fi
+}
+
+construct_node_base_image() {
+  require_env ECR_REGISTRY
+  require_env WIZOS_ECR_REPOSITORY
+  require_env WIZOS_NODE_TAG
+  require_env WIZOS_NODE_DIGEST
+  require_env WIZOS_OS_RELEASE_ID
+
+  local registry repository tag digest os_id
+  registry="$(trim "${ECR_REGISTRY}")"
+  repository="$(trim "${WIZOS_ECR_REPOSITORY}")"
+  tag="$(trim "${WIZOS_NODE_TAG}")"
+  digest="$(trim "${WIZOS_NODE_DIGEST}")"
+  os_id="$(trim "${WIZOS_OS_RELEASE_ID}")"
+
+  if [[ ! "${registry}" =~ ^[0-9]{12}\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com$ ]]; then
+    echo "::error::ECR_REGISTRY must be an AWS ECR registry host (<account>.dkr.ecr.<region>.amazonaws.com)." >&2
+    exit 1
+  fi
+  if [[ "${repository}" != wizos/* || "${repository}" == *:* || "${repository}" == *@* ]]; then
+    echo "::error::WIZOS_ECR_REPOSITORY must be a pull-through path starting with wizos/ and must not include a tag or digest." >&2
+    exit 1
+  fi
+  if [[ "${tag}" == *:* || "${tag}" == *@* || "${tag}" == */* ]]; then
+    echo "::error::WIZOS_NODE_TAG must be a single tag, not a repository path or digest." >&2
+    exit 1
+  fi
+  if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "::error::WIZOS_NODE_DIGEST must be sha256: followed by 64 lowercase hex characters." >&2
+    exit 1
+  fi
+  if [[ "${os_id}" == "alpine" ]]; then
+    echo "::error::WIZOS_OS_RELEASE_ID cannot be alpine." >&2
+    exit 1
+  fi
+
+  printf '%s/%s:%s@%s\n' "${registry}" "${repository}" "${tag}" "${digest}"
+}
+
+read_os_release_from_image() {
+  local image="$1"
+  docker run --rm --user 0 --entrypoint cat "${image}" /etc/os-release
+}
+
+cmd="${1:-}"
+case "${cmd}" in
+  construct)
+    construct_node_base_image
+    ;;
+  pull-base)
+    image="$(construct_node_base_image)"
+    echo "Pulling WizOS Node base ${image}" >&2
+    docker pull "${image}" >&2
+    tmp="$(mktemp)"
+    read_os_release_from_image "${image}" > "${tmp}"
+    check_os_release_file "${tmp}"
+    rm -f "${tmp}"
+    echo "WizOS Node base verified (ID=$(trim "${WIZOS_OS_RELEASE_ID}"))" >&2
+    printf '%s\n' "${image}"
+    ;;
+  verify-image)
+    image="${2:-}"
+    if is_blank "${image}"; then
+      usage
+    fi
+    require_env WIZOS_OS_RELEASE_ID
+    tmp="$(mktemp)"
+    read_os_release_from_image "${image}" > "${tmp}"
+    check_os_release_file "${tmp}"
+    rm -f "${tmp}"
+    echo "Built image ${image} is WizOS (ID=$(trim "${WIZOS_OS_RELEASE_ID}"))"
+    ;;
+  check-os-release-file)
+    file="${2:-}"
+    if is_blank "${file}"; then
+      usage
+    fi
+    check_os_release_file "${file}"
+    echo "os-release check passed (ID=$(trim "${WIZOS_OS_RELEASE_ID}"))"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/scripts/ci/wizos-base-image.test.sh
+++ b/scripts/ci/wizos-base-image.test.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Guardrails for Cloud/preview WizOS bases: the resolver rejects Alpine and
+# incomplete pins, and the Dockerfiles / Cloud workflows stay wired correctly.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+script="${repo_root}/scripts/ci/wizos-base-image.sh"
+tmpdir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+
+expect_fail() {
+  local message="$1"
+  shift
+  if "$@" >/dev/null 2>"${tmpdir}/err"; then
+    echo "expected failure: ${message}" >&2
+    cat "${tmpdir}/err" >&2
+    exit 1
+  fi
+}
+
+expect_ok() {
+  local message="$1"
+  shift
+  if ! "$@" >"${tmpdir}/out" 2>"${tmpdir}/err"; then
+    echo "expected success: ${message}" >&2
+    cat "${tmpdir}/err" >&2
+    exit 1
+  fi
+}
+
+valid_env() {
+  export ECR_REGISTRY="123456789012.dkr.ecr.us-east-1.amazonaws.com"
+  export WIZOS_ECR_REPOSITORY="wizos/node"
+  export WIZOS_NODE_TAG="24"
+  export WIZOS_NODE_DIGEST="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  export WIZOS_OS_RELEASE_ID="wizos"
+}
+
+cat > "${tmpdir}/wizos-os-release" <<'EOF'
+NAME="WizOS"
+ID=wizos
+VERSION_ID="1"
+EOF
+
+cat > "${tmpdir}/alpine-os-release" <<'EOF'
+NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.22.0
+EOF
+
+valid_env
+
+expect_ok "construct a digest-pinned ECR pull-through ref" \
+  "${script}" construct
+expected="123456789012.dkr.ecr.us-east-1.amazonaws.com/wizos/node:24@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+got="$(cat "${tmpdir}/out")"
+if [[ "${got}" != "${expected}" ]]; then
+  echo "construct produced '${got}', expected '${expected}'" >&2
+  exit 1
+fi
+
+expect_ok "accept WizOS os-release" \
+  "${script}" check-os-release-file "${tmpdir}/wizos-os-release"
+
+expect_fail "reject alpine os-release" \
+  "${script}" check-os-release-file "${tmpdir}/alpine-os-release"
+
+WIZOS_OS_RELEASE_ID=alpine expect_fail "reject alpine as the expected ID" \
+  "${script}" construct
+
+unset WIZOS_NODE_DIGEST
+expect_fail "reject a missing digest" \
+  "${script}" construct
+valid_env
+
+WIZOS_NODE_DIGEST="sha256:deadbeef" expect_fail "reject a short digest" \
+  "${script}" construct
+valid_env
+
+WIZOS_ECR_REPOSITORY="node" expect_fail "reject a repository outside the wizos/ pull-through prefix" \
+  "${script}" construct
+valid_env
+
+WIZOS_ECR_REPOSITORY="wizos/node:24" expect_fail "reject a tag embedded in the repository" \
+  "${script}" construct
+valid_env
+
+ECR_REGISTRY="docker.io" expect_fail "reject a non-ECR registry" \
+  "${script}" construct
+valid_env
+
+expect_fail "require an image argument for verify-image" \
+  "${script}" verify-image
+
+for dockerfile in web/Dockerfile worker/Dockerfile; do
+  if ! grep -Fq 'ARG NODE_BASE_IMAGE=node:24-alpine' "${repo_root}/${dockerfile}"; then
+    echo "${dockerfile} must default NODE_BASE_IMAGE to node:24-alpine for OSS builds" >&2
+    exit 1
+  fi
+  if ! grep -Fq 'FROM --platform=${TARGETPLATFORM:-linux/amd64} ${NODE_BASE_IMAGE} AS alpine' "${repo_root}/${dockerfile}"; then
+    echo "${dockerfile} must FROM NODE_BASE_IMAGE as the alpine stage" >&2
+    exit 1
+  fi
+done
+
+for workflow in .github/workflows/_deploy_ecs_service.yml .github/workflows/preview-build.yml; do
+  if ! grep -q 'wizos-node-base' "${repo_root}/${workflow}"; then
+    echo "${workflow} must resolve the WizOS Node base via .github/actions/wizos-node-base" >&2
+    exit 1
+  fi
+  if ! grep -q 'NODE_BASE_IMAGE' "${repo_root}/${workflow}"; then
+    echo "${workflow} must pass NODE_BASE_IMAGE into docker build" >&2
+    exit 1
+  fi
+  if ! grep -q 'verify-image' "${repo_root}/${workflow}"; then
+    echo "${workflow} must verify the built image is WizOS" >&2
+    exit 1
+  fi
+done
+
+oss_leaks="$(grep -n 'NODE_BASE_IMAGE' "${repo_root}/.github/workflows/pipeline.yml" | grep -v 'test-wizos-cloud-base-guardrails\|wizos-base-image' || true)"
+if [[ -n "${oss_leaks}" ]]; then
+  echo "pipeline.yml must not pass NODE_BASE_IMAGE into OSS release builds" >&2
+  echo "${oss_leaks}" >&2
+  exit 1
+fi
+
+echo "wizos-base-image.sh: ok"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,8 @@
-# The node alpine image is available here: https://github.com/nodejs/docker-node
-FROM --platform=${TARGETPLATFORM:-linux/amd64} node:24-alpine AS alpine
+# Cloud and PR-preview builds override NODE_BASE_IMAGE with a digest-pinned
+# WizOS Node image from the account's ECR pull-through cache. The default stays
+# on Docker Hub so OSS releases and local builds need no private registry.
+ARG NODE_BASE_IMAGE=node:24-alpine
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ${NODE_BASE_IMAGE} AS alpine
 
 # It's important to update the index before installing packages to ensure you're getting the latest versions.
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,5 +1,8 @@
-# The node alpine image is available here: https://github.com/nodejs/docker-node
-FROM --platform=${TARGETPLATFORM:-linux/amd64} node:24-alpine AS alpine
+# Cloud and PR-preview builds override NODE_BASE_IMAGE with a digest-pinned
+# WizOS Node image from the account's ECR pull-through cache. The default stays
+# on Docker Hub so OSS releases and local builds need no private registry.
+ARG NODE_BASE_IMAGE=node:24-alpine
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ${NODE_BASE_IMAGE} AS alpine
 
 # It's important to update the index before installing packages to ensure you're getting the latest versions.
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Langfuse Cloud ECS and PR-preview images now fail closed unless they are built from a digest-pinned WizOS Node base pulled through the account's ECR cache. OSS tag releases stay on public `node:24-alpine` and need no private registry.

`web/Dockerfile` and `worker/Dockerfile` take `NODE_BASE_IMAGE` (default `node:24-alpine`). Cloud (`_deploy_ecs_service.yml`) and preview (`preview-build.yml`) construct

`<account>.dkr.ecr.<region>.amazonaws.com/<WIZOS_ECR_REPOSITORY>:<WIZOS_NODE_TAG>@<WIZOS_NODE_DIGEST>`

pull it, check `/etc/os-release`, pass it as the build-arg, then check the built image again. Missing variables, a non-`wizos/` repository, a missing digest, or `ID=alpine` fail the job. There is no Alpine fallback.

The tagged Docker Hub / GHCR release job does not pass `NODE_BASE_IMAGE`.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Do not merge until Cloud infra is wired

This will break staging/prod deploys and PR previews the moment it lands if the following are missing.

1. **ECR pull-through** in each Cloud AWS account (staging, prod-*, preview), prefix `wizos`, upstream `registry.os.wiz.io`, Wiz registry credentials in Secrets Manager. After that, Node is pulled as `<account>.dkr.ecr.<region>.amazonaws.com/wizos/<upstream-path>:<tag>`.
2. **GitHub Actions variables** (repo-level, or per GitHub environment if an account uses a different path):
   - `WIZOS_ECR_REPOSITORY` — pull-through path starting with `wizos/` (example: `wizos/node`)
   - `WIZOS_NODE_TAG` — upstream tag (example: `24`)
   - `WIZOS_NODE_DIGEST` — `sha256:` + 64 lowercase hex
   - `WIZOS_OS_RELEASE_ID` — `/etc/os-release` `ID` of that image, not `alpine`
3. Confirm the WizOS Node image still has `apk` (and `dumb-init` / `tzdata`). These Dockerfiles still use Alpine-style `apk`. If the catalog image does not, Cloud builds will fail at `apk` and we will need a follow-up package-install branch.

The golang-migrate compile stage still uses public `golang:1.26`; only the copied static binary lands in the runtime image.

This is intentionally Cloud-only. It does not rebase OSS images onto UBI/Iron Bank.

## Impacted packages

- `web/Dockerfile`, `worker/Dockerfile`
- `.github/workflows/_deploy_ecs_service.yml`, `preview-build.yml`, `pipeline.yml`
- `scripts/ci/wizos-base-image.sh`

## Verification

- `bash scripts/ci/wizos-base-image.test.sh` — `wizos-base-image.sh: ok`
- Default `NODE_BASE_IMAGE` still resolves to Alpine: `docker build --target alpine` for web and worker, then `cat /etc/os-release` → `ID=alpine` / `Alpine Linux v3.24`
- That same Alpine os-release is rejected by `check-os-release-file` when `WIZOS_OS_RELEASE_ID=wizos`
- Construct without `WIZOS_NODE_DIGEST` fails closed (no Alpine fallback)
- Pre-commit: `prettier --check` and `turbo run lint` (`Tasks: 7 successful, 7 total`, `Cached: 0 cached, 7 total`)

Not verified here: an actual WizOS pull (no Cloud ECR pull-through or Wiz credentials in this environment). First staging deploy is the real signoff. PR preview builds on this branch will stay red until the GitHub variables exist — that is the fail-closed path working.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- I have read the contributing guide
- The change is CI/Docker only
- Guardrail tests cover the fail-closed checks
- I have not added Wiz credentials or private registry refs to OSS release jobs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6fc656c-ebd3-485d-a5e4-2eef4c0bde74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6fc656c-ebd3-485d-a5e4-2eef4c0bde74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a digest-pinned WizOS Node base-image path for Cloud and preview containers while preserving the public Alpine base for OSS releases.
- Adds a composite action and shell resolver that validate the ECR reference, digest, and `/etc/os-release`.
- Passes the resolved base into ECS and preview Docker builds and verifies completed images before pushing.
- Adds CI guardrails and documents the Cloud-versus-OSS base-image policy.
- Preview builds need adjustment so pre-existing PR heads can load the newly introduced CI action and script.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because preview workflow events for pre-existing PR heads can fail before image construction.

The preview job checks out the PR head before loading newly added repository-local CI tooling, so heads created before this change cannot resolve that tooling; the accompanying guardrail test also does not reliably enforce the intended workflow data flow.

**Files Needing Attention:** .github/workflows/preview-build.yml, scripts/ci/wizos-base-image.test.sh
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant GHA as Preview workflow
  participant Head as PR-head checkout
  participant Resolver as WizOS local action
  participant ECR as ECR pull-through cache
  participant Docker as Docker build

  GHA->>Head: Checkout head.sha
  GHA->>Resolver: Load local composite action
  alt Head contains new action and script
    Resolver->>ECR: Pull digest-pinned WizOS base
    Resolver->>Resolver: Verify /etc/os-release
    Resolver-->>GHA: NODE_BASE_IMAGE
    GHA->>Docker: Build with NODE_BASE_IMAGE
    GHA->>Docker: Verify built image
  else Pre-existing PR head
    Resolver--xGHA: Local action or script is missing
  end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/preview-build.yml:207
**Older PR previews fail**

Existing same-repository PRs whose heads predate this change do not contain the new local action or resolver script. This job checks out only the PR head and then loads `./.github/actions/wizos-node-base` from that workspace, so the next label or synchronization event fails before either preview image can be built. Source the CI action and script from the base revision while keeping the build context at the PR head, as the `meta` job already does.

### Issue 2
scripts/ci/wizos-base-image.test.sh:111-124
**Guardrails miss broken wiring**

These checks only search each workflow for the separate presence of `wizos-node-base`, `NODE_BASE_IMAGE`, and `verify-image`. Removing the effective `--build-arg NODE_BASE_IMAGE` while retaining its environment declaration—or leaving verification in a comment or inactive step—would still pass and silently restore the `node:24-alpine` default. Assert the concrete action-output-to-build-argument wiring and active verification command instead.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(docker): build Cloud and preview imag..."](https://github.com/langfuse/langfuse/commit/c8cfefe00277884cbd98a1b37dde7adcff52361d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61172241)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->