### PR TITLE
fix(shared): exclude empty string from in-memory "is not null" filter evaluation

### DIFF
--- a/packages/shared/src/server/services/InMemoryFilterService.ts
+++ b/packages/shared/src/server/services/InMemoryFilterService.ts
@@ -437,9 +437,10 @@ export class InMemoryFilterService {
   ): boolean {
     switch (operator) {
       case "is null":
-        return (
-          fieldValue === null || fieldValue === undefined || fieldValue === ""
-        );
+        // '' is a regular non-null value here: the eval/automation table
+        // mappings (traces, observations) do not set emptyEqualsNull, so
+        // ClickHouse `IS NULL` does not match empty strings either.
+        return fieldValue === null || fieldValue === undefined;
       case "is not null":
         return fieldValue !== null && fieldValue !== undefined;
       default:

--- a/worker/src/__tests__/inMemoryFilterService.test.ts
+++ b/worker/src/__tests__/inMemoryFilterService.test.ts
@@ -1093,6 +1093,37 @@ describe("InMemoryFilterService", () => {
       ).toBe(true);
     });
 
+    test("empty string matches 'is not null' but not 'is null'", () => {
+      // The eval/automation table mappings (traces, observations) do not set
+      // emptyEqualsNull, so ClickHouse treats '' as a regular non-null value:
+      // IS NULL excludes it, IS NOT NULL includes it. The in-memory filter
+      // used for eval scheduling and automations must match that.
+      const dataWithEmptyString = { ...mockData, release: "" };
+
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          dataWithEmptyString,
+          [{ column: "release", type: "null", operator: "is null", value: "" }],
+          fieldMapper,
+        ),
+      ).toBe(false);
+
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          dataWithEmptyString,
+          [
+            {
+              column: "release",
+              type: "null",
+              operator: "is not null",
+              value: "",
+            },
+          ],
+          fieldMapper,
+        ),
+      ).toBe(true);
+    });
+
     test("evaluates multiple filters with AND logic", () => {
       expect(
         InMemoryFilterService.evaluateFilter(


### PR DESCRIPTION
## What does this PR do?

Fixes #17151

`InMemoryFilterService.evaluateNullFilter` treats `""` as null for the `is null` operator. But the tables this filter runs against for eval scheduling and automations (traces, observations) set `emptyEqualsNull` on no column, so the equivalent ClickHouse `NullFilter` compiles to a plain `IS NULL`, which does not match `''`. An empty string therefore matched `is null` in memory while ClickHouse excludes it. The `is not null` arm was already consistent with ClickHouse `IS NOT NULL`.

Concrete impact: observation eval scheduling (`scheduleObservationEvals`) and automation trigger matching (`matchesTriggerFilter`) evaluate these filters in memory. A filter like "Parent Observation is null" matched observations whose `parent_observation_id` is `''`, while the ClickHouse-backed table query on the same column does not.

(Edited after review: the original version of this PR framed the divergence on the `is not null` side, which was inverted - see the discussion below.)

## Change

`evaluateNullFilter` no longer treats `""` as null: `is null` matches only `null`/`undefined`, and `is not null` matches everything else, `""` included - matching ClickHouse for the affected tables.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- Regression test in `worker/src/__tests__/inMemoryFilterService.test.ts`: `""` does not match `is null` but does match `is not null` (ClickHouse parity for columns without `emptyEqualsNull`).
- `inMemoryFilterService` suite: 17/17 pass (16 existing + 1 new).
- Caveat: the full monorepo `pnpm install` would not complete in my environment (network), so vitest ran against the repo's real source files with a scratch install providing `zod`, and module shims for the `logger` and `clickhouse-filter` imports of `InMemoryFilterService.ts` (their real dependency chains pull in AWS/ClickHouse clients; the shimmed `encodeBooleanScoreEntry` is a verbatim copy of the one-line helper). CI should confirm the full suite.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes in-memory `is not null` evaluation exclude empty strings and adds regression coverage for that behavior.

- Restores symmetry between the two in-memory null operators.
- Covers the intended `release`-style empty-as-null convention.
- Applies that convention too broadly to columns whose ClickHouse mappings retain standard null semantics.
- Adds a regression test whose name contradicts its assertions.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not safe to merge until empty-string handling is conditioned on the target column’s `emptyEqualsNull` semantics.

The change fixes the intended parent-observation and release cases, but globally changes `is not null` behavior and therefore creates a concrete mismatch for null-filterable columns whose ClickHouse mappings use ordinary `IS NOT NULL` semantics.

**Files Needing Attention:** packages/shared/src/server/services/InMemoryFilterService.ts; worker/src/__tests__/inMemoryFilterService.test.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/services/InMemoryFilterService.ts:447-449
**Null semantics applied globally**

This excludes empty strings from every in-memory `is not null` filter, but ClickHouse treats `""` as null only for columns whose mapping sets `emptyEqualsNull`. Null filters are accepted for any evaluator column, so an empty string in a column without that flag, such as `version`, is excluded during in-memory evaluator scheduling or automation matching even though the equivalent ClickHouse `IS NOT NULL` filter includes it. Pass the target column's null semantics into this evaluation instead of applying the release and parent-ID convention globally.

### Issue 2
worker/src/__tests__/inMemoryFilterService.test.ts:1096
**Test name contradicts assertions**

The name says an empty string matches neither side, but the first assertion requires it to match `is null` and the second requires it not to match `is not null`. This makes test output state the opposite of the regression contract and can mislead future debugging.

```suggestion
    test("empty string matches is null but not is not null", () => {
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): exclude empty string from i..."](https://github.com/langfuse/langfuse/commit/58526f5b1f896b7be81de52e43cf175ea37a91d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61466003)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->