### PR TITLE
feat(evals): emit generation-only judge traces

### DIFF
--- a/packages/shared/src/server/llm/ai-sdk/telemetry.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetry.ts
@@ -224,9 +224,10 @@ export function createAiSdkTelemetryCapture(params: {
       )
     : undefined;
 
-  const otelIntegration = createGenerationSpanTelemetry({
+  const generationCapture = createGenerationSpanTelemetry({
     tracer,
     recordedInput: generationInput,
+    deferEndUntilFlush: generationIsRoot,
     attributes: {
       // Experiment linkage goes on every span so every materialized event
       // remains associated with the run item root.
@@ -240,6 +241,11 @@ export function createAiSdkTelemetryCapture(params: {
             [LangfuseOtelSpanAttributes.TRACE_METADATA]: JSON.stringify(
               traceSinkParams.metadata,
             ),
+          }
+        : {}),
+      ...(generationIsRoot && serializedInput !== undefined
+        ? {
+            [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: serializedInput,
           }
         : {}),
       ...(traceSinkParams.userId
@@ -261,23 +267,26 @@ export function createAiSdkTelemetryCapture(params: {
   let flushed = false;
 
   const setRootOutput = (output: unknown): void => {
-    if (!rootSpan || flushed || output === undefined) return;
+    if (flushed || output === undefined) return;
     const serializedOutput = stringifyValue(output);
+    const targetSpan = rootSpan ?? generationCapture.getActiveSpan();
 
-    rootSpan.setAttribute(
+    targetSpan?.setAttribute(
       LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT,
       serializedOutput,
     );
   };
 
   const setRootError = (error: unknown): void => {
-    if (!rootSpan || flushed) return;
-    rootSpan.setAttribute("error.type", getErrorType(error));
-    rootSpan.setStatus({
+    if (flushed) return;
+    const targetSpan = rootSpan ?? generationCapture.getActiveSpan();
+    if (!targetSpan) return;
+    targetSpan.setAttribute("error.type", getErrorType(error));
+    targetSpan.setStatus({
       code: SpanStatusCode.ERROR,
       message: error instanceof Error ? error.message : String(error),
     });
-    if (error instanceof Error) rootSpan.recordException(error);
+    if (error instanceof Error) targetSpan.recordException(error);
   };
 
   const flush = async (): Promise<void> => {
@@ -286,6 +295,7 @@ export function createAiSdkTelemetryCapture(params: {
 
     try {
       rootSpan?.end();
+      generationCapture.endActiveSpans();
       await tracerProvider.forceFlush();
 
       const spans = exporter.getFinishedSpans();
@@ -328,7 +338,10 @@ export function createAiSdkTelemetryCapture(params: {
   };
 
   return {
-    telemetry: { isEnabled: true, integrations: [otelIntegration] },
+    telemetry: {
+      isEnabled: true,
+      integrations: [generationCapture.telemetry],
+    },
     run: (fn) => context.with(activeContext, fn),
     setRootOutput,
     setRootError,
@@ -351,12 +364,22 @@ function createGenerationSpanTelemetry(params: {
    * may contain short-lived signed media URLs that must not enter traces.
    */
   recordedInput?: unknown;
-}): Telemetry {
-  const { tracer, attributes, recordedInput } = params;
+  /**
+   * Keeps the evaluator's sole generation mutable until result parsing has
+   * completed. Repeated model-call starts reuse this span.
+   */
+  deferEndUntilFlush?: boolean;
+}): {
+  telemetry: Telemetry;
+  getActiveSpan: () => Span | undefined;
+  endActiveSpans: () => void;
+} {
+  const { tracer, attributes, recordedInput, deferEndUntilFlush } = params;
   const openSpans = new Map<string, Span>();
+  let deferredSpan: Span | undefined;
 
   const endAllOpenSpans = (error?: unknown): void => {
-    for (const span of openSpans.values()) {
+    for (const span of new Set(openSpans.values())) {
       if (error !== undefined) {
         span.setAttribute("error.type", getErrorType(error));
         span.setStatus({
@@ -369,42 +392,47 @@ function createGenerationSpanTelemetry(params: {
       span.end();
     }
     openSpans.clear();
+    deferredSpan = undefined;
   };
 
-  return {
+  const telemetry: Telemetry = {
     onLanguageModelCallStart(event) {
-      // Defensive: a lingering span for this call id means its end event never
-      // fired (e.g. a retried attempt) — close it before starting the next.
-      openSpans.get(event.callId)?.end();
+      let span = deferEndUntilFlush ? deferredSpan : undefined;
+      if (!span) {
+        // Defensive: a lingering span for this call id means its end event
+        // never fired. Evaluator retries intentionally reuse one deferred span.
+        openSpans.get(event.callId)?.end();
 
-      const span = tracer.startSpan(
-        `chat ${event.modelId}`,
-        {
-          kind: SpanKind.CLIENT,
-          attributes: {
-            "gen_ai.operation.name": "chat",
-            "gen_ai.provider.name": event.provider,
-            "gen_ai.request.model": event.modelId,
-            ...definedNumberAttributes({
-              "gen_ai.request.max_tokens": event.maxOutputTokens,
-              "gen_ai.request.temperature": event.temperature,
-              "gen_ai.request.top_p": event.topP,
-            }),
-            ...(recordedInput !== undefined || event.messages !== undefined
-              ? {
-                  "gen_ai.input.messages": safeJsonStringify(
-                    recordedInput ?? event.messages,
-                  ),
-                }
-              : {}),
-            ...(event.tools && event.tools.length > 0
-              ? { "gen_ai.tool.definitions": safeJsonStringify(event.tools) }
-              : {}),
-            ...attributes,
+        span = tracer.startSpan(
+          `chat ${event.modelId}`,
+          {
+            kind: SpanKind.CLIENT,
+            attributes: {
+              "gen_ai.operation.name": "chat",
+              "gen_ai.provider.name": event.provider,
+              "gen_ai.request.model": event.modelId,
+              ...definedNumberAttributes({
+                "gen_ai.request.max_tokens": event.maxOutputTokens,
+                "gen_ai.request.temperature": event.temperature,
+                "gen_ai.request.top_p": event.topP,
+              }),
+              ...(recordedInput !== undefined || event.messages !== undefined
+                ? {
+                    "gen_ai.input.messages": safeJsonStringify(
+                      recordedInput ?? event.messages,
+                    ),
+                  }
+                : {}),
+              ...(event.tools && event.tools.length > 0
+                ? { "gen_ai.tool.definitions": safeJsonStringify(event.tools) }
+                : {}),
+              ...attributes,
+            },
           },
-        },
-        context.active(),
-      );
+          context.active(),
+        );
+        if (deferEndUntilFlush) deferredSpan = span;
+      }
 
       openSpans.set(event.callId, span);
     },
@@ -413,8 +441,6 @@ function createGenerationSpanTelemetry(params: {
       const span = openSpans.get(event.callId);
 
       if (!span) return;
-
-      openSpans.delete(event.callId);
 
       span.setAttributes({
         "gen_ai.response.finish_reasons": [event.finishReason],
@@ -431,7 +457,10 @@ function createGenerationSpanTelemetry(params: {
           { role: "assistant", content: event.content },
         ]),
       });
-      span.end();
+      if (!deferEndUntilFlush) {
+        openSpans.delete(event.callId);
+        span.end();
+      }
     },
 
     onError(event) {
@@ -450,6 +479,12 @@ function createGenerationSpanTelemetry(params: {
 
       return context.with(trace.setSpan(context.active(), span), execute);
     },
+  };
+
+  return {
+    telemetry,
+    getActiveSpan: () => deferredSpan,
+    endActiveSpans: () => endAllOpenSpans(),
   };
 }
 

--- a/packages/shared/src/server/llm/ai-sdk/telemetry.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetry.ts
@@ -151,47 +151,59 @@ export function createAiSdkTelemetryCapture(params: {
     ? buildEvaluationAttributes(traceSinkParams.evaluationContext)
     : undefined;
 
-  const rootSpan: Span = tracer.startSpan(
-    traceSinkParams.traceName,
-    {
-      attributes: {
-        [LangfuseOtelSpanAttributes.TRACE_NAME]: traceSinkParams.traceName,
-        [LangfuseOtelSpanAttributes.ENVIRONMENT]: traceSinkParams.environment,
-        ...(traceSinkParams.userId
-          ? {
-              [LangfuseOtelSpanAttributes.TRACE_USER_ID]:
-                traceSinkParams.userId,
-            }
-          : {}),
-        ...(evaluationAttributes ?? {}),
-        ...(traceSinkParams.metadata
-          ? {
-              [LangfuseOtelSpanAttributes.TRACE_METADATA]: JSON.stringify(
-                traceSinkParams.metadata,
-              ),
-            }
-          : {}),
-        ...(serializedInput !== undefined
-          ? {
-              [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: serializedInput,
-            }
-          : {}),
-      },
-    },
-    // ROOT_CONTEXT detaches from the server's own observability trace.
-    ROOT_CONTEXT,
-  );
-  const activeContext = trace.setSpan(ROOT_CONTEXT, rootSpan);
-
   const experimentContext = traceSinkParams.eventsWriter?.experimentContext;
-  const experimentAttributes = experimentContext
-    ? buildExperimentAttributes(
-        experimentContext,
-        rootSpan.spanContext().spanId,
-      )
-    : undefined;
+  // An evaluator execution is exactly one model call, so its generation is
+  // the trace root. Other internal traces can describe a larger operation and
+  // retain their synthetic root span.
+  const generationIsRoot =
+    evaluationAttributes !== undefined && experimentContext === undefined;
+  const rootSpan: Span | undefined = generationIsRoot
+    ? undefined
+    : tracer.startSpan(
+        traceSinkParams.traceName,
+        {
+          attributes: {
+            [LangfuseOtelSpanAttributes.TRACE_NAME]: traceSinkParams.traceName,
+            [LangfuseOtelSpanAttributes.ENVIRONMENT]:
+              traceSinkParams.environment,
+            ...(traceSinkParams.userId
+              ? {
+                  [LangfuseOtelSpanAttributes.TRACE_USER_ID]:
+                    traceSinkParams.userId,
+                }
+              : {}),
+            ...(evaluationAttributes ?? {}),
+            ...(traceSinkParams.metadata
+              ? {
+                  [LangfuseOtelSpanAttributes.TRACE_METADATA]: JSON.stringify(
+                    traceSinkParams.metadata,
+                  ),
+                }
+              : {}),
+            ...(serializedInput !== undefined
+              ? {
+                  [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]:
+                    serializedInput,
+                }
+              : {}),
+          },
+        },
+        // ROOT_CONTEXT detaches from the server's own observability trace.
+        ROOT_CONTEXT,
+      );
+  const activeContext = rootSpan
+    ? trace.setSpan(ROOT_CONTEXT, rootSpan)
+    : ROOT_CONTEXT;
+
+  const experimentAttributes =
+    experimentContext && rootSpan
+      ? buildExperimentAttributes(
+          experimentContext,
+          rootSpan.spanContext().spanId,
+        )
+      : undefined;
   if (experimentAttributes) {
-    rootSpan.setAttributes(experimentAttributes);
+    rootSpan?.setAttributes(experimentAttributes);
   }
 
   const promptAttributes = traceSinkParams.prompt
@@ -223,6 +235,13 @@ export function createAiSdkTelemetryCapture(params: {
       ...(promptAttributes ?? {}),
       [LangfuseOtelSpanAttributes.TRACE_NAME]: traceSinkParams.traceName,
       [LangfuseOtelSpanAttributes.ENVIRONMENT]: traceSinkParams.environment,
+      ...(generationIsRoot && traceSinkParams.metadata
+        ? {
+            [LangfuseOtelSpanAttributes.TRACE_METADATA]: JSON.stringify(
+              traceSinkParams.metadata,
+            ),
+          }
+        : {}),
       ...(traceSinkParams.userId
         ? {
             [LangfuseOtelSpanAttributes.TRACE_USER_ID]: traceSinkParams.userId,
@@ -242,7 +261,7 @@ export function createAiSdkTelemetryCapture(params: {
   let flushed = false;
 
   const setRootOutput = (output: unknown): void => {
-    if (flushed || output === undefined) return;
+    if (!rootSpan || flushed || output === undefined) return;
     const serializedOutput = stringifyValue(output);
 
     rootSpan.setAttribute(
@@ -252,7 +271,7 @@ export function createAiSdkTelemetryCapture(params: {
   };
 
   const setRootError = (error: unknown): void => {
-    if (flushed) return;
+    if (!rootSpan || flushed) return;
     rootSpan.setAttribute("error.type", getErrorType(error));
     rootSpan.setStatus({
       code: SpanStatusCode.ERROR,
@@ -266,7 +285,7 @@ export function createAiSdkTelemetryCapture(params: {
     flushed = true;
 
     try {
-      rootSpan.end();
+      rootSpan?.end();
       await tracerProvider.forceFlush();
 
       const spans = exporter.getFinishedSpans();

--- a/packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
@@ -13,6 +13,7 @@ import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-ho
 import { APICallError } from "ai";
 import { MockLanguageModelV4 } from "ai/test";
 import { createOpenAI } from "@ai-sdk/openai";
+import { z } from "zod";
 
 import { encrypt } from "../../../encryption";
 import { env } from "../../../env";
@@ -24,7 +25,11 @@ import {
   type ModelParams,
   type TraceSinkParams,
 } from "../types";
-import { generateLLMText, mapLegacyLLMCompletionParams } from "../llmText";
+import {
+  createLLMOutput,
+  generateLLMText,
+  mapLegacyLLMCompletionParams,
+} from "../llmText";
 
 const publishToOtelIngestionQueue = vi.fn().mockResolvedValue(undefined);
 
@@ -166,7 +171,18 @@ describe("AI SDK telemetry integration", () => {
     const serializedAttributes = JSON.stringify(
       spans.flatMap((span: any) => span.attributes),
     );
-    expect(serializedAttributes.match(/@@@langfuseMedia/g)).toHaveLength(1);
+    const rootAttributes = Object.fromEntries(
+      spans[0].attributes.map((attribute: any) => [
+        attribute.key,
+        attribute.value.stringValue ?? attribute.value,
+      ]),
+    );
+    expect(rootAttributes["langfuse.observation.input"]).toContain(
+      originalReference,
+    );
+    // The safe value is intentionally present in both the GenAI model input
+    // and Langfuse root-observation input attributes.
+    expect(serializedAttributes.match(/@@@langfuseMedia/g)).toHaveLength(2);
     expect(serializedAttributes).toContain(originalReference);
     expect(serializedAttributes).toContain("Inspect");
     expect(serializedAttributes).toContain("text");
@@ -220,6 +236,7 @@ describe("AI SDK telemetry integration", () => {
       "gen_ai.operation.name": "chat",
       "gen_ai.provider.name": "openai",
       "gen_ai.request.model": "gpt-4o",
+      "langfuse.observation.output": "Hello there",
     });
 
     // The captured spans convert through the real OTel ingestion processor —
@@ -477,6 +494,111 @@ describe("AI SDK telemetry integration", () => {
 
     expect(generationSpan.status).toMatchObject({ code: 2 });
     expect(attributes).toMatchObject({ "error.type": "AI_APICallError" });
+  });
+
+  it("marks the root generation as failed when structured output parsing fails", async () => {
+    vi.mocked(createOpenAI).mockReturnValue({
+      chat: () =>
+        new MockLanguageModelV4({
+          provider: "openai",
+          modelId: "gpt-4o",
+          doGenerate: {
+            content: [{ type: "text", text: "not valid json" }],
+            finishReason: { unified: "stop", raw: "stop" },
+            usage: {
+              inputTokens: {
+                total: 3,
+                noCache: 3,
+                cacheRead: undefined,
+                cacheWrite: undefined,
+              },
+              outputTokens: { total: 3, text: 3, reasoning: undefined },
+            },
+            warnings: [],
+          },
+        }),
+    } as never);
+
+    await expect(
+      generateLLMText({
+        ...mapLegacyLLMCompletionParams({
+          messages,
+          modelParams,
+          connection: { secretKey: encrypt("sk-test") },
+        }),
+        output: createLLMOutput(z.object({ score: z.number() })),
+        trace: traceSinkParams,
+      }),
+    ).rejects.toMatchObject({ name: "AI_NoObjectGeneratedError" });
+
+    const resourceSpans = publishToOtelIngestionQueue.mock.calls[0][0];
+    const spans = resourceSpans.flatMap((resourceSpan: any) =>
+      resourceSpan.scopeSpans.flatMap((scopeSpan: any) => scopeSpan.spans),
+    );
+    expect(spans).toHaveLength(1);
+    expect(spans[0].status).toMatchObject({ code: 2 });
+    expect(
+      Object.fromEntries(
+        spans[0].attributes.map((attribute: any) => [
+          attribute.key,
+          attribute.value.stringValue ?? attribute.value,
+        ]),
+      ),
+    ).toMatchObject({ "error.type": "AI_NoObjectGeneratedError" });
+  });
+
+  it("keeps retries in one root generation", async () => {
+    const retryableError = new APICallError({
+      message: "Service unavailable",
+      url: "https://api.openai.com/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 503,
+      isRetryable: true,
+    });
+    let attempt = 0;
+    const model = new MockLanguageModelV4({
+      provider: "openai",
+      modelId: "gpt-4o",
+      doGenerate: async () => {
+        attempt += 1;
+        if (attempt === 1) throw retryableError;
+        return {
+          content: [{ type: "text" as const, text: "Hello after retry" }],
+          finishReason: { unified: "stop" as const, raw: "stop" },
+          usage: {
+            inputTokens: {
+              total: 3,
+              noCache: 3,
+              cacheRead: undefined,
+              cacheWrite: undefined,
+            },
+            outputTokens: { total: 4, text: 4, reasoning: undefined },
+          },
+          warnings: [],
+        };
+      },
+    });
+    vi.mocked(createOpenAI).mockReturnValue({ chat: () => model } as never);
+
+    await expect(
+      generateLLMText({
+        ...mapLegacyLLMCompletionParams({
+          messages,
+          modelParams,
+          connection: { secretKey: encrypt("sk-test") },
+        }),
+        maxRetries: 1,
+        trace: traceSinkParams,
+      }),
+    ).resolves.toMatchObject({ text: "Hello after retry" });
+
+    expect(model.doGenerateCalls).toHaveLength(2);
+    const resourceSpans = publishToOtelIngestionQueue.mock.calls[0][0];
+    const spans = resourceSpans.flatMap((resourceSpan: any) =>
+      resourceSpan.scopeSpans.flatMap((scopeSpan: any) => scopeSpan.spans),
+    );
+    expect(spans).toHaveLength(1);
+    expect(spans.filter((span: any) => !span.parentSpanId)).toHaveLength(1);
   });
 
   it("records unsupported media URL errors without downloading or calling the model", async () => {

--- a/packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
@@ -166,7 +166,7 @@ describe("AI SDK telemetry integration", () => {
     const serializedAttributes = JSON.stringify(
       spans.flatMap((span: any) => span.attributes),
     );
-    expect(serializedAttributes.match(/@@@langfuseMedia/g)).toHaveLength(2);
+    expect(serializedAttributes.match(/@@@langfuseMedia/g)).toHaveLength(1);
     expect(serializedAttributes).toContain(originalReference);
     expect(serializedAttributes).toContain("Inspect");
     expect(serializedAttributes).toContain("text");
@@ -195,20 +195,17 @@ describe("AI SDK telemetry integration", () => {
       rs.scopeSpans.flatMap((ss: any) => ss.spans),
     );
 
-    // Exactly two spans: the internal root and one generation per model call
-    // (the minimal telemetry integration emits no operation/step spans).
-    expect(spans).toHaveLength(2);
+    // Evaluator traces contain only the model generation. The generation is
+    // the trace root, avoiding a wrapper observation that adds no eval value.
+    expect(spans).toHaveLength(1);
     for (const span of spans) {
       expect(span.traceId.toLowerCase()).toBe(VALID_TRACE_ID);
     }
 
     const rootSpans = spans.filter((span: any) => !span.parentSpanId);
     expect(rootSpans).toHaveLength(1);
-    expect(rootSpans[0].name).toBe("Execute evaluator: helpfulness");
-
-    const generationSpan = spans.find((span: any) => span.parentSpanId);
+    const generationSpan = rootSpans[0];
     expect(generationSpan.name).toBe("chat gpt-4o");
-    expect(generationSpan.parentSpanId).toBe(rootSpans[0].spanId);
     // OTLP SpanKind 3 = CLIENT. The detached trace owns the actual GenAI
     // client span; worker eval.* spans remain INTERNAL orchestration spans.
     expect(generationSpan.kind).toBe(3);
@@ -310,7 +307,7 @@ describe("AI SDK telemetry integration", () => {
     });
 
     const eventInputs = processor.processToEvent(resourceSpans);
-    expect(eventInputs).toHaveLength(2);
+    expect(eventInputs).toHaveLength(1);
     for (const eventInput of eventInputs) {
       expect(eventInput).toMatchObject({
         evaluationContext: {
@@ -462,7 +459,7 @@ describe("AI SDK telemetry integration", () => {
     const spans = resourceSpans.flatMap((resourceSpan: any) =>
       resourceSpan.scopeSpans.flatMap((scopeSpan: any) => scopeSpan.spans),
     );
-    const generationSpan = spans.find((span: any) => span.parentSpanId);
+    const generationSpan = spans.find((span: any) => !span.parentSpanId);
     const attributes = Object.fromEntries(
       generationSpan.attributes.map((attribute: any) => [
         attribute.key,
@@ -535,41 +532,8 @@ describe("AI SDK telemetry integration", () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(model.doGenerateCalls).toHaveLength(0);
-    expect(publishToOtelIngestionQueue).toHaveBeenCalledTimes(1);
-
-    const resourceSpans = publishToOtelIngestionQueue.mock.calls[0][0];
-    const spans = resourceSpans.flatMap((resourceSpan: any) =>
-      resourceSpan.scopeSpans.flatMap((scopeSpan: any) => scopeSpan.spans),
-    );
-    const rootSpan = spans.find((span: any) => !span.parentSpanId);
-    const attributes = Object.fromEntries(
-      rootSpan.attributes.map((attribute: any) => [
-        attribute.key,
-        attribute.value.stringValue ?? attribute.value,
-      ]),
-    );
-
-    expect(rootSpan.status).toMatchObject({ code: 2, message: errorMessage });
-    expect(attributes).toMatchObject({ "error.type": "LLMValidationError" });
-
-    // Convert the failed root span through the production ingestion mapper to
-    // prove the evaluator execution trace exposes the validation error.
-    const { OtelIngestionProcessor } = await vi.importActual<
-      typeof import("../../otel/OtelIngestionProcessor")
-    >("../../otel/OtelIngestionProcessor");
-    const eventInputs = new OtelIngestionProcessor({
-      projectId: "project-1",
-      publicKey: "",
-      sdkName: "langfuse-internal-ai-sdk",
-      sdkVersion: "unknown",
-      isLangfuseInternal: true,
-    }).processToEvent(resourceSpans);
-    const rootEvent = eventInputs.find((input: any) => !input.parentSpanId);
-
-    expect(rootEvent).toMatchObject({
-      level: "ERROR",
-      statusMessage: errorMessage,
-      environment: "langfuse-llm-judge",
-    });
+    // Validation failed before a model call began, so there is no generation
+    // to persist and evaluator traces do not fall back to a wrapper span.
+    expect(publishToOtelIngestionQueue).not.toHaveBeenCalled();
   });
 });

--- a/packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
@@ -259,6 +259,10 @@ describe("AI SDK telemetry integration", () => {
       id: VALID_TRACE_ID,
       name: "Execute evaluator: helpfulness",
       environment: "langfuse-llm-judge",
+      metadata: expect.objectContaining({
+        job_execution_id: "job-1",
+        evaluator_id: "evaluator-1",
+      }),
     });
 
     // The model call span materializes as a generation with usage — and it is
@@ -310,6 +314,10 @@ describe("AI SDK telemetry integration", () => {
     expect(eventInputs).toHaveLength(1);
     for (const eventInput of eventInputs) {
       expect(eventInput).toMatchObject({
+        type: "GENERATION",
+        traceName: "Execute evaluator: helpfulness",
+        input: expect.anything(),
+        output: expect.anything(),
         evaluationContext: {
           evaluatorId: "evaluator-1",
           evaluationRuleId: "legacy-rule-1",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17146 app preview](https://pr-17146.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

LLM-as-a-judge execution traces now use the model generation as the trace root instead of adding a synthetic wrapper span. This removes one observation per evaluator execution while preserving trace names, evaluator context, trace metadata, model input/output, usage, provider and structured-output errors, and prompt links on the generation.

The generation remains open until result parsing completes, and retries reuse the same root generation. Prompt experiments and other internal AI traces continue to use their existing wrapper span. Validation failures that occur before a model call starts do not create an empty evaluator trace.

Impacted package: `@langfuse/shared`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Self-reviewed the code and reconstructed the existing telemetry history.

## Verification

- Shared telemetry: `Test Files 2 passed (2)`, `Tests 13 passed (13)`
- Worker evaluator dependency: `Test Files 1 passed (1)`, `Tests 3 passed (3)`
- Web evaluator test execution: `Test Files 1 passed (1)`, `Tests 4 passed (4)`
- Forced lint: `Tasks: 7 successful, 7 total`, `Cached: 0 cached, 7 total`
- Typecheck: `Tasks: 8 successful, 8 total`, `Cached: 3 cached, 8 total`
- `pnpm exec knip` — passed
- Latest revision CI: all 48 checks passed

<a href="https://cursor.com/agents/bc-c9e248c6-1134-4725-b6b7-7617e02217d5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevaluator_trace_ci_proof_demo.mp4"><img src="https://cursor.com/artifacts/c/art-4fb0ad09-bc49-4457-8bd3-d75a794c5ad9" alt="evaluator_trace_ci_proof_demo.mp4" /></a>

## Preview review

[pr-17146 app preview](https://pr-17146.preview.langfuse.com)

The preview is healthy, but its demo project has neither an LLM connection nor existing evaluator execution traces. I did not add a real provider credential to the public preview, so the customer-visible execution could not be recreated there. The shared integration suite verifies the generated OTel spans through the real ingestion mapper, including one root `GENERATION`, trace name/metadata, input/output, usage, evaluator identity, post-call errors, and retries.

## Checklist

- [x] Code follows the repository formatting and lint rules
- [x] Added regression assertions proving evaluator traces contain one root generation
- [x] Verified root-generation trace fields through the real ingestion mapper
- [x] Verified structured-output failures remain visible on the generation
- [x] Verified retries produce one root generation
- [x] Existing prompt-experiment telemetry behavior remains covered by the integration suite
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15474](https://linear.app/clickhouse/issue/LFE-15474/remove-spans-from-eval-traces)

<div><a href="https://cursor.com/agents/bc-c9e248c6-1134-4725-b6b7-7617e02217d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9e248c6-1134-4725-b6b7-7617e02217d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the synthetic wrapper span from LLM-as-a-judge telemetry and promotes the model generation to the trace root, while retaining wrapper spans for prompt experiments.

- Preserves evaluator, trace, metadata, user, environment, prompt, usage, and model-call error attributes on the generation.
- Stops emitting empty evaluator traces for validation failures before a model call.
- Adds integration assertions for the generation-only evaluator shape.
- The promoted generation currently fails to preserve the evaluator’s trace-level input.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the generation root preserves the evaluator’s trace-level input.

Evaluator callers normally provide `traceInput`, but after wrapper removal it is stored only as generation input, while root trace ingestion reads trace-domain input attributes; the resulting trace therefore loses its input.

**Files Needing Attention:** packages/shared/src/server/llm/ai-sdk/telemetry.ts, packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    E[Evaluator execution] --> G[Root generation]
    G --> O[Generation observation]
    G --> T[Trace event]
    GI[gen_ai.input.messages] --> O
    GI -. not extracted as trace input .-> T

    X[Prompt experiment] --> R[Synthetic root]
    R --> CG[Child generation]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/llm/ai-sdk/telemetry.ts:238-244
**Trace input is lost**

When an evaluator supplies `traceInput`, the removed wrapper previously stored it as the trace-level input. The new root generation records it only as `gen_ai.input.messages`, which the ingestion processor does not use when constructing the root trace. As a result, the generation retains its input, but the evaluator trace loses it.

```suggestion
      ...(generationIsRoot && traceSinkParams.metadata
        ? {
            [LangfuseOtelSpanAttributes.TRACE_METADATA]: JSON.stringify(
              traceSinkParams.metadata,
            ),
          }
        : {}),
      ...(generationIsRoot && serializedInput !== undefined
        ? {
            [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: serializedInput,
          }
        : {}),
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evals): emit generation-only judge ..."](https://github.com/langfuse/langfuse/commit/0519f3215f0e8f5aec57fd1bd7b296487d307081) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61323328)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->