### PR TITLE
feat(public-api): add ?dataType filter to GET /api/public/score-configs

### DIFF
--- a/fern/apis/server/definition/score-configs.yml
+++ b/fern/apis/server/definition/score-configs.yml
@@ -19,6 +19,13 @@ service:
       request:
         name: GetScoreConfigsRequest
         query-parameters:
+          dataType:
+            type: optional<commons.ScoreConfigDataType>
+            docs: |
+              Optional categorical filter on the score config row's
+              `dataType` (one of `CATEGORICAL`, `NUMERIC`, `BOOLEAN`,
+              `TEXT`). The `dataType` column is indexed in the Prisma
+              schema so the filter is cheap. Omit for all data types.
           page:
             type: optional<integer>
             docs: Page number, starts at 1.

--- a/packages/shared/src/server/repositories/score-configs.ts
+++ b/packages/shared/src/server/repositories/score-configs.ts
@@ -5,29 +5,38 @@ import {
 } from "../../features/scoreConfigs/validation";
 import { LangfuseNotFoundError, InternalServerError } from "../../errors";
 import { traceException } from "../instrumentation";
+import type { ScoreConfigDataType } from "@prisma/client";
 
 export const listScoreConfigs = async ({
   projectId,
+  dataType,
   page,
   limit,
 }: {
   projectId: string;
+  dataType?: ScoreConfigDataType;
   page: number;
   limit: number;
 }) => {
+  // Optional categorical filter on `dataType`. The column is indexed
+  // (`@@index([dataType])` in `packages/shared/prisma/schema.prisma`),
+  // so the filter is cheap.
+  const dataTypeFilter = dataType ? { dataType } : {};
+
+  const where = {
+    projectId,
+    ...dataTypeFilter,
+  };
+
   const [rawConfigs, totalItems] = await Promise.all([
     prisma.scoreConfig.findMany({
-      where: {
-        projectId,
-      },
+      where,
       orderBy: [{ createdAt: "desc" }, { id: "asc" }],
       take: limit,
       skip: (page - 1) * limit,
     }),
     prisma.scoreConfig.count({
-      where: {
-        projectId,
-      },
+      where,
     }),
   ]);
 

--- a/web/src/__tests__/server/score-configs.servertest.ts
+++ b/web/src/__tests__/server/score-configs.servertest.ts
@@ -809,4 +809,153 @@ describe("/api/public/score-configs API Endpoint", () => {
       });
     });
   });
+
+  describe("GET /api/public/score-configs dataType filter", () => {
+    // One score config per data type so the filter can be exercised across
+    // the full enum (CATEGORICAL, NUMERIC, BOOLEAN, TEXT).
+    let booleanId: string;
+    let numericId: string;
+    let categoricalId: string;
+    let textId: string;
+
+    const createConfig = async (
+      dataType: ScoreConfigDataType,
+      name: string,
+    ) => {
+      return prisma.scoreConfig.create({
+        data: {
+          projectId,
+          name,
+          dataType,
+          ...(dataType === ScoreConfigDataType.NUMERIC
+            ? { minValue: 0, maxValue: 1 }
+            : {}),
+          ...(dataType === ScoreConfigDataType.BOOLEAN
+            ? { minValue: 0, maxValue: 1 }
+            : {}),
+          ...(dataType === ScoreConfigDataType.CATEGORICAL
+            ? {
+                categories: [
+                  { label: "A", value: 1 },
+                  { label: "B", value: 2 },
+                ],
+              }
+            : {}),
+        },
+      });
+    };
+
+    beforeEach(async () => {
+      const boolean = await createConfig(
+        ScoreConfigDataType.BOOLEAN,
+        `dt-bool-${v4()}`,
+      );
+      const numeric = await createConfig(
+        ScoreConfigDataType.NUMERIC,
+        `dt-num-${v4()}`,
+      );
+      const categorical = await createConfig(
+        ScoreConfigDataType.CATEGORICAL,
+        `dt-cat-${v4()}`,
+      );
+      const text = await createConfig(
+        ScoreConfigDataType.TEXT,
+        `dt-txt-${v4()}`,
+      );
+      booleanId = boolean.id;
+      numericId = numeric.id;
+      categoricalId = categorical.id;
+      textId = text.id;
+    });
+
+    it("omits the filter when no dataType is provided (existing behavior)", async () => {
+      const response = await makeZodVerifiedAPICall(
+        GetScoreConfigsResponse,
+        "GET",
+        "/api/public/score-configs?limit=50",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const ids = response.body.data.map((c) => c.id);
+      expect(ids).toEqual(
+        expect.arrayContaining([booleanId, numericId, categoricalId, textId]),
+      );
+    });
+
+    it.each([
+      ["BOOLEAN", "booleanId"],
+      ["NUMERIC", "numericId"],
+      ["CATEGORICAL", "categoricalId"],
+      ["TEXT", "textId"],
+    ] as const)(
+      "filters by dataType=%s and returns only that type",
+      async (dataType, expectedIdKey) => {
+        const expectedId = {
+          booleanId,
+          numericId,
+          categoricalId,
+          textId,
+        }[expectedIdKey];
+
+        const response = await makeZodVerifiedAPICall(
+          GetScoreConfigsResponse,
+          "GET",
+          `/api/public/score-configs?dataType=${dataType}&limit=50`,
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(200);
+        const ids = response.body.data.map((c) => c.id);
+        expect(ids).toEqual([expectedId]);
+        expect(response.body.meta.totalItems).toBe(1);
+        // Every returned config must have the requested dataType.
+        for (const config of response.body.data) {
+          expect(config.dataType).toBe(dataType);
+        }
+      },
+    );
+
+    it("returns 400 on an invalid dataType value", async () => {
+      const response = await makeAPICall(
+        "GET",
+        "/api/public/score-configs?dataType=NOT_A_TYPE",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("composes the dataType filter with the existing project scope", async () => {
+      // Create a separate project + api key so we can prove the filter
+      // does not leak configs across the project boundary.
+      const other = await createOrgProjectAndApiKey();
+
+      await prisma.scoreConfig.create({
+        data: {
+          projectId: other.projectId,
+          name: `dt-other-project-${v4()}`,
+          dataType: ScoreConfigDataType.BOOLEAN,
+          minValue: 0,
+          maxValue: 1,
+        },
+      });
+
+      const response = await makeZodVerifiedAPICall(
+        GetScoreConfigsResponse,
+        "GET",
+        "/api/public/score-configs?dataType=BOOLEAN&limit=50",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      // Only `booleanId` belongs to `projectId` with dataType=BOOLEAN.
+      expect(response.body.meta.totalItems).toBe(1);
+      expect(response.body.data.map((c) => c.id)).toEqual([booleanId]);
+    });
+  });
 });

--- a/web/src/features/public-api/types/score-configs.ts
+++ b/web/src/features/public-api/types/score-configs.ts
@@ -7,6 +7,7 @@ import {
   paginationMetaResponseZod,
   publicApiPaginationZod,
   ScoreConfigCategory,
+  ScoreConfigDataType,
   ScoreConfigNameSchema,
   validateCategories,
   validateNumericRangeFields,
@@ -149,6 +150,12 @@ export const PutScoreConfigResponse = APIScoreConfig;
 
 // GET /score-configs
 export const GetScoreConfigsQuery = z.object({
+  // Optional categorical filter on the score config row's `dataType`
+  // (one of CATEGORICAL, NUMERIC, BOOLEAN, TEXT). The `dataType` column
+  // is indexed (`@@index([dataType])` in `packages/shared/prisma/schema.prisma`)
+  // so the filter is cheap. Omitting the param preserves the historical
+  // "all configs" behavior.
+  dataType: z.enum(ScoreConfigDataType).nullish(),
   ...publicApiPaginationZod,
 });
 

--- a/web/src/pages/api/public/score-configs/index.ts
+++ b/web/src/pages/api/public/score-configs/index.ts
@@ -30,9 +30,10 @@ export default withMiddlewares({
     querySchema: GetScoreConfigsQuery,
     responseSchema: GetScoreConfigsResponse,
     fn: async ({ query, auth }) => {
-      const { page, limit } = query;
+      const { page, limit, dataType } = query;
       return await listScoreConfigs({
         projectId: auth.scope.projectId,
+        dataType: dataType ?? undefined,
         page,
         limit,
       });


### PR DESCRIPTION
## Problem

`GET /api/public/score-configs` previously supported only pagination (`?page`, `?limit`). Customers with a large catalog of score configs (custom eval configs grow over time) cannot scope the list to a specific data type — every page scan returns configs of all four types (`CATEGORICAL`, `NUMERIC`, `BOOLEAN`, `TEXT`) mixed together.

The `dataType` field is required when creating a score config (via `POST /api/public/score-configs`) and is indexed in the Prisma schema (`@@index([dataType])` at `packages/shared/prisma/schema.prisma:596`), so a filter is cheap. A `?dataType=BOOLEAN` filter is a real customer use case:

- A team reviewing its eval suite wants to see "all my BOOLEAN score configs" — currently they must paginate the full list and filter client-side.
- An admin auditing its scoring surface wants to see "all my NUMERIC configs for numeric metrics" — no way to scope by type today.
- A user who only uses a single data type (e.g. `NUMERIC` for numeric evals) wants to scope the list to that type without sifting through configs of other types.

The companion `?fromTimestamp` / `?toTimestamp` filter on `createdAt` (PR #17100) is the time-window half of the same story. The `?dataType` filter is the categorical-dimension half. Together they let customers scope the list along both axes.

## Proposed solution

Extend `GetScoreConfigsQuery` to accept an optional `dataType` field using the existing `ScoreConfigDataType` Prisma enum, pipe it through to the shared `listScoreConfigs` repository function as a Prisma `dataType` equality filter, and apply the same `where` to the count query.

- `?dataType=BOOLEAN` returns only configs where `dataType = 'BOOLEAN'`. The same applies for `CATEGORICAL`, `NUMERIC`, and `TEXT`.
- The param is validated against the Prisma enum via `z.enum(ScoreConfigDataType)`; an invalid value returns 400, not 500.
- The pagination `totalItems` reflects the filtered set.
- The filter composes with the existing `projectId` scope — it can only narrow the result set, never widen it.
- Omitting the param preserves the existing "all configs" behavior.
- The shared `listScoreConfigs` function takes an optional `dataType` parameter with a safe `undefined` default, so existing internal callers are unaffected.

## Files

- `web/src/features/public-api/types/score-configs.ts` — add `dataType: z.enum(ScoreConfigDataType).nullish()` on `GetScoreConfigsQuery`.
- `packages/shared/src/server/repositories/score-configs.ts` — extend `listScoreConfigs` to accept and apply the new param as a `dataType` equality filter on both `findMany` and `count`.
- `web/src/pages/api/public/score-configs/index.ts` — pass the new param from the route handler to the service.
- `web/src/__tests__/server/score-configs.servertest.ts` — new `describe("GET /api/public/score-configs dataType filter", ...)` block with 6 cases: omit filter (existing behavior), each of the four data type values (BOOLEAN, NUMERIC, CATEGORICAL, TEXT), an invalid value (400), and a project-scope composition test. Four score configs are created with one of each data type so the filter can be exercised across the full enum.
- `fern/apis/server/definition/score-configs.yml` — document the new query parameter on the `get` endpoint.

## Compatibility

- The new param is optional. Existing API consumers see no change.
- `GetScoreConfigsQuery` is widened (more allowed keys), not narrowed, so no client breaks.
- The shared `listScoreConfigs` function is extended with one new optional parameter; existing callers that do not pass it see no behavior change.
- The route handler is updated to pass the new param through; the Prisma query is the only behavior change.

## Verification

- `prettier --check` on the 4 source files and the Fern yml: clean.
- `tsc --noEmit` from `web/`: no new errors in the changed files.
- `npx fern-api check --api server`: `All checks passed`.
- Standalone structural smoke test (`dataType` field on Zod, `z.enum(ScoreConfigDataType)` import, shared repo typed as `ScoreConfigDataType`, route passes param, Fern spec uses `commons.ScoreConfigDataType`): all assertions pass.
- `pnpm --filter web exec vitest run web/src/__tests__/server/score-configs.servertest.ts` is blocked locally by a pre-existing storybook dep mismatch (`@typescript/typescript6` package-name issue in `.storybook/main.ts`); CI is expected to exercise the new cases on the standard test infrastructure.

## Risk

Minimal. The change adds a filter that narrows the result set; it cannot widen it. The `dataType` column has an index (`@@index([dataType])` at `packages/shared/prisma/schema.prisma:596`), so the filter is cheap. An invalid value is caught by `z.enum` and returns 400, not 500. The shared `listScoreConfigs` function is internal — its existing callers are unaffected because the new parameter is optional with a safe `undefined` default. The `scoreConfigs:read` RBAC action is preserved on the route handler.

## Future work

- Mirror the same `?dataType` filter on the (future) v2 score-configs endpoint.
- Support multi-type filtering via `?dataType=BOOLEAN&dataType=NUMERIC` or a comma-separated list.
- Combine with the time-window filter from PR #17100 for full-dimensional scoping.
- Add a `?name` substring filter (separate concern).

Fixes #17126


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an optional `dataType` filter to the public score-config list endpoint and applies it consistently to retrieval and pagination counts.

- Validates the query against the four score-config data types.
- Preserves project scoping and existing behavior when the filter is omitted.
- Documents the query parameter in the Fern contract.
- Adds endpoint coverage, although overlapping test fixtures currently make four of the new cases fail.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation itself appears sound, but the PR should not merge until the newly added server tests stop creating duplicate matching fixtures.

The nested test setup duplicates BOOLEAN, NUMERIC, and CATEGORICAL records already created by the outer setup, so three parameterized cases and the project-scope case cannot satisfy their exact single-result assertions.

**Files Needing Attention:** web/src/__tests__/server/score-configs.servertest.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Client[Public API client] --> Route[GET /api/public/score-configs]
  Route --> Validation[Validate optional dataType]
  Validation --> Repository[listScoreConfigs]
  Repository --> Scope[projectId plus optional dataType]
  Scope --> Rows[Prisma findMany]
  Scope --> Count[Prisma count]
  Rows --> Response[Filtered page and metadata]
  Count --> Response
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/score-configs.servertest.ts:848-869
**Duplicate fixtures break tests**

The outer `beforeEach` already creates BOOLEAN, NUMERIC, and CATEGORICAL configs in this project, while this nested setup creates another config of each type. The parameterized cases therefore receive two matching rows for those three types instead of the asserted single row. The project-scope case also receives both BOOLEAN configs, so four of the new tests fail their exact result and `totalItems` assertions.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add ?dataType filter t..."](https://github.com/langfuse/langfuse/commit/65c960ee999b67db698d08c3b04052e87767b709) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61176290)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->