### PR TITLE
fix(seeder): write the evaluator columns in the bulk scores insert

### DIFF
--- a/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
+++ b/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
@@ -364,6 +364,8 @@ export class ClickHouseQueryBuilder {
         'API' AS source,
         'Generated synthetic score' AS comment,
         map() AS metadata,
+        '' AS evaluator_id,
+        '' AS evaluation_rule_id,
         NULL AS author_user_id,
         NULL AS config_id,
         case 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17131 app preview](https://pr-17131.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Problem

`pnpm run seed -- many-traces` (and any other scenario that seeds scores) inserts traces and observations, then dies:

```
ClickHouseError: Number of columns doesn't match (source: 27 and result: 29).
```

The scenario's readback verification never runs, so the seed leaves a project with traces and observations and **zero scores**.

## Cause

`buildBulkScoresInsert` builds a positional `INSERT INTO scores SELECT …` with no column list. When `evaluator_id` and `evaluation_rule_id` were added to the `scores` table (positions 14 and 15, between `metadata` and `author_user_id`), the builder was not updated, so it offers 27 columns to a 29-column table.

Both new columns are non-nullable `String`, so they take `''` — matching how `long_string_value` is already handled a few lines below.

## Impact beyond local seeding

PR previews seed with this scenario. Their dashboards read the V4 events tables, which are backfilled from `traces`/`observations`, so the missing scores were invisible for a while — but since preview seeding started propagating ClickHouse failures instead of swallowing them, this aborts the seed job outright and the preview's post-seed backfill hook never runs.

## Verification

Ran against a fresh ClickHouse migrated to head (all 48 migrations), before and after:

- **Before:** `Number of columns doesn't match (source: 27 and result: 29)`, no scores written.
- **After:** `verified: {"traces":20,"observations":100,"scores":40}` — the scenario's own readback assertion passes.

`pnpm run lint` → `Tasks: 7 successful, 7 total`. `pnpm run typecheck` → `Tasks: 8 successful, 8 total`.

## Tests

Tests added: 0. There is no test suite for the seeder scripts, and the scenario already asserts its own completeness — it reads every id prefix back and throws `SeedError` on a shortfall, which is exactly what turns this class of bug into a non-zero exit. A unit test asserting the SQL's column count would restate the schema rather than protect behavior; the real guard is running the scenario, which now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR repairs the positional bulk score insert used by seeder scenarios.
- Adds values for `evaluator_id` and `evaluation_rule_id`.
- Restores alignment between the `SELECT` list and the 29-column `scores` table.
- Uses valid empty-string values for the two non-nullable string columns.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge and correctly restores the seeder’s bulk score insertion.

The new expressions align with the current ClickHouse schema’s column order and types, with no actionable failures identified.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(seeder): write the evaluator columns..."](https://github.com/langfuse/langfuse/commit/8518a71ef4794e0f37a010704a438a11f7c583ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61201147)</sub>

<!-- /greptile_comment -->