### PR TITLE
fix(otel): normalize official cache-write usage

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -3065,6 +3065,7 @@ export class OtelIngestionProcessor {
       rawUsageDetails["input_cached_tokens"];
     const cacheCreationTokens =
       rawUsageDetails["cache_creation.input_tokens"] ??
+      rawUsageDetails["cache_write.input_tokens"] ??
       rawUsageDetails["cache_creation_input_tokens"] ??
       rawUsageDetails["cache_write_tokens"] ??
       rawUsageDetails["details.cache_write_tokens"] ??
@@ -3098,6 +3099,7 @@ export class OtelIngestionProcessor {
             "prompt_details.cache_read",
             "input_cached_tokens",
             "cache_creation.input_tokens",
+            "cache_write.input_tokens",
             "cache_creation_input_tokens",
             "cache_write_tokens",
             "details.cache_write_tokens",

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -8109,6 +8109,77 @@ describe("OTel Resource Span Mapping", () => {
       expect(usageDetails.output_reasoning_tokens).toBe(25);
       expect(usageDetails["reasoning.output_tokens"]).toBeUndefined();
     });
+
+    it("should normalize the official cache-write token attribute", async () => {
+      const traceId = "abcdef1234567890abcdef1234567893";
+      const officialCacheUsageSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "service.name",
+              value: { stringValue: "test-service" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "opentelemetry",
+              version: "1.0.0",
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from("1234567890abcde2", "hex"),
+                name: "official-cache-usage",
+                kind: 1,
+                startTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                endTimeUnixNano: {
+                  low: 2000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "gen_ai.usage.input_tokens",
+                    value: { intValue: { low: 300, high: 0, unsigned: false } },
+                  },
+                  {
+                    key: "gen_ai.usage.cache_read.input_tokens",
+                    value: { intValue: { low: 40, high: 0, unsigned: false } },
+                  },
+                  {
+                    key: "gen_ai.usage.cache_write.input_tokens",
+                    value: { intValue: { low: 25, high: 0, unsigned: false } },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        officialCacheUsageSpan,
+        new Set(),
+      );
+      const observationEvent = events.find(
+        (event) =>
+          event.type === "generation-create" || event.type === "span-create",
+      );
+
+      expect(observationEvent?.body.usageDetails).toEqual({
+        input: 235,
+        input_cached_tokens: 40,
+        input_cache_creation: 25,
+      });
+    });
+
     it("should normalize raw Anthropic cache_read_input_tokens / cache_creation_input_tokens into Langfuse canonical keys", async () => {
       // flat Anthropic cache spellings must map to cache aliases, not opaque passthrough buckets
       const traceId = "abcdef1234567890abcdef1234567893";

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -190,6 +190,22 @@ describe("Token Cost Calculation", () => {
     expect(costs.total_cost).toBe(9.0);
   });
 
+  it("should apply the configured cache-creation price", () => {
+    const costs = (IngestionService as any).calculateUsageCosts(
+      [
+        {
+          price: new Decimal(0.00000375),
+          usageType: "input_cache_creation",
+        },
+      ],
+      { provided_cost_details: {} },
+      { input_cache_creation: 25 },
+    );
+
+    expect(costs.cost_details.input_cache_creation).toBe(0.00009375);
+    expect(costs.total_cost).toBe(0.00009375);
+  });
+
   it("should correctly calculate token costs with user provided costs", async () => {
     const prices = await prisma.price.findMany({
       where: {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17129 app preview](https://pr-17129.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Normalizes the official `gen_ai.usage.cache_write.input_tokens` OpenTelemetry attribute into the canonical `input_cache_creation` bucket. This subtracts cache writes from inclusive input usage, prevents aggregate double counting, and allows the configured cache-creation price to match.

Impacted packages: `@langfuse/shared`, `web`, `worker`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- Red phase reproduced the bug: received `{ input: 260, input_cached_tokens: 40, "cache_write.input_tokens": 25 }` instead of canonical `{ input: 235, input_cached_tokens: 40, input_cache_creation: 25 }`.
- OTel regression: `Test Files 1 passed (1)`; `Tests 1 passed | 260 skipped (261)`
- Cache pricing regression: `Test Files 1 passed (1)`; `Tests 1 passed | 30 skipped (31)`
- `pnpm exec turbo run lint --force`: `Tasks: 7 successful, 7 total`; `Cached: 0 cached, 7 total`
- `pnpm run typecheck`: `Tasks: 8 successful, 8 total`; `Cached: 2 cached, 8 total`
- `pnpm exec knip`: exit code 0

No documentation update is required; this aligns ingestion with the existing canonical usage key and pricing contract.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-16018](https://linear.app/clickhouse/issue/LFE-16018/otel-extractor-official-gen-aiusagecache-writeinput-tokens-missing)

<div><a href="https://cursor.com/agents/bc-1b943d9e-2564-4f88-ad6c-73365f378e68?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b943d9e-2564-4f88-ad6c-73365f378e68&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds regression coverage for the official OpenTelemetry cache-write usage attribute and cache-creation pricing.

- Adds an OTel mapping test expecting the official attribute to become the canonical `input_cache_creation` bucket.
- Adds a worker unit test for applying a configured cache-creation rate.
- The corresponding extractor change is absent, so the new mapping regression test does not pass against the implementation in this PR.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR is not safe to merge because its new OTel regression test expects normalization behavior that the production extractor still lacks.

The official `cache_write.input_tokens` spelling is absent from the extractor’s cache-creation aliases, so the new test receives an opaque field and incorrect canonical input buckets.

**Files Needing Attention:** web/src/__tests__/server/api/otel/otelMapping.servertest.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/api/otel/otelMapping.servertest.ts:8176-8180
**Extractor Fix Is Missing**

This test expects `gen_ai.usage.cache_write.input_tokens` to normalize to `input_cache_creation`, but the production extractor does not recognize `cache_write.input_tokens` as a cache-creation alias. It instead keeps that value under an opaque key, leaves `input` at 300, and omits `input_cache_creation`, so this regression test fails rather than delivering the stated fix.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(otel): cover official cache-write u..."](https://github.com/langfuse/langfuse/commit/e40df42ce8bb9dc145759abb4d8d8f91999b01c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61177968)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->