### PR TITLE
fix(otel): use LiteLLM dispatched model for routed calls

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2755,6 +2755,7 @@ export class OtelIngestionProcessor {
   ): string | undefined {
     const modelNameKeys = [
       LangfuseOtelSpanAttributes.OBSERVATION_MODEL,
+      "litellm.provider.model",
       "gen_ai.response.model",
       "ai.model.id",
       "gen_ai.request.model",

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -3045,6 +3045,49 @@ describe("OTel Resource Span Mapping", () => {
       expect(langfuseEvents[1].body.name).toBe("right name");
     });
 
+    it("should prefer LiteLLM's dispatched provider model over the router alias", async () => {
+      const resourceSpan = {
+        scopeSpans: [
+          {
+            scope: { name: "litellm" },
+            spans: [
+              {
+                ...defaultSpanProps,
+                attributes: [
+                  {
+                    key: "gen_ai.operation.name",
+                    value: { stringValue: "chat" },
+                  },
+                  {
+                    key: "gen_ai.request.model",
+                    value: { stringValue: "router" },
+                  },
+                  {
+                    key: "gen_ai.response.model",
+                    value: { stringValue: "router" },
+                  },
+                  {
+                    key: "litellm.provider.model",
+                    value: { stringValue: "openai/gpt-4o-mini" },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const langfuseEvents = await convertOtelSpanToIngestionEvent(
+        resourceSpan,
+        new Set(),
+      );
+      const observationEvent = langfuseEvents.find(
+        (event) => event.type !== "trace-create",
+      );
+
+      expect(observationEvent?.body.model).toBe("openai/gpt-4o-mini");
+    });
+
     it.each([
       [
         "should cast input_tokens from string to number",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17128 app preview](https://pr-17128.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

For LiteLLM OTel v2 spans, maps `litellm.provider.model` to the Langfuse observation model ahead of the request/response aliases. This preserves the actual provider model selected by LiteLLM routing while keeping explicit Langfuse model overrides and all existing generic fallbacks.

A separate `isrouted` field is unnecessary: LiteLLM's vendor attributes remain available in observation metadata, while the dispatched model directly fixes attribution and model-price matching.

Scope: LiteLLM's native `success_callback: ["langfuse"]` path does not emit this OTel attribute and must be corrected upstream if that is the reporter's setup.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm --filter web run test 'src/__tests__/server/api/otel/otelMapping.servertest.ts'` — `Tests 260 passed | 1 skipped (261)`
- `pnpm --filter worker run test 'src/queues/__tests__/otelToObservationForEval.test.ts'` — `Tests 25 passed (25)`
- `pnpm exec turbo run lint --force` — `Tasks: 7 successful, 7 total`; `Cached: 0 cached, 7 total`
- `pnpm exec knip` — exited 0 with no findings

No documentation update is required because this consumes an existing LiteLLM OTel attribute without changing Langfuse's public API.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15987](https://linear.app/clickhouse/issue/LFE-15987/litellm-integration-should-state-the-used-model-in-trace-not-router-as)

<div><a href="https://cursor.com/agents/bc-10991f20-c800-4e6b-a3dd-89f79fa69048?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10991f20-c800-4e6b-a3dd-89f79fa69048&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds regression coverage asserting that LiteLLM’s dispatched provider model takes precedence over router aliases during OpenTelemetry observation mapping.

- Adds a single-span LiteLLM fixture containing request, response, and dispatched-provider model attributes.
- Asserts that the normalized observation uses the dispatched provider model.
- Does not include the production mapping change required to satisfy the new assertion.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR is not safe to merge until the production OpenTelemetry model mapping recognizes `litellm.provider.model`, allowing the new regression test to pass.

The new fixture supplies a recognized response model of `"router"`, while the production precedence list never examines the LiteLLM provider attribute, so conversion returns `"router"` and the added assertion fails.

**Files Needing Attention:** web/src/__tests__/server/api/otel/otelMapping.servertest.ts; packages/shared/src/server/otel/OtelIngestionProcessor.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/api/otel/otelMapping.servertest.ts:3088
**Provider model remains unmapped**

This regression test cannot pass because the production model precedence list does not include `litellm.provider.model`. With this fixture, `extractModelName` selects `gen_ai.response.model` and returns `"router"` instead of the asserted provider model, so the intended LiteLLM routing bug remains unfixed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(otel): cover LiteLLM routed model p..."](https://github.com/langfuse/langfuse/commit/b98534df8e16dff230e32f4803d0ea9242914b9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61177596)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Trace and observation ingestion](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-observation-ingestion.md)

<!-- /greptile_comment -->