### PR TITLE
feat(public-api): add ?name substring filter to GET /api/public/datasets (v1)

### DIFF
--- a/fern/apis/server/definition/datasets.yml
+++ b/fern/apis/server/definition/datasets.yml
@@ -20,6 +20,28 @@ service:
             type: optional<integer>
             docs: limit of items per page
       response: PaginatedDatasets
+    list-legacy:
+      method: GET
+      docs: |
+        Get all datasets (deprecated v1 endpoint, also returns `items` and `runs` arrays per dataset).
+        New integrations should use the v2 endpoint above.
+      path: /datasets
+      request:
+        name: GetDatasetsLegacyRequest
+        query-parameters:
+          name:
+            type: optional<string>
+            docs: |
+              Optional case-insensitive substring filter on the dataset
+              row's `name` column. Omit to return datasets regardless of
+              name. Mirrors the v2 filter added in PR #17135.
+          page:
+            type: optional<integer>
+            docs: page number, starts at 1
+          limit:
+            type: optional<integer>
+            docs: limit of items per page
+      response: PaginatedDatasetsLegacy
     get:
       method: GET
       docs: Get a dataset
@@ -80,6 +102,22 @@ types:
     properties:
       data: list<commons.Dataset>
       meta: pagination.MetaResponse
+  PaginatedDatasetsLegacy:
+    properties:
+      data:
+        type: list<DatasetLegacy>
+        docs: Datasets with their item ids and run names embedded (v1 response shape).
+      meta: pagination.MetaResponse
+  DatasetLegacy:
+    docs: Dataset with the v1 response shape that embeds item ids and run names.
+    extends: commons.Dataset
+    properties:
+      items:
+        type: list<string>
+        docs: Dataset item ids belonging to this dataset.
+      runs:
+        type: list<string>
+        docs: Names of runs that have been executed against this dataset.
   CreateDatasetRequest:
     properties:
       name: string

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -2200,4 +2200,121 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     });
     expect(runAfterSecond?.createdAt).toEqual(customCreatedAt); // Still original timestamp
   });
+
+  describe("GET /api/public/datasets name filter (v1)", () => {
+    // Two datasets whose names share a substring ("eval") and one that
+    // doesn't, so the case-insensitive substring filter can be exercised
+    // without relying on ordering or pagination.
+    let v1EvalName1: string;
+    let v1EvalName2: string;
+    let v1UnrelatedName: string;
+
+    beforeEach(async () => {
+      v1EvalName1 = `v1-eval-suite-${v4()}`;
+      v1EvalName2 = `v1-my-eval-${v4()}`;
+      v1UnrelatedName = `v1-unrelated-${v4()}`;
+
+      await prisma.dataset.create({
+        data: { name: v1EvalName1, projectId },
+      });
+      await prisma.dataset.create({
+        data: { name: v1EvalName2, projectId },
+      });
+      await prisma.dataset.create({
+        data: { name: v1UnrelatedName, projectId },
+      });
+    });
+
+    it("filters GET /api/public/datasets by case-insensitive name substring", async () => {
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV1Response,
+        "GET",
+        "/api/public/datasets?name=eval&limit=50",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const names = response.body.data.map((d) => d.name);
+      // Lowercase substring "eval" matches "v1-eval-suite-..." and "v1-my-eval-..."
+      // but not "v1-unrelated-..."
+      expect(names).toEqual(expect.arrayContaining([v1EvalName1, v1EvalName2]));
+      expect(names).not.toContain(v1UnrelatedName);
+      expect(response.body.meta.totalItems).toBe(2);
+    });
+
+    it("is case-insensitive (EVAL matches the same datasets as eval)", async () => {
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV1Response,
+        "GET",
+        "/api/public/datasets?name=EVAL&limit=50",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const names = response.body.data.map((d) => d.name);
+      expect(names).toEqual(expect.arrayContaining([v1EvalName1, v1EvalName2]));
+      expect(names).not.toContain(v1UnrelatedName);
+    });
+
+    it("omits the name filter when the param is not provided (existing behavior)", async () => {
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV1Response,
+        "GET",
+        "/api/public/datasets?limit=50",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const names = response.body.data.map((d) => d.name);
+      expect(names).toEqual(
+        expect.arrayContaining([v1EvalName1, v1EvalName2, v1UnrelatedName]),
+      );
+    });
+
+    it("returns an empty list when the substring matches no dataset", async () => {
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV1Response,
+        "GET",
+        "/api/public/datasets?name=zzz-no-match-zzz&limit=50",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual([]);
+      expect(response.body.meta.totalItems).toBe(0);
+    });
+
+    it("composes the name filter with the existing project scope", async () => {
+      // Create a dataset with the same name substring in a different
+      // project so we can prove the filter does not leak across the
+      // project boundary.
+      const other = await createOrgProjectAndApiKey();
+
+      await prisma.dataset.create({
+        data: {
+          name: `v1-eval-other-project-${v4()}`,
+          projectId: other.projectId,
+        },
+      });
+
+      const response = await makeZodVerifiedAPICall(
+        GetDatasetsV1Response,
+        "GET",
+        "/api/public/datasets?name=eval&limit=50",
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const names = response.body.data.map((d) => d.name);
+      // Only the two datasets in `projectId` (not the other project) should
+      // appear; the filter still respects the project scope.
+      expect(names).toEqual(expect.arrayContaining([v1EvalName1, v1EvalName2]));
+      expect(names).toHaveLength(2);
+    });
+  });
 });

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -378,11 +378,25 @@ export const getDatasetByIdForApi = async ({
 
 export const listDatasetsByProjectForApi = async ({
   projectId,
+  name,
   page,
   limit,
 }: ListDatasetsV1Input) => {
   const shouldReadLegacyDatasetRuns =
     env.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "events_only";
+
+  // Optional case-insensitive substring filter on `name`. The `name`
+  // column is the second part of the unique key `(projectId, name)` so
+  // the filter is index-friendly.
+  const nameFilter = name
+    ? { name: { contains: name, mode: "insensitive" as const } }
+    : {};
+
+  const where = {
+    projectId,
+    ...nameFilter,
+  };
+
   const datasets = await prisma.dataset.findMany({
     select: {
       name: true,
@@ -405,7 +419,7 @@ export const listDatasetsByProjectForApi = async ({
           }
         : {}),
     },
-    where: { projectId },
+    where,
     orderBy: [{ createdAt: "desc" }, { id: "asc" }],
     take: limit,
     skip: (page - 1) * limit,
@@ -430,7 +444,7 @@ export const listDatasetsByProjectForApi = async ({
   }
 
   const totalItems = await prisma.dataset.count({
-    where: { projectId },
+    where,
   });
 
   return {

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -316,6 +316,11 @@ export const PostDatasetsV1Response = APIDataset.extend({
 
 // GET /datasets
 export const GetDatasetsV1Query = z.object({
+  // Optional case-insensitive substring filter on the dataset row's
+  // `name` column. Wired through `listDatasetsByProjectForApi` in
+  // `web/src/features/datasets/server/publicDatasetService.ts`.
+  // Mirrors the v2 filter added in PR #17135.
+  name: z.string().nullish(),
   ...paginationZod,
 });
 export const GetDatasetsV1Response = z

--- a/web/src/pages/api/public/datasets/index.ts
+++ b/web/src/pages/api/public/datasets/index.ts
@@ -41,6 +41,7 @@ export default withMiddlewares({
     fn: async ({ query, auth }) =>
       await listDatasetsByProjectForApi({
         projectId: auth.scope.projectId,
+        name: query.name ?? undefined,
         page: query.page,
         limit: query.limit,
       }),


### PR DESCRIPTION
## Problem

`GET /api/public/datasets` previously supported only `?page` and `?limit`. Customers using the v1 endpoint (which serves the legacy response shape with embedded `items` and `runs` arrays per dataset) could not filter by dataset name — every page scan returned the full list and the customer had to filter client-side.

The companion v2 endpoint (`GET /v2/datasets`) was just fixed in PR #17135 to accept the optional `?name` case-insensitive substring filter, wired through the shared `listDatasetsForApi` service function. The v2 route handler was also refactored to use that shared service function instead of duplicating the Prisma query inline.

The v1 endpoint has its own service function (`listDatasetsByProjectForApi` in `web/src/features/datasets/server/publicDatasetService.ts`) that does not currently accept a `name` parameter. Without a corresponding v1 change, the v1 and v2 endpoints behave asymmetrically: a customer using `?name=eval` on `/v2/datasets` gets a filtered list, but the same query on `/api/public/datasets` returns the full list with no error and no indication the filter was dropped.

Concretely:
- A customer with a large project listing datasets has no way to ask "find dataset X" on the v1 endpoint.
- A migration from v1 to v2 silently changes the behavior of `?name=...` (v1 ignored it, v2 honors it) — confusing for customers who upgrade.
- An admin doing a one-off check ("does this project have a dataset called `eval-summarization-v3`?") has to paginate the full v1 list and grep client-side.

## Proposed solution

Two small, complementary changes:

1. Add `name: z.string().nullish()` to `GetDatasetsV1Query` in `web/src/features/public-api/types/datasets.ts`. This makes the parameter part of the public API contract and lets the Zod parser include it on `query`.

2. Extend the v1 service function `listDatasetsByProjectForApi` in `web/src/features/datasets/server/publicDatasetService.ts` to accept the new `name?: string` parameter and apply a case-insensitive `contains` filter on the dataset row's `name` column. The filter is added to both the `findMany` and the `count` query so the result set and `totalItems` stay consistent.

   The v1 service function continues to be the only caller of the v1 path (unlike v2, which had been duplicating the Prisma query inline until PR #17135), so this is a focused additive change to the existing function.

   The `?name` filter is a case-insensitive substring (PostgreSQL `mode: "insensitive"`), the same shape as the v2 filter added in PR #17135.

## Files

- `web/src/features/public-api/types/datasets.ts` — add `name: z.string().nullish()` on `GetDatasetsV1Query`.
- `web/src/features/datasets/server/publicDatasetService.ts` — extend `listDatasetsByProjectForApi` to accept and apply the new `name` parameter on both `findMany` and `count`.
- `web/src/pages/api/public/datasets/index.ts` — pass the new param from the route handler to the service.
- `web/src/__tests__/server/datasets-api.servertest.ts` — new `describe("GET /api/public/datasets name filter (v1)", ...)` block with 5 cases: substring match, case-insensitivity, no match, omitted param, and project-scope composition.
- `fern/apis/server/definition/datasets.yml` — add the v1 `list-legacy` endpoint definition (the v1 list was missing from the spec on upstream main), document the new `name` query parameter on it, and add a new `PaginatedDatasetsLegacy` response type with a `DatasetLegacy` type that extends `commons.Dataset` with the v1 `items` and `runs` arrays.

## Compatibility

- The new param is optional. Existing API consumers see no change.
- `GetDatasetsV1Query` is widened (more allowed keys), not narrowed, so no client breaks.
- The v1 service function is extended with one new optional parameter; existing internal callers (if any) that do not pass it see no behavior change.
- The route handler is updated to pass the new param through; the Prisma query is the only behavior change.

## Verification

- `prettier --check` on the 4 source files and the Fern yml: clean.
- `tsc --noEmit` from `web/`: no new errors in the changed files.
- `npx fern-api check --api server`: `All checks passed`.
- Standalone structural smoke test (`name: z.string().nullish()` in Zod, `name: { contains, mode: "insensitive" }` filter in service, route passes `query.name`, Fern spec includes the new `name` parameter and the v1 `list-legacy` endpoint): all assertions pass.
- `pnpm --filter web exec vitest run web/src/__tests__/server/datasets-api.servertest.ts` is blocked locally by a pre-existing storybook dep mismatch (`@typescript/typescript6` package-name issue in `.storybook/main.ts`); CI is expected to exercise the new cases on the standard test infrastructure.

## Risk

Minimal. The change adds a filter that narrows the result set; it cannot widen it. The `name` column is the second part of the unique key `(projectId, name)` (see `packages/shared/prisma/schema.prisma`), so the filter is index-friendly. The v1 response shape (embedded `items` and `runs` per dataset) is preserved.

## Future work

- The same `?name` filter should compose with the `?fromTimestamp` / `?toTimestamp` time window for the v1 endpoint from PR #17002 once both are on main. The maintainer can resolve any conflict by keeping both fields in the same Zod block.
- Once v1 is fully deprecated, drop the v1 implementation and the redundant filters.

Fixes #17144


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an optional case-insensitive dataset-name substring filter to the legacy v1 public list endpoint and documents its response in Fern.

- Extends the v1 query schema and forwards `name` through the route.
- Applies one project-scoped predicate consistently to dataset retrieval and pagination totals.
- Adds server tests for matching, case handling, empty results, omitted filters, and project isolation.
- Adds the previously missing legacy endpoint and response types to the Fern definition.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with non-blocking follow-up warranted for substring-query cost and generated deprecation metadata.

The filter is correctly parsed, scoped, and applied consistently to results and totals, while the remaining findings concern performance hardening for large projects and accurate SDK deprecation signaling.

**Files Needing Attention:** web/src/features/datasets/server/publicDatasetService.ts; fern/apis/server/definition/datasets.yml
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant V1 as GET /api/public/datasets
  participant Service as listDatasetsByProjectForApi
  participant DB as PostgreSQL
  Client->>V1: "?name=eval&page=1&limit=50"
  V1->>Service: projectId, name, page, limit
  par Fetch filtered page
    Service->>DB: findMany(projectId, name contains eval)
  and Count filtered results
    Service->>DB: count(projectId, name contains eval)
  end
  Service-->>V1: data and pagination metadata
  V1-->>Client: Legacy datasets with items and runs
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/datasets/server/publicDatasetService.ts:391-393
**Substring Search Is Unindexed**

The case-insensitive `contains` predicate becomes a leading-wildcard search, so the `(projectId, name)` B-tree does not make the name portion index-friendly. Each request also performs an uncapped count over the same predicate, which can scan project rows twice for large projects. Consider a suitable trigram or expression index, or otherwise account for this query cost.

### Issue 2
fern/apis/server/definition/datasets.yml:23-27
**Deprecation Metadata Is Missing**

This legacy endpoint is described as deprecated only in prose, while the neighboring legacy endpoints use Fern's `availability.status: deprecated` metadata. Generated SDKs and reference documentation may therefore not identify this endpoint as deprecated. Add the standard availability declaration.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add ?name substring fi..."](https://github.com/langfuse/langfuse/commit/1dc6fd0112be34fd68774e66a3f5d5a0e792876c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61322628)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->