### PR TITLE
fix(ingestion): preserve explicit zero usage totals

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1965,7 +1965,7 @@ export class IngestionService {
         "usage" in obs.body ? obs.body.usage?.output : undefined;
 
       const newTotalCount =
-        ("usage" in obs.body ? obs.body.usage?.total : undefined) ||
+        ("usage" in obs.body ? obs.body.usage?.total : undefined) ??
         (Object.keys(
           "usageDetails" in obs.body ? (obs.body.usageDetails ?? {}) : {},
         ).length === 0

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1969,7 +1969,7 @@ export class IngestionService {
         (Object.keys(
           "usageDetails" in obs.body ? (obs.body.usageDetails ?? {}) : {},
         ).length === 0
-          ? newInputCount && newOutputCount
+          ? newInputCount != null && newOutputCount != null
             ? newInputCount + newOutputCount
             : (newInputCount ?? newOutputCount)
           : undefined);

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -2197,8 +2197,8 @@ describe("Ingestion end-to-end tests", () => {
             name: "zero-token-generation",
             startTime: new Date().toISOString(),
             usage: {
-              input: 100,
-              output: 50,
+              input: 0,
+              output: 0,
               total: 0,
               unit: "TOKENS",
             },
@@ -2216,11 +2216,55 @@ describe("Ingestion end-to-end tests", () => {
     );
 
     expect(generation.provided_usage_details).toMatchObject({
-      input: 100,
-      output: 50,
+      input: 0,
+      output: 0,
       total: 0,
     });
     expect(generation.usage_details.total).toBe(0);
+  });
+
+  it("should derive the total token count when one of the counts is zero", async () => {
+    const generationId = randomUUID();
+    const traceId = randomUUID();
+
+    await ingestionService.processObservationEventList({
+      projectId,
+      entityId: generationId,
+      createdAtTimestamp: new Date(),
+      observationEventList: [
+        {
+          id: randomUUID(),
+          type: "generation-create",
+          timestamp: new Date().toISOString(),
+          body: {
+            id: generationId,
+            traceId,
+            name: "zero-input-generation",
+            startTime: new Date().toISOString(),
+            usage: {
+              input: 0,
+              output: 50,
+              unit: "TOKENS",
+            },
+            environment,
+          },
+        },
+      ],
+    });
+
+    await clickhouseWriter.flushAll(true);
+
+    const generation = await getClickhouseRecord(
+      TableName.Observations,
+      generationId,
+    );
+
+    expect(generation.provided_usage_details).toMatchObject({
+      input: 0,
+      output: 50,
+      total: 50,
+    });
+    expect(generation.usage_details.total).toBe(50);
   });
 
   it("should update all token counts if update does not contain model name", async () => {

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -2178,6 +2178,51 @@ describe("Ingestion end-to-end tests", () => {
     expect(generation.provided_cost_details.total).toEqual(0.001412);
   });
 
+  it("should preserve an explicitly provided zero total token count", async () => {
+    const generationId = randomUUID();
+    const traceId = randomUUID();
+
+    await ingestionService.processObservationEventList({
+      projectId,
+      entityId: generationId,
+      createdAtTimestamp: new Date(),
+      observationEventList: [
+        {
+          id: randomUUID(),
+          type: "generation-create",
+          timestamp: new Date().toISOString(),
+          body: {
+            id: generationId,
+            traceId,
+            name: "zero-token-generation",
+            startTime: new Date().toISOString(),
+            usage: {
+              input: 100,
+              output: 50,
+              total: 0,
+              unit: "TOKENS",
+            },
+            environment,
+          },
+        },
+      ],
+    });
+
+    await clickhouseWriter.flushAll(true);
+
+    const generation = await getClickhouseRecord(
+      TableName.Observations,
+      generationId,
+    );
+
+    expect(generation.provided_usage_details).toMatchObject({
+      input: 100,
+      output: 50,
+      total: 0,
+    });
+    expect(generation.usage_details.total).toBe(0);
+  });
+
   it("should update all token counts if update does not contain model name", async () => {
     const traceId = randomUUID();
     const generationId = randomUUID();


### PR DESCRIPTION
Fixes #16503

## Summary
- preserve an explicitly provided `usage.total: 0` during legacy ingestion
- add an integration regression test covering zero totals

## Validation
- `pnpm --filter @langfuse/shared build`
- Prettier check passes
- Focused integration test is currently blocked locally because the required ClickHouse and S3 test environment variables/services are not configured
- ESLint could not run because the local `@repo/eslint-plugin` build artifact is missing

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects legacy observation ingestion so an explicitly supplied `usage.total: 0` is treated as data rather than as a missing value.
- Replaces truthiness fallback with nullish fallback when deriving the supplied total.
- Adds an end-to-end ClickHouse regression test confirming both provided and normalized usage retain zero.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the explicit-zero fix remains consistent through downstream usage normalization.

The changed nullish fallback preserves zero without affecting missing-total derivation, and supported ingestion paths validate numeric totals before this code executes. The regression test exercises the reported persistence behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): preserve explicit zero u..."](https://github.com/langfuse/langfuse/commit/428ce7ece82cad6c3fc706122c3a9cabf79f9bda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61220255)</sub>

**Context used:**

- Knowledge Base — [Trace and observation ingestion](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-observation-ingestion.md)

<!-- /greptile_comment -->