### PR TITLE
fix(web): stop IME composition text from duplicating in SearchInput

### DIFF
--- a/web/src/components/design-system/SearchInput/SearchInput.clienttest.tsx
+++ b/web/src/components/design-system/SearchInput/SearchInput.clienttest.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SearchInput } from "./SearchInput";
+
+const noop = () => {};
+
+describe("SearchInput", () => {
+  it("suppresses onChange while an IME composition is in progress and commits once at compositionEnd", () => {
+    const onChange = vi.fn();
+    render(
+      <SearchInput
+        value=""
+        onChange={onChange}
+        onSubmit={noop}
+        placeholder="Search..."
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("Search...");
+
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: "内" } });
+    fireEvent.change(input, { target: { value: "内部" } });
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.compositionEnd(input, { target: { value: "内部" } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("内部");
+  });
+
+  it("still calls onChange immediately for plain (non-IME) typing", () => {
+    const onChange = vi.fn();
+    render(
+      <SearchInput
+        value=""
+        onChange={onChange}
+        onSubmit={noop}
+        placeholder="Search..."
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Search..."), {
+      target: { value: "abc" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith("abc");
+  });
+});

--- a/web/src/components/design-system/SearchInput/SearchInput.tsx
+++ b/web/src/components/design-system/SearchInput/SearchInput.tsx
@@ -55,63 +55,77 @@ export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
       dropdown,
     },
     ref,
-  ) => (
-    <div className={searchInputVariants({ size })}>
-      <button
-        type="button"
-        aria-label="Search"
-        disabled={disabled}
-        onClick={() => onSubmit(value)}
-        className="text-foreground-tertiary hover:bg-accent hover:text-accent-foreground flex aspect-square shrink-0 items-center justify-center disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        <Search className="h-4 w-4" />
-      </button>
-      <input
-        ref={ref}
-        type="search"
-        data-1p-ignore
-        value={value}
-        placeholder={placeholder}
-        disabled={disabled}
-        autoFocus={autoFocus}
-        onChange={(event) => onChange(event.currentTarget.value)}
-        onBlur={() => onBlur?.(value)}
-        onKeyDown={(event) => {
-          if (event.key === "Enter") onSubmit(value);
-        }}
-        className="placeholder:text-foreground-tertiary disabled:bg-muted/50 min-w-0 flex-1 appearance-none border-0 bg-transparent py-1 pr-2 pl-0 text-sm shadow-none outline-hidden focus:border-0 focus:shadow-none focus:ring-0 focus:ring-offset-0 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&::-webkit-search-cancel-button]:cursor-pointer"
-      />
-      {dropdown && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              disabled={disabled}
-              className="hover:bg-accent hover:text-accent-foreground flex w-30 shrink-0 items-center justify-between gap-1 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <span className="flex min-w-0 items-center gap-1">
-                <span
-                  className="truncate"
-                  title={
-                    typeof dropdown.label === "string"
-                      ? dropdown.label
-                      : undefined
-                  }
-                >
-                  {dropdown.label}
+  ) => {
+    const [isComposing, setIsComposing] = React.useState(false);
+    return (
+      <div className={searchInputVariants({ size })}>
+        <button
+          type="button"
+          aria-label="Search"
+          disabled={disabled}
+          onClick={() => onSubmit(value)}
+          className="text-foreground-tertiary hover:bg-accent hover:text-accent-foreground flex aspect-square shrink-0 items-center justify-center disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Search className="h-4 w-4" />
+        </button>
+        <input
+          ref={ref}
+          type="search"
+          data-1p-ignore
+          value={value}
+          placeholder={placeholder}
+          disabled={disabled}
+          autoFocus={autoFocus}
+          onChange={(event) => {
+            // Skip mid-composition updates (IME input, e.g. pinyin): committing
+            // each intermediate value here re-renders the input with a `value`
+            // prop that races the browser's own composition buffer, which is
+            // what causes composed characters to duplicate while typing.
+            if (!isComposing) onChange(event.currentTarget.value);
+          }}
+          onCompositionStart={() => setIsComposing(true)}
+          onCompositionEnd={(event) => {
+            setIsComposing(false);
+            onChange(event.currentTarget.value);
+          }}
+          onBlur={() => onBlur?.(value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") onSubmit(value);
+          }}
+          className="placeholder:text-foreground-tertiary disabled:bg-muted/50 min-w-0 flex-1 appearance-none border-0 bg-transparent py-1 pr-2 pl-0 text-sm shadow-none outline-hidden focus:border-0 focus:shadow-none focus:ring-0 focus:ring-offset-0 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&::-webkit-search-cancel-button]:cursor-pointer"
+        />
+        {dropdown && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                disabled={disabled}
+                className="hover:bg-accent hover:text-accent-foreground flex w-30 shrink-0 items-center justify-between gap-1 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <span className="flex min-w-0 items-center gap-1">
+                  <span
+                    className="truncate"
+                    title={
+                      typeof dropdown.label === "string"
+                        ? dropdown.label
+                        : undefined
+                    }
+                  >
+                    {dropdown.label}
+                  </span>
+                  {dropdown.labelAccessory}
                 </span>
-                {dropdown.labelAccessory}
-              </span>
-              <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {dropdown.content}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
-    </div>
-  ),
+                <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {dropdown.content}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+    );
+  },
 );
 
 SearchInput.displayName = "SearchInput";


### PR DESCRIPTION
## What does this PR do?

Fixes the frontend half of #15072 ("Tracing search has Unicode compatibility and Chinese input binding issues"). The SQL/backend half of that issue is already covered separately by #15207, which explicitly leaves this half — the search-bar composer duplicating characters while typing via an IME (e.g. pinyin → Chinese) — for a follow-up.

**Root cause.** `SearchInput` (`web/src/components/design-system/SearchInput/SearchInput.tsx`) is a fully controlled `<input>` that calls `onChange` on every native `change` event, including the intermediate events fired while an IME composition is still in progress. Re-rendering the input with a new `value` prop mid-composition races the browser's own composition buffer, which causes the composed characters to duplicate (`内部` becomes `内部内部`). This affects every consumer of `SearchInput` — the classic table search field, trace/session search, etc.

**Fix.** Track composition state and skip `onChange` while composing, committing once on `compositionEnd` instead — the same pattern already used correctly by the newer grammar-based search bar composer (`SearchComposer.tsx`, which was unaffected by this bug).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Validation

Added two tests to a new `SearchInput.clienttest.tsx`, written failing-first against the buggy component:

1. Simulates an IME composition (`compositionStart` → intermediate `change` events → `compositionEnd`) and asserts `onChange` is not called mid-composition and is called exactly once with the final committed value at `compositionEnd`. This failed against the pre-fix component (`onChange` was called on every intermediate `change` event) and passes after the fix.
2. Confirms plain (non-IME) typing still calls `onChange` immediately, unaffected by the composition guard.

```
✓ |client| src/components/design-system/SearchInput/SearchInput.clienttest.tsx (2 tests)
```

Also ran the existing consumer test suite (`data-table-toolbar.clienttest.tsx`, which renders `SearchInput`) alongside it to check for regressions:

```
✓ |client| src/components/table/data-table-toolbar.clienttest.tsx (11 tests)
Test Files  2 passed (2)
     Tests  13 passed (13)
```

`eslint` (targeted at the two changed files, `--max-warnings 0`) and `tsc --noEmit` (full `web` typecheck) both pass with no output/errors.

Not covered here: the SQL-side matching bug in #15207 is a separate, already-open fix.

## Checklist

- [x] Read the contributing guide.
- [x] Added behavioral regression tests and confirmed pre-fix failure.
- [x] Checked formatting, lint, types.
- [x] Checked documentation impact: no user-facing configuration or API contract changed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GquJUuKDd24udSA5GTXBMt

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes SearchInput to defer controlled-value updates during IME composition and adds client tests for composition and ordinary typing.
- Suppresses intermediate `onChange` callbacks while composition is active.
- Commits the final DOM value when composition ends.
- Preserves immediate callbacks for non-IME input.
- The Enter submission path still needs to account for composing key events.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not safe to merge until Enter presses used to commit an active IME composition are prevented from submitting the stale query.

Intermediate changes are intentionally withheld from the controlled value, but the Enter handler still submits that old value during composition, breaking the primary keyboard submission path for IME users.

**Files Needing Attention:** web/src/components/design-system/SearchInput/SearchInput.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/design-system/SearchInput/SearchInput.tsx:92-94
**Composing Enter Submits Stale Query**

Users commonly press Enter to commit an IME candidate. The new guard keeps the controlled `value` at its pre-composition value until `compositionEnd`, but this handler submits that stale value on the composing Enter keydown. As a result, it can submit an empty or previous query; the later `onChange` only updates the draft and does not redo the search. Ignore Enter while `event.nativeEvent.isComposing` is true, as `SearchComposer` does, or submit the committed live value after composition ends.

```suggestion
          onKeyDown={(event) => {
            if (event.nativeEvent.isComposing) return;
            if (event.key === "Enter") onSubmit(value);
          }}
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): stop IME composition text from..."](https://github.com/langfuse/langfuse/commit/5bb63481a37e08f78771580b9f01ccf0ec1f40dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61180832)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->