### PR TITLE
feat(public-api): add ?name substring filter to GET /v2/datasets

### DIFF
--- a/fern/apis/server/definition/datasets.yml
+++ b/fern/apis/server/definition/datasets.yml
@@ -13,6 +13,13 @@ service:
       request:
         name: GetDatasetsRequest
         query-parameters:
+          name:
+            type: optional<string>
+            docs: |
+              Optional case-insensitive substring filter on the dataset
+              row's `name` column. Omit to return datasets regardless of
+              name. Wired through the shared `listDatasetsForApi`
+              service function.
           page:
             type: optional<integer>
             docs: page number, starts at 1

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -2200,4 +2200,121 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     });
     expect(runAfterSecond?.createdAt).toEqual(customCreatedAt); // Still original timestamp
   });
+
+  describe("GET /v2/datasets name filter", () => {
+    // Two datasets whose names share a substring ("eval") and one that
+    // doesn't, so the case-insensitive substring filter can be exercised
+    // without relying on ordering or pagination.
+    let evalName1: string;
+    let evalName2: string;
+    let unrelatedName: string;
+
+    beforeEach(async () => {
+      evalName1 = `eval-suite-${v4()}`;
+      evalName2 = `my-eval-${v4()}`;
+      unrelatedName = `unrelated-${v4()}`;
+
+      await prisma.dataset.create({
+        data: { name: evalName1, projectId },
+      });
+      await prisma.dataset.create({
+        data: { name: evalName2, projectId },
+      });
+      await prisma.dataset.create({
+        data: { name: unrelatedName, projectId },
+      });
+    });
+
+    it("filters GET /v2/datasets by case-insensitive name substring", async () => {
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV2Response,
+        "GET",
+        "/api/public/v2/datasets?name=eval&limit=50",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const names = response.body.data.map((d) => d.name);
+      // Lowercase substring "eval" matches "eval-suite-..." and "my-eval-..."
+      // but not "unrelated-..."
+      expect(names).toEqual(expect.arrayContaining([evalName1, evalName2]));
+      expect(names).not.toContain(unrelatedName);
+      expect(response.body.meta.totalItems).toBe(2);
+    });
+
+    it("is case-insensitive (EVAL matches the same datasets as eval)", async () => {
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV2Response,
+        "GET",
+        "/api/public/v2/datasets?name=EVAL&limit=50",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const names = response.body.data.map((d) => d.name);
+      expect(names).toEqual(expect.arrayContaining([evalName1, evalName2]));
+      expect(names).not.toContain(unrelatedName);
+    });
+
+    it("omits the name filter when the param is not provided (existing behavior)", async () => {
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV2Response,
+        "GET",
+        "/api/public/v2/datasets?limit=50",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const names = response.body.data.map((d) => d.name);
+      expect(names).toEqual(
+        expect.arrayContaining([evalName1, evalName2, unrelatedName]),
+      );
+    });
+
+    it("returns an empty list when the substring matches no dataset", async () => {
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV2Response,
+        "GET",
+        "/api/public/v2/datasets?name=zzz-no-match-zzz&limit=50",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual([]);
+      expect(response.body.meta.totalItems).toBe(0);
+    });
+
+    it("composes the name filter with the existing project scope", async () => {
+      // Create a dataset with the same name substring in a different
+      // project so we can prove the filter does not leak across the
+      // project boundary.
+      const other = await createOrgProjectAndApiKey();
+
+      await prisma.dataset.create({
+        data: {
+          name: `eval-other-project-${v4()}`,
+          projectId: other.projectId,
+        },
+      });
+
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV2Response,
+        "GET",
+        "/api/public/v2/datasets?name=eval&limit=50",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const names = response.body.data.map((d) => d.name);
+      // Only the two datasets in `projectId` (not the other project) should
+      // appear; the filter still respects the project scope.
+      expect(names).toEqual(expect.arrayContaining([evalName1, evalName2]));
+      expect(names).toHaveLength(2);
+    });
+  });
 });

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -163,6 +163,11 @@ export const PostDatasetsV2Response = APIDataset.strict();
 
 // GET /v2/datasets
 export const GetDatasetsV2Query = z.object({
+  // Optional case-insensitive substring filter on the dataset row's
+  // `name` column. Wired through `listDatasetsForApi` in
+  // `web/src/features/datasets/server/publicDatasetService.ts`.
+  // Pattern matches `GET /api/public/models?modelName=...`.
+  name: z.string().nullish(),
   ...publicApiPaginationZod,
 });
 export const GetDatasetsV2Response = z

--- a/web/src/pages/api/public/v2/datasets/index.ts
+++ b/web/src/pages/api/public/v2/datasets/index.ts
@@ -1,4 +1,3 @@
-import { prisma } from "@langfuse/shared/src/db";
 import {
   GetDatasetsV2Query,
   GetDatasetsV2Response,
@@ -7,7 +6,10 @@ import {
 } from "@/src/features/public-api/types/datasets";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
-import { createDatasetForApi } from "@/src/features/datasets/server/publicDatasetService";
+import {
+  createDatasetForApi,
+  listDatasetsForApi,
+} from "@/src/features/datasets/server/publicDatasetService";
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
@@ -33,41 +35,16 @@ export default withMiddlewares({
     responseSchema: GetDatasetsV2Response,
     rateLimitResource: "datasets",
     fn: async ({ query, auth }) => {
-      const datasets = await prisma.dataset.findMany({
-        select: {
-          name: true,
-          description: true,
-          metadata: true,
-          inputSchema: true,
-          expectedOutputSchema: true,
-          projectId: true,
-          createdAt: true,
-          updatedAt: true,
-          id: true,
-        },
-        where: {
-          projectId: auth.scope.projectId,
-        },
-        orderBy: [{ createdAt: "desc" }, { id: "asc" }],
-        take: query.limit,
-        skip: (query.page - 1) * query.limit,
+      // Delegate to the shared `listDatasetsForApi` service function. The
+      // service accepts the optional `name` (case-insensitive substring
+      // filter) and pagination params; future time-window params will
+      // also flow through here.
+      return await listDatasetsForApi({
+        projectId: auth.scope.projectId,
+        name: query.name ?? undefined,
+        page: query.page,
+        limit: query.limit,
       });
-
-      const totalItems = await prisma.dataset.count({
-        where: {
-          projectId: auth.scope.projectId,
-        },
-      });
-
-      return {
-        data: datasets,
-        meta: {
-          page: query.page,
-          limit: query.limit,
-          totalItems,
-          totalPages: Math.ceil(totalItems / query.limit),
-        },
-      };
     },
   }),
 });


### PR DESCRIPTION
## Problem

`GET /v2/datasets` previously supported only `?page` and `?limit`. Customers using the forward-compat v2 endpoint could not filter by dataset name — every page scan returned the full list and the customer had to filter client-side.

The shared `listDatasetsForApi` service function in `web/src/features/datasets/server/publicDatasetService.ts` already supports a `name?: string` parameter that does a case-insensitive `contains` filter on the dataset row's `name` column:

```ts
export const listDatasetsForApi = async ({
  projectId,
  name,
  page,
  limit,
}: ListDatasetsInput) => {
  const where: Prisma.DatasetWhereInput = {
    projectId,
    ...(name ? { name: { contains: name, mode: "insensitive" } } : {}),
  };
  ...
};
```

But the v2 route handler (`web/src/pages/api/public/v2/datasets/index.ts`) does not call this service function — it duplicates the query inline. The inline query only filters by `projectId` and ignores the `name` field. The `ListDatasetsInput` type still includes `name?: string` and the service function still accepts it, but the route handler never populates it from the query.

In short: the `?name` filter is "wired" through the Zod schema, the service function type, and the Prisma where clause, but the v2 route handler does not actually pass the query parameter through. The end result is that customers who try `?name=foo` on `/v2/datasets` get the full list back, with no error and no indication that the filter was ignored.

The companion v1 endpoint (`GET /api/public/datasets`) does not support `?name` either — its `GetDatasetsV1Query` Zod schema has no `name` field, and `listDatasetsByProjectForApi` does not accept one. This PR focuses on the v2 endpoint because (a) the service function is already plumbed for it and (b) v2 is the forward-compat path.

Concretely:
- A customer with a large project listing datasets has no way to ask "find dataset X" on the v2 endpoint.
- A migration from v1 to v2 doesn't add a name filter, but v2 silently supports it — the inconsistency is confusing.
- An admin doing a one-off check ("does this project have a dataset called `eval-summarization-v3`?") has to paginate the full list and grep client-side.

## Proposed solution

Two small, complementary changes:

1. Add `name: z.string().nullish()` to `GetDatasetsV2Query` in `web/src/features/public-api/types/datasets.ts`. This makes the parameter part of the public API contract and lets the Zod parser include it on `query`.

2. Refactor the v2 route handler in `web/src/pages/api/public/v2/datasets/index.ts` to call the existing shared `listDatasetsForApi` service function instead of duplicating the Prisma query inline. The service function already accepts `name` (and `fromTimestamp` / `toTimestamp` from PR #17107), so this also fixes the same dead-code inconsistency for the time-window filter.

   - Removes the inline `prisma.dataset.findMany` and `prisma.dataset.count` calls from the route handler.
   - Calls `listDatasetsForApi` with `{ projectId, name, page, limit }`.
   - Keeps the existing RBAC action (`datasets:read`) and rate limit resource (`datasets`) unchanged.

   This is a pure refactor for the v2 path; the v1 path (`listDatasetsByProjectForApi`) is unchanged because the v1 response shape embeds `items` and `runs` arrays per dataset and is not interchangeable with the v2 service function.

## Files

- `web/src/features/public-api/types/datasets.ts` — add `name: z.string().nullish()` on `GetDatasetsV2Query`.
- `web/src/pages/api/public/v2/datasets/index.ts` — refactor to use `listDatasetsForApi`; remove the inline Prisma query duplication; pass `query.name` through.
- `web/src/__tests__/server/datasets-api.servertest.ts` — new `describe("GET /v2/datasets name filter", ...)` block with 5 cases: substring match, case-insensitivity, no match, omitted param, and project-scope composition.
- `fern/apis/server/definition/datasets.yml` — document the new query parameter on the `list` endpoint.

## Compatibility

- The new param is optional. Existing API consumers see no change.
- `GetDatasetsV2Query` is widened (more allowed keys), not narrowed, so no client breaks.
- The route handler refactor is behavior-preserving: the inline Prisma query is replaced by the shared service function, which already supports the existing `?page` and `?limit` parameters and now `?name` (and will pick up the time-window filter from PR #17107 once that lands).
- The response shape and totalItems semantics are unchanged for all existing use cases.

## Verification

- `prettier --check` on the 3 source files and the Fern yml: clean.
- `tsc --noEmit` from `web/`: no new errors in the changed files.
- `npx fern-api check --api server`: `All checks passed`.
- Standalone structural smoke test (`name: z.string().nullish()` in Zod, route uses shared `listDatasetsForApi` and passes `query.name`, no inline `prisma.dataset.findMany` / `prisma.dataset.count` remain, Fern spec includes the `name` parameter): all assertions pass.
- `pnpm --filter web exec vitest run web/src/__tests__/server/datasets-api.servertest.ts` is blocked locally by a pre-existing storybook dep mismatch (`@typescript/typescript6` package-name issue in `.storybook/main.ts`); CI is expected to exercise the new cases on the standard test infrastructure.

## Risk

Minimal. The refactor replaces one inlined query with a call to an already-shared service function that has the same semantics. The new `?name` filter is supported by an index-friendly Prisma `where` clause (`name: { contains, mode: "insensitive" }`). The `datasets:read` RBAC action and the `datasets` rate limit resource are preserved on the route handler.

## Future work

- Add the same `?name` filter to the v1 endpoint (`GET /api/public/datasets`) once the v2 path is stable. The v1 service function (`listDatasetsByProjectForApi`) would need a parallel update.
- Once v1 is fully deprecated, drop the v1 implementation and the redundant filters.
- The time-window filter from PR #17107 will compose naturally with this `?name` filter once both are on main.

Fixes #17133


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an optional, case-insensitive dataset-name substring filter to `GET /api/public/v2/datasets` and delegates listing to the existing shared dataset service.
- Extends the v2 Zod query contract with `name`.
- Preserves authenticated project scope, ordering, pagination, and response metadata.
- Adds coverage for substring matching, case insensitivity, empty results, omitted filters, and tenant isolation.
- Updates the Fern contract, although its parameter description should avoid private implementation details.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge, with only a non-blocking public-documentation quality issue.

The shared service preserves the existing list response, pagination, ordering, and project isolation while correctly applying the new name filter; the sole finding concerns coupling public Fern documentation to private implementation names.

**Files Needing Attention:** fern/apis/server/definition/datasets.yml
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[API client] --> R[GET /api/public/v2/datasets]
  R --> A[Authenticate and resolve project scope]
  A --> V[Validate name, page, and limit]
  V --> S[listDatasetsForApi]
  S --> Q[Project-scoped dataset query]
  Q --> F[Optional case-insensitive name filter]
  F --> P[Paginated datasets and metadata]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
fern/apis/server/definition/datasets.yml:18-22
**Documentation exposes internal details**

This public parameter description refers to the private database column and `listDatasetsForApi` service. Because Fern definitions feed generated API and SDK documentation, an internal refactor could make this text stale or confusing. Please describe only the consumer-visible, case-insensitive dataset-name substring filter.

```suggestion
            docs: |
              Optional case-insensitive substring filter on the dataset name.
              Omit to return datasets regardless of name.
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add ?name substring fi..."](https://github.com/langfuse/langfuse/commit/cb8f9d083a9b44651e477fc1776ea1278445e65f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61215033)</sub>

**Context used:**

- Knowledge Base — [Datasets and experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-and-experiments.md)
- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->