### PR TITLE
test(datasets): persist string IO with object metadata on public create

### DIFF
--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -900,6 +900,43 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     expect(dbDatasetItem?.status).toBe("ARCHIVED");
   });
 
+  it("should persist string IO and object metadata when the client sends an id", async () => {
+    const datasetName = `dataset-${v4()}`;
+    const itemId = v4();
+
+    await makeZodVerifiedAPICall(
+      PostDatasetsV1Response,
+      "POST",
+      "/api/public/datasets",
+      { name: datasetName },
+      auth,
+    );
+
+    const created = await makeZodVerifiedAPICall(
+      PostDatasetItemsV1Response,
+      "POST",
+      "/api/public/dataset-items",
+      {
+        id: itemId,
+        datasetName,
+        input: "input",
+        expectedOutput: "output",
+        metadata: { test: 1 },
+      },
+      auth,
+    );
+
+    expect(created.status).toBe(200);
+    expect(created.body.input).toBe("input");
+    expect(created.body.expectedOutput).toBe("output");
+    expect(created.body.metadata).toEqual({ test: 1 });
+
+    const stored = await prisma.datasetItem.findFirst({
+      where: { id: itemId, projectId },
+    });
+    expect(stored?.metadata).toEqual({ test: 1 });
+  });
+
   it("should create and get a dataset run, include special characters", async () => {
     const dataset = await makeZodVerifiedAPICall(
       PostDatasetsV1Response,

--- a/web/src/__tests__/server/datasets-schema-validation.servertest.ts
+++ b/web/src/__tests__/server/datasets-schema-validation.servertest.ts
@@ -6,6 +6,7 @@ import {
 } from "@/src/__tests__/test-utils";
 import {
   PostDatasetsV2Response,
+  PostDatasetItemsV1Body,
   PostDatasetItemsV1Response,
 } from "@/src/features/public-api/types/datasets";
 import {
@@ -388,6 +389,63 @@ describe("Unit Tests - DatasetItemValidator", () => {
       expect(result.input).toBe(Prisma.DbNull);
       expect(result.expectedOutput).toBe(Prisma.DbNull);
       expect(result.metadata).toBe(Prisma.DbNull);
+    }
+  });
+});
+
+describe("Python SDK create_dataset_item payload with string IO and object metadata", () => {
+  const pythonSdkPayload = {
+    datasetName: "sample-dataset",
+    input: "input",
+    expectedOutput: "output",
+    metadata: { test: 1 },
+    id: "ee850c3c-0000-4000-8000-000000000001",
+  };
+  const validator = new DatasetItemValidator({
+    inputSchema: null,
+    expectedOutputSchema: null,
+  });
+
+  it("PostDatasetItemsV1Body keeps object metadata for string scalar IO", () => {
+    const parsed = PostDatasetItemsV1Body.parse(pythonSdkPayload);
+    expect(parsed.metadata).toEqual({ test: 1 });
+    expect(parsed.input).toBe("input");
+    expect(parsed.expectedOutput).toBe("output");
+  });
+
+  it("preserves metadata through public-API mapping when the client sends id", () => {
+    const parsed = PostDatasetItemsV1Body.parse(pythonSdkPayload);
+    const mappedMetadata = parsed.metadata ?? undefined;
+    expect(mappedMetadata).toEqual({ test: 1 });
+
+    const result = validator.validateAndNormalize({
+      input: parsed.input,
+      expectedOutput: parsed.expectedOutput,
+      metadata: mappedMetadata,
+      normalizeOpts: { sanitizeControlChars: true },
+      validateOpts: { normalizeUndefinedToNull: !parsed.id },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.metadata).toEqual({ test: 1 });
+      expect(result.input).toBe("input");
+      expect(result.expectedOutput).toBe("output");
+    }
+  });
+
+  it("leaves omitted metadata as undefined so Prisma INSERT writes SQL NULL", () => {
+    const result = validator.validateAndNormalize({
+      input: "input",
+      expectedOutput: "output",
+      metadata: undefined,
+      normalizeOpts: { sanitizeControlChars: true },
+      validateOpts: { normalizeUndefinedToNull: false },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.metadata).toBeUndefined();
     }
   });
 });

--- a/web/src/__tests__/server/repositories/dataset-items-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/dataset-items-repository.servertest.ts
@@ -18,6 +18,7 @@ import {
   getDatasetItemVersionHistory,
   getDatasetItemChangesSinceVersion,
   getDatasetItems,
+  createOrgProjectAndApiKey,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
 
@@ -832,6 +833,35 @@ describe("Dataset Items Repository - Versioning Tests", () => {
   });
 
   describe("upsertDatasetItem()", () => {
+    it("should persist string IO plus object metadata with public-API sanitize opts", async () => {
+      const { projectId: createdProjectId } = await createOrgProjectAndApiKey();
+      const datasetId = v4();
+      const itemId = v4();
+      await prisma.dataset.create({
+        data: { id: datasetId, name: v4(), projectId: createdProjectId },
+      });
+
+      const item = await upsertDatasetItem({
+        projectId: createdProjectId,
+        datasetId,
+        datasetItemId: itemId,
+        input: "input",
+        expectedOutput: "output",
+        metadata: { test: 1 },
+        normalizeOpts: { sanitizeControlChars: true },
+        validateOpts: { normalizeUndefinedToNull: false },
+      });
+
+      expect(item.input).toBe("input");
+      expect(item.expectedOutput).toBe("output");
+      expect(item.metadata).toEqual({ test: 1 });
+
+      const stored = await prisma.datasetItem.findFirst({
+        where: { id: itemId, projectId: createdProjectId },
+      });
+      expect(stored?.metadata).toEqual({ test: 1 });
+    });
+
     it("should create new item with version when ID doesn't exist", async () => {
       const datasetId = v4();
       const itemId = v4();


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17137 app preview](https://pr-17137.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Regression tests for public-API dataset item create when the client sends string scalars for `input` / `expectedOutput`, an object for `metadata`, and a client-generated `id` (the Python SDK always sends `id`).

That combination is a valid Fern/JSON payload. The write path must store `{"test": 1}` in Postgres, not omit the column as SQL NULL. Missing or JSON-null `metadata` still becomes SQL NULL; that path is unchanged.

## Type of change

- [x] Tests that lock existing behavior

## Impacted packages

- `web` (server tests)

## Verification

- `pnpm exec vitest run --project server-isolated src/__tests__/server/datasets-schema-validation.servertest.ts -t "Python SDK create_dataset_item payload"`
- `pnpm exec vitest run --project server-isolated src/__tests__/server/repositories/dataset-items-repository.servertest.ts -t "should persist string IO plus object metadata with public-API sanitize opts"`
- Live local `POST /api/public/dataset-items` with `{ input: "input", expectedOutput: "output", metadata: { test: 1 }, id: "<uuid>" }` returned `metadata: {"test": 1}` and Postgres `metadata_is_null = f`

## Mandatory Tasks

- [x] Self-reviewed

## Checklist

- Tests cover the public-API mapping (`metadata ?? undefined`), control-character sanitization, and `normalizeUndefinedToNull: false` when `id` is present
- Prettier and lint ran on commit

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15166](https://linear.app/clickhouse/issue/LFE-15166/dataset-item-metadata-not-saved-for-specific-project)

<div><a href="https://cursor.com/agents/bc-a54f2297-4383-4112-be8b-bf4a22c4f9eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a54f2297-4383-4112-be8b-bf4a22c4f9eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds regression coverage ensuring public dataset-item creation preserves scalar string input/output and object metadata when clients provide their own item ID.
- Exercises the authenticated public HTTP endpoint and verifies both its response and PostgreSQL persistence.
- Verifies request-schema parsing and dataset-item normalization behavior.
- Covers the repository write path with the same public-API normalization options.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; it only adds regression tests, and no actionable correctness, security, or repository-rule issues were identified.

The added tests consistently exercise schema parsing, normalization, the real public API route, repository persistence, and direct database verification for the targeted metadata regression.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    SDK[Python SDK-shaped payload] --> Schema[Public request schema]
    Schema --> API[POST /api/public/dataset-items]
    API --> Normalize[Dataset item validation and normalization]
    Normalize --> Repository[upsertDatasetItem]
    Repository --> PG[(PostgreSQL)]
    PG --> Assert[Verify object metadata persisted]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(datasets): persist string IO with o..."](https://github.com/langfuse/langfuse/commit/3ee8bcaf7daca133497c8b668fc3e339d2ebf730) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61218766)</sub>

**Context used:**

- Knowledge Base — [Datasets and experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-and-experiments.md)
- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->