### PR TITLE
refactor(web): Fix no-null-render: eval-version-callout.tsx

### DIFF
--- a/web/src/features/evals/components/eval-version-callout.tsx
+++ b/web/src/features/evals/components/eval-version-callout.tsx
@@ -12,7 +12,7 @@ interface EvalVersionCalloutProps {
   content: CalloutContent;
 }
 
-export interface CalloutContent {
+interface CalloutContent {
   title: string;
   description: React.ReactNode;
 }

--- a/web/src/features/evals/components/eval-version-callout.tsx
+++ b/web/src/features/evals/components/eval-version-callout.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @repo/no-null-render */
 import { Alert } from "@/src/components/design-system/Alert/Alert";
 import { AlertTriangle } from "lucide-react";
 import { type EvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilities";
@@ -10,30 +9,25 @@ import {
 } from "@/src/features/evals/utils/typeHelpers";
 
 interface EvalVersionCalloutProps {
-  targetObject: string;
-  evalCapabilities: EvalCapabilities;
+  content: CalloutContent;
 }
 
-interface CalloutContent {
-  visible: boolean;
+export interface CalloutContent {
   title: string;
   description: React.ReactNode;
 }
 
-const getCalloutContent = (
+export const getEvalVersionCalloutContent = (
   targetObject: string,
   evalCapabilities: EvalCapabilities,
-): CalloutContent => {
-  const hidden = { visible: false, title: "", description: "" };
-
+) => {
   // For event/observation target
   if (isEventTarget(targetObject)) {
     if (evalCapabilities.isNewCompatible) {
-      return hidden;
+      return null;
     }
 
     return {
-      visible: true,
       title: "Please verify your SDK version",
       description: (
         <>
@@ -58,7 +52,6 @@ const getCalloutContent = (
   if (isExperimentTarget(targetObject)) {
     if (!evalCapabilities.isNewCompatible) {
       return {
-        visible: true,
         title: "Please verify you are using the Experiment Runner SDK",
         description: (
           <>
@@ -79,7 +72,7 @@ const getCalloutContent = (
       };
     }
 
-    return hidden;
+    return null;
   }
 
   // For dataset target (legacy dataset run methods)
@@ -87,11 +80,10 @@ const getCalloutContent = (
     // Forced-v3 projects keep trace evaluators as their intended experience —
     // no upgrade nag.
     if (evalCapabilities.forceV3Experience) {
-      return hidden;
+      return null;
     }
 
     return {
-      visible: true,
       title: "Legacy low-level SDK methods",
       description: (
         <>
@@ -118,11 +110,10 @@ const getCalloutContent = (
     // Forced-v3 projects keep trace evaluators as their intended experience —
     // no upgrade nag.
     if (evalCapabilities.forceV3Experience) {
-      return hidden;
+      return null;
     }
 
     return {
-      visible: true,
       title: "Consider upgrading to observation evaluators",
       description: (
         <>
@@ -142,19 +133,10 @@ const getCalloutContent = (
     };
   }
 
-  return hidden;
+  return null;
 };
 
-export function EvalVersionCallout({
-  targetObject,
-  evalCapabilities,
-}: EvalVersionCalloutProps) {
-  const content = getCalloutContent(targetObject, evalCapabilities);
-
-  if (!content.visible) {
-    return null;
-  }
-
+export function EvalVersionCallout({ content }: EvalVersionCalloutProps) {
   return (
     <div className="mt-2 w-full max-w-4xl">
       <Alert variant="warning" icon={AlertTriangle}>

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -63,7 +63,10 @@ import {
 } from "@/src/utils/date-range-utils";
 import { type PartialConfig } from "@/src/features/evals/types";
 import { type EvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilities";
-import { EvalVersionCallout } from "@/src/features/evals/components/eval-version-callout";
+import {
+  EvalVersionCallout,
+  getEvalVersionCalloutContent,
+} from "@/src/features/evals/components/eval-version-callout";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import {
   Dialog,
@@ -566,6 +569,10 @@ export const InnerEvaluatorForm = (props: {
   const previewTableVisible = !props.disabled && !props.hidePreviewTable;
   const previewAlreadyShowsSdkWarning =
     previewTableVisible && shouldShowEventsPreview;
+  const evalVersionCalloutContent = getEvalVersionCalloutContent(
+    watchedTarget,
+    props.evalCapabilities,
+  );
   const eventsPreviewFilterState = useMemo(
     () =>
       shouldShowExperimentEventsPreview
@@ -1002,11 +1009,9 @@ export const InnerEvaluatorForm = (props: {
             {!props.hideTargetSelection &&
               props.mode !== "edit" &&
               !props.disabled &&
-              !previewAlreadyShowsSdkWarning && (
-                <EvalVersionCallout
-                  targetObject={watchedTarget}
-                  evalCapabilities={props.evalCapabilities}
-                />
+              !previewAlreadyShowsSdkWarning &&
+              evalVersionCalloutContent && (
+                <EvalVersionCallout content={evalVersionCalloutContent} />
               )}
 
             {!props.hideAdvancedSettings &&


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17143 app preview](https://pr-17143.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors evaluator version-callout visibility so nullable content is computed by the parent and the presentation component always receives renderable content.

- Replaces hidden sentinel objects with `null`.
- Moves conditional rendering into `InnerEvaluatorForm`.
- Exports the content helper and content type.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the refactor preserves existing callout visibility and content behavior.

No concrete behavioral regression, broken caller, security issue, or repository-rule violation remains; nullable content now prevents the callout component itself from returning null.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): Fix non-null-render: eval..."](https://github.com/langfuse/langfuse/commit/9840898c4daf6a4499a597c412260ff88530a61d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61292115)</sub>

<!-- /greptile_comment -->