### PR TITLE
fix(evals): use radio controls for sample observation selection

### DIFF
--- a/web/src/components/Radio/Radio.stories.tsx
+++ b/web/src/components/Radio/Radio.stories.tsx
@@ -1,0 +1,62 @@
+import { fn } from "storybook/test";
+import preview from "../../../.storybook/preview";
+import { Radio } from "./Radio";
+
+const meta = preview.meta({
+  component: Radio,
+  args: {
+    "aria-label": "Sample option",
+    onChange: fn(),
+  },
+});
+
+export const Default = meta.story({});
+
+export const Checked = meta.story({
+  args: {
+    defaultChecked: true,
+  },
+});
+
+export const Disabled = meta.story({
+  args: {
+    disabled: true,
+  },
+});
+
+export const DisabledChecked = meta.story({
+  args: {
+    defaultChecked: true,
+    disabled: true,
+  },
+});
+
+export const Group = meta.story({
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+  render: () => (
+    <fieldset className="flex flex-col gap-2">
+      <legend className="mb-1 text-sm font-bold">Sample observation</legend>
+      {[
+        { label: "Checkout generation", value: "checkout" },
+        { label: "Support generation", value: "support" },
+        { label: "Search generation", value: "search" },
+      ].map((option, index) => (
+        <label
+          key={option.value}
+          className="flex cursor-pointer items-center gap-2 text-sm"
+        >
+          <Radio
+            name="sample-observation"
+            value={option.value}
+            defaultChecked={index === 0}
+          />
+          {option.label}
+        </label>
+      ))}
+    </fieldset>
+  ),
+});

--- a/web/src/components/Radio/Radio.tsx
+++ b/web/src/components/Radio/Radio.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import * as React from "react";
+
+type RadioProps = Pick<
+  React.ComponentPropsWithRef<"input">,
+  | "aria-label"
+  | "checked"
+  | "defaultChecked"
+  | "disabled"
+  | "id"
+  | "name"
+  | "onChange"
+  | "ref"
+  | "required"
+  | "value"
+>;
+
+function Radio({ ref, ...props }: RadioProps) {
+  return (
+    <span className="relative inline-flex h-4 w-4 shrink-0">
+      <input
+        ref={ref}
+        type="radio"
+        className="peer absolute inset-0 m-0 h-4 w-4 cursor-pointer opacity-0 disabled:cursor-not-allowed"
+        {...props}
+      />
+      <span
+        aria-hidden="true"
+        className="border-control-border peer-checked:border-control-fill peer-focus-visible:ring-ring flex h-4 w-4 items-center justify-center rounded-full border shadow-sm peer-focus-visible:ring-1 peer-focus-visible:outline-hidden peer-disabled:opacity-50 peer-checked:[&>span]:opacity-100"
+      >
+        <span className="bg-control-fill h-2 w-2 rounded-full opacity-0" />
+      </span>
+    </span>
+  );
+}
+
+export { Radio };

--- a/web/src/features/evals/v2/components/Evaluators/Testing/components/EvaluatorSampleObservationSelector/EvaluatorSampleObservationSelector.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/Testing/components/EvaluatorSampleObservationSelector/EvaluatorSampleObservationSelector.tsx
@@ -1,8 +1,8 @@
-import { useMemo } from "react";
+import { useId, useMemo } from "react";
 import { Star } from "lucide-react";
 import type { FilterState } from "@langfuse/shared";
 
-import { Checkbox } from "@/src/components/design-system/Checkbox/Checkbox";
+import { Radio } from "@/src/components/Radio/Radio";
 import type { LangfuseColumnDef } from "@/src/components/table/types";
 import type { AbsoluteTimeRange } from "@/src/utils/date-range-utils";
 import { compactNumberFormatter } from "@/src/utils/numbers";
@@ -45,17 +45,20 @@ export function EvaluatorSampleObservationSelector({
   onSelect: (observation: SampleObservation | null) => void;
   onOpenTrace: (observation: SampleObservation) => void;
 }) {
+  const selectionGroupName = useId();
   const leadingColumns = useMemo<LangfuseColumnDef<SampleObservation>[]>(
     () => [
       {
         accessorKey: "sample",
         id: "sample",
         header: () => (
-          <>
+          <div className="flex w-full justify-center">
             <Star aria-hidden="true" className="h-4 w-4" />
             <span className="sr-only">Sample</span>
-          </>
+          </div>
         ),
+        headerBlock: true,
+        headerLabel: "Sample",
         size: 72,
         enableHiding: false,
         isFixedPosition: true,
@@ -63,19 +66,22 @@ export function EvaluatorSampleObservationSelector({
         cellPadding: "none",
         cell: ({ row }) => (
           <label
-            className="flex h-full w-full cursor-pointer items-center px-2"
+            className="flex h-full w-full cursor-pointer items-center justify-center px-2"
+            htmlFor={`sample-selection-${selectionGroupName}-${row.original.id}`}
             onClick={(event) => event.stopPropagation()}
           >
-            <Checkbox
+            <Radio
+              id={`sample-selection-${selectionGroupName}-${row.original.id}`}
+              name={selectionGroupName}
               checked={selectedObservationId === row.original.id}
               aria-label={`Use ${row.original.name ?? row.original.id} as sample`}
-              onCheckedChange={() => onSelect(row.original)}
+              onChange={() => onSelect(row.original)}
             />
           </label>
         ),
       },
     ],
-    [onSelect, selectedObservationId],
+    [onSelect, selectedObservationId, selectionGroupName],
   );
 
   return (


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17134 app preview](https://pr-17134.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What

Replace the sample observation checkboxes with radio controls. The selector always keeps exactly one matching observation selected, so the control now matches the actual behavior.

A shared `Radio` component provides the native radio styling without exposing custom class names. The inputs share one `name`, which keeps their grouping scoped to the selection controls instead of wrapping the full table. Each option has an accessible label, and the selected-row highlight remains unchanged.

This incorporates the original contribution from @luo22833548 in #17098, with the follow-up design review changes.

## Testing

- `pnpm exec turbo run lint --force`
- `pnpm run typecheck`

## Manual check

Open an evaluator setup, go to **Test with sample observations**, and confirm that selecting a row radio clears the previous selection while the chosen row stays highlighted.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns the evaluator sample-observation control with its single-selection behavior.
- Replaces per-row checkboxes with accessible radio items.
- Wraps the observation table in a controlled radio group while preserving table layout.
- Adds `asChild` support to the shared RadioGroup root and retains existing styling for normal usage.
- Keeps selected-row highlighting and selection reconciliation unchanged.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no actionable regression was identified in the changed selection behavior.

The radio items remain connected to the existing selection owner, table row activation is suppressed for control interactions, and the shared RadioGroup retains its prior behavior when `asChild` is not used.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): use radio controls for sampl..."](https://github.com/langfuse/langfuse/commit/d25ee9657af0078635b1b3da43e832b9b12918db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61214990)</sub>

<!-- /greptile_comment -->

