### PR TITLE
fix(web): avoid key collisions in score comparison confusion matrix

### DIFF
--- a/.agents/skills/datadog-query-recipes/SKILL.md
+++ b/.agents/skills/datadog-query-recipes/SKILL.md
@@ -41,6 +41,8 @@ data domain you need: traces, logs, metrics, and visualizations.
      [`references/public-api-tenant-usage.md`](references/public-api-tenant-usage.md)
    - Queue inventory, queue consumers, and queue metrics:
      [`references/queue-consumers.md`](references/queue-consumers.md)
+   - Scheduled-export freshness lag (blob / PostHog / Mixpanel):
+     [`references/export-freshness-lag.md`](references/export-freshness-lag.md)
 3. Start with aggregate queries, grouped by environment, service, route,
    queue, project, org, status, or error facets as appropriate.
 4. Fetch raw spans, logs, or traces only after aggregation identifies the

--- a/.agents/skills/datadog-query-recipes/references/export-freshness-lag.md
+++ b/.agents/skills/datadog-query-recipes/references/export-freshness-lag.md
@@ -1,0 +1,43 @@
+# Export freshness lag
+
+Scheduled integrations (blob, PostHog, Mixpanel) emit a pooled distribution at
+the end of each run. Provenance: the shape from LFE-15853.
+
+## Metric
+
+- Name: `langfuse.export.freshness_lag_seconds`
+- Type: distribution
+- Value: `runStartTime − maxExportedTimestamp` (seconds, clamped at 0)
+- Watermark: `lastSyncAt` after a successful window (`maxTimestamp` just
+  written). Failing runs use the **unchanged** watermark so stall shows as
+  rising lag. Do not treat intended window end as the watermark.
+- Tags: `integration` (`blob_storage` / `posthog` / `mixpanel`), `window`
+  (`20m` / `1h` / `1d` / `1w`), `status` (`success` / `failure`), `unit:seconds`.
+  `env` comes from the agent. **No `project_id`.**
+- PostHog and Mixpanel are tagged `window:1h` (hourly cron). Blob uses the
+  configured cadence.
+
+## Baseline P95 (both Datadog sites)
+
+EU (`prod-eu`) and US (`prod-us`, `prod-hipaa`, `prod-jp`):
+
+```text
+p95:langfuse.export.freshness_lag_seconds{*} by {integration,window,env}
+```
+
+Split success vs failure while baselining:
+
+```text
+p95:langfuse.export.freshness_lag_seconds{*} by {integration,window,status}
+```
+
+Catch-up (historic backfill) sits in the tail. P95 is the planned SLI **if**
+those runs stay under ~5% of pooled volume. If they do not, filter runs whose
+target window is older than N× the cadence (follow-up, not this metric).
+
+## Emit sites
+
+- `worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts`
+- `worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts`
+- `worker/src/features/mixpanel/handleMixpanelIntegrationProjectJob.ts`
+- Helper: `worker/src/services/exportFreshnessLagMetric.ts`

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -58,9 +58,9 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: bash "scripts/validate-release-tag-branch.sh" "${RELEASE_TAG}" "${RELEASE_COMMIT}" "origin/v3"
 
-  # Skips runs whose git tree was already tested in a prior successful run of
-  # this workflow (replaces fkirc/skip-duplicate-actions). This fires almost
-  # exclusively on pushes to main, whose tree the merge queue just tested, so
+  # Skips main pushes already tested by a successful merge-queue run of this
+  # workflow; other push refs use a recent successful tree match. This fires
+  # almost exclusively on main, whose tree the merge queue just tested, so
   # the job only runs for push events: pull_request and merge_group runs skip
   # it instantly and their jobs start without waiting for it (~45-100s of
   # wall clock per run).
@@ -71,25 +71,57 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     timeout-minutes: 15
     permissions:
+      actions: read
       contents: read
     steps:
       - id: skip_check
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           COMMIT_SHA: ${{ github.sha }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          CURRENT_TREE=$(gh api "repos/$REPOSITORY/git/commits/$COMMIT_SHA" --jq '.tree.sha')
+          if ! CURRENT_TREE=$(timeout 10s gh api "repos/$REPOSITORY/git/commits/$COMMIT_SHA" --jq '.tree.sha // empty') \
+            || [[ ! "$CURRENT_TREE" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::warning::Cannot verify the current tree; running CI"
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-          MATCH=$(gh api "repos/$REPOSITORY/actions/workflows/pipeline.yml/runs?status=success&per_page=20" \
-            | jq -r --argjson run_id "$RUN_ID" --arg current_tree "$CURRENT_TREE" \
-              '[.workflow_runs[] | select(.id != $run_id and .head_commit.tree_id == $current_tree)] | first | .head_sha // empty')
+          QUERY="status=success&per_page=20"
+          ATTEMPTS=1
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+            # Scope the lookup to this commit and evaluate status locally so
+            # a just-completed queue run is not lost in a global success list.
+            QUERY="head_sha=$COMMIT_SHA&per_page=100"
+            ATTEMPTS=3
+          fi
+
+          MATCH=""
+          for ((ATTEMPT=1; ATTEMPT<=ATTEMPTS; ATTEMPT++)); do
+            if MATCH=$(timeout 10s gh api "repos/$REPOSITORY/actions/workflows/pipeline.yml/runs?$QUERY" \
+              -H "Cache-Control: no-cache" \
+              | jq -r --argjson run_id "$RUN_ID" --arg current_tree "$CURRENT_TREE" \
+                --arg sha "$COMMIT_SHA" --arg ref "$GITHUB_REF" \
+                '[.workflow_runs[] | select(.id != $run_id
+                  and .status == "completed" and .conclusion == "success"
+                  and .head_commit.tree_id == $current_tree
+                  and ($ref != "refs/heads/main" or (.head_sha == $sha and .event == "merge_group")))]
+                  | first | .id // empty'); then
+              if [[ -n "$MATCH" ]]; then break; fi
+            else
+              MATCH=""
+              echo "::warning::Duplicate lookup $ATTEMPT/$ATTEMPTS failed"
+            fi
+            if ((ATTEMPT < ATTEMPTS)); then sleep 5; fi
+          done
 
           if [[ -n "$MATCH" ]]; then
-            echo "::notice::Tree $CURRENT_TREE already tested in a prior successful run (commit $MATCH) — skipping"
+            echo "::notice::Tree $CURRENT_TREE already tested in successful run $MATCH — skipping"
             echo "should_skip=true" >> "$GITHUB_OUTPUT"
           else
+            echo "::notice::No verified duplicate after $ATTEMPTS lookup(s); running CI"
             echo "should_skip=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/preview-health-check.yml
+++ b/.github/workflows/preview-health-check.yml
@@ -1,0 +1,175 @@
+name: Preview deployment health check
+
+# Poll every labeled preview's public health endpoint and shout in Slack when
+# one answers but is not serving. Argo CD notifications already cover a preview
+# whose *sync* failed; they cannot see this case, because a Deployment scaled to
+# zero is Healthy to Argo (`/spec/replicas` sits in the ApplicationSet's
+# ignoreDifferences for the downscaler), so a preview that exists, resolves, and
+# returns 503 looks fine from the cluster's point of view. Until this, the only
+# detector was someone opening the URL.
+#
+# Schedule is UTC; we want 08:00-20:00 Europe/Berlin, inside the window where
+# previews are up at all ("Mon-Fri 08:00-24:00 Europe/Berlin", downscaler/uptime
+# in the infrastructure repo's ApplicationSet). Berlin is UTC+1 or UTC+2
+# depending on DST, so a UTC hour H lands at H+1 or H+2 local: only 07:00-18:00
+# UTC is inside 08:00-20:00 Berlin whichever side of DST we are on. On a
+# 2-hourly grid that is 07:00-17:00, i.e. first probe at 08:00 or 09:00 local
+# and last at 18:00 or 19:00 — never on a deliberately sleeping preview.
+#
+# Safe triggers only: `schedule` + `workflow_dispatch`. No checkout, no PR-code
+# execution, no cloud credentials.
+on:
+  schedule:
+    - cron: "0 7,9,11,13,15,17 * * 1-5"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: preview-health-check
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check labeled previews are serving
+    runs-on: ubuntu-latest
+    # Same preview-system feature gate as preview-build / preview-stale-cleanup:
+    # unset => system off, nothing to poll.
+    if: vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != ''
+    permissions:
+      # Listing labeled open PRs is all this needs; it mutates nothing.
+      pull-requests: read
+    steps:
+      - name: Probe every labeled preview
+        id: probe
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # A preview is only expected to serve if the PR is open AND labeled.
+          numbers="$(gh api "repos/$REPOSITORY/pulls?state=open&per_page=100" --paginate \
+            --jq '.[] | select(any(.labels[]; .name == "preview")) | .number')"
+
+          if [ -z "$numbers" ]; then
+            echo "No labeled previews open; nothing to probe."
+            echo "unhealthy=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # curl already prints 000 for a timeout, DNS failure or refused
+          # connection, so swallow its exit status rather than echoing a second
+          # 000 after it (which would report "HTTP 000000").
+          probe() {
+            local code
+            code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
+              "https://pr-$1.preview.langfuse.com/api/public/health" 2>/dev/null || true)"
+            printf '%s' "${code:-000}"
+          }
+
+          unhealthy=""
+          suspects=""
+          undeployed=0
+          healthy=0
+          total=0
+
+          # 404 is the shared ALB's wildcard catch-all: the PR is labeled but
+          # nothing is deployed for it — an author off the deploy allowlist, or a
+          # teardown still in flight. Not a failure, so it never alerts, in
+          # either pass.
+          classify() {
+            case "$2" in
+              200) healthy=$((healthy + 1)); echo "pr-$1: ok" ;;
+              404) undeployed=$((undeployed + 1)); echo "pr-$1: not deployed (404)" ;;
+              *) return 1 ;;
+            esac
+          }
+
+          for n in $numbers; do
+            total=$((total + 1))
+            code="$(probe "$n")"
+            if ! classify "$n" "$code"; then
+              suspects="${suspects:+$suspects }$n"
+              echo "pr-$n: HTTP $code, re-probing"
+            fi
+          done
+
+          # A rebuild rolls the web Deployment, and a brief ImagePullBackOff is
+          # documented as normal and self-healing, so nothing is called broken on
+          # a single bad response. The wait is shared across all suspects rather
+          # than paid per preview: at 50 previews a per-preview sleep would run
+          # for tens of minutes.
+          if [ -n "$suspects" ]; then
+            sleep 30
+            for n in $suspects; do
+              code="$(probe "$n")"
+              if ! classify "$n" "$code"; then
+                # Space-free token: the Slack step counts and truncates this
+                # list by word, so an entry must never contain a space.
+                unhealthy="${unhealthy:+$unhealthy }pr-$n($code)"
+                echo "::error::pr-$n.preview.langfuse.com is labeled but not serving (HTTP $code)"
+              fi
+            done
+          fi
+
+          echo "unhealthy=$unhealthy" >> "$GITHUB_OUTPUT"
+          echo "total=$total" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Preview health"
+            echo ""
+            echo "- labeled previews: $total"
+            echo "- serving: $healthy"
+            echo "- not deployed (404, ignored): $undeployed"
+            echo "- not serving: ${unhealthy:-none}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify Slack
+        if: steps.probe.outputs.unhealthy != ''
+        env:
+          # Incoming webhook bound to #lf-preview-alerts, the same channel the
+          # Argo CD preview sync-failure alerts post to, so every preview signal
+          # lands in one place and none of it competes with CI failures.
+          SLACK_WEBHOOK: ${{ secrets.SLACK_PREVIEW_ALERTS_WEBHOOK_URL }}
+          UNHEALTHY: ${{ steps.probe.outputs.unhealthy }}
+          TOTAL: ${{ steps.probe.outputs.total }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${SLACK_WEBHOOK:-}" ]; then
+            echo "::warning::SLACK_PREVIEW_ALERTS_WEBHOOK_URL is unset; skipping the Slack post."
+            exit 0
+          fi
+
+          # One message per run listing every offender, never one per preview, so
+          # the alert volume is set by the schedule (6/day) and not by the size of
+          # the fleet. Only the list itself grows, so cap it: a broken ALB would
+          # otherwise paste 50 hostnames into the channel.
+          count="$(printf '%s' "$UNHEALTHY" | wc -w | tr -d ' ')"
+          shown="$(printf '%s' "$UNHEALTHY" | tr ' ' '\n' | head -10 | paste -sd' ' -)"
+          if [ "$count" -gt 10 ]; then
+            shown="$shown (+$((count - 10)) more)"
+          fi
+
+          text="Preview health: $count of ${TOTAL} labeled previews not serving — ${shown}. Run: ${RUN_URL}"
+
+          response="$(curl -sS -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-type: application/json; charset=utf-8' \
+            --data "$(jq -nc --arg text "$text" '{text: $text}')")"
+
+          # A Slack incoming webhook answers with the literal body "ok"; a revoked
+          # or mistyped hook answers 4xx with a reason, which -sS surfaces.
+          if [ "$response" != "ok" ]; then
+            echo "::error::Slack post failed: $response"
+            exit 1
+          fi
+          echo "Posted to #lf-preview-alerts."
+
+      - name: Fail if any preview is not serving
+        if: steps.probe.outputs.unhealthy != ''
+        env:
+          UNHEALTHY: ${{ steps.probe.outputs.unhealthy }}
+        run: |
+          echo "Not serving: $UNHEALTHY"
+          exit 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "4.31.0",
+  "version": "4.32.0",
   "author": "engineering@langfuse.com",
   "license": "MIT",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "4.30.0",
+  "version": "4.31.0",
   "author": "engineering@langfuse.com",
   "license": "MIT",
   "private": true,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -210,7 +210,7 @@
     "oci-objectstorage": "^2.140.0",
     "safe-regex2": "^5.0.0",
     "slackify-markdown": "^5.0.0",
-    "undici": "^7.29.0",
+    "undici": "^7.29.1",
     "uuid": "^14.0.2",
     "winston": "^3.15.0",
     "zod": "^4.3.6"

--- a/packages/shared/src/constants/VERSION.ts
+++ b/packages/shared/src/constants/VERSION.ts
@@ -1,1 +1,1 @@
-export const VERSION = "v4.31.0";
+export const VERSION = "v4.32.0";

--- a/packages/shared/src/constants/VERSION.ts
+++ b/packages/shared/src/constants/VERSION.ts
@@ -1,1 +1,1 @@
-export const VERSION = "v4.30.0";
+export const VERSION = "v4.31.0";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ overrides:
   browserslist: 4.28.7
   postcss: 8.5.25
   esbuild: 0.28.1
-  undici@7: 7.29.0
+  undici@7: 7.29.1
   zod: 4.3.6
   nanoid: 3.3.18
   katex: ^0.16.21
@@ -421,8 +421,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(supports-color@8.1.1)
       undici:
-        specifier: 7.29.0
-        version: 7.29.0
+        specifier: 7.29.1
+        version: 7.29.1
       uuid:
         specifier: ^14.0.2
         version: 14.0.2
@@ -11412,8 +11412,8 @@ packages:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
-  undici@7.29.0:
-    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+  undici@7.29.1:
+    resolution: {integrity: sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==}
     engines: {node: '>=20.18.1'}
 
   unhead@2.1.17:
@@ -18397,7 +18397,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.29.0
+      undici: 7.29.1
       whatwg-mimetype: 4.0.0
 
   chokidar@4.0.3:
@@ -19315,6 +19315,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.67.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@7.0.2))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      debug: 3.2.7(supports-color@8.1.1)
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@7.0.2)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.1(@typescript-eslint/parser@8.67.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@7.0.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
@@ -19365,6 +19376,35 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.67.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@7.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7(supports-color@8.1.1)
+      doctrine: 2.1.0
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.67.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@7.0.2))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      hasown: 2.0.4
+      is-core-module: 2.16.2
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@7.0.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -22733,7 +22773,7 @@ snapshots:
       proxy-agent: 7.0.0(supports-color@8.1.1)
       semver: 7.7.4
       tinyglobby: 0.2.15
-      undici: 7.29.0
+      undici: 7.29.1
       url-join: 5.0.0
       wildcard-match: 5.1.4
       yargs-parser: 22.0.0
@@ -23765,7 +23805,7 @@ snapshots:
 
   undici@6.28.0: {}
 
-  undici@7.29.0: {}
+  undici@7.29.1: {}
 
   unhead@2.1.17:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -80,7 +80,7 @@ overrides:
   browserslist: 4.28.7
   postcss: 8.5.25
   esbuild: "0.28.1"
-  "undici@7": 7.29.0
+  "undici@7": 7.29.1
   zod: 4.3.6
   nanoid: 3.3.18
   katex: ^0.16.21
@@ -155,3 +155,6 @@ minimumReleaseAgeExclude:
   - qs@6.16.0
   # Host confusion + output-escaping fixes (CVE-2026-84394, CVE-2026-84292).
   - fast-uri@3.1.7
+  # Certificate validation, request smuggling, and resource-exhaustion fixes
+  # in the 7.x line (CVE-2026-84961, CVE-2026-18540, CVE-2026-84890 and more).
+  - undici@7.29.1

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "4.30.0",
+  "version": "4.31.0",
   "private": true,
   "license": "MIT",
   "engines": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "4.31.0",
+  "version": "4.32.0",
   "private": true,
   "license": "MIT",
   "engines": {

--- a/web/src/__tests__/server/datasets-metrics.servertest.ts
+++ b/web/src/__tests__/server/datasets-metrics.servertest.ts
@@ -44,7 +44,7 @@ const session: Session = {
       experimentsV4Enabled: false,
       searchBar: false,
     },
-    v4BetaEnabled: true,
+    v4BetaEnabled: false,
     admin: true,
   },
   environment: {} as any,

--- a/web/src/constants/VERSION.ts
+++ b/web/src/constants/VERSION.ts
@@ -1,1 +1,1 @@
-export const VERSION = "v4.31.0";
+export const VERSION = "v4.32.0";

--- a/web/src/constants/VERSION.ts
+++ b/web/src/constants/VERSION.ts
@@ -1,1 +1,1 @@
-export const VERSION = "v4.30.0";
+export const VERSION = "v4.31.0";

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -492,7 +492,7 @@ export const datasetRouter = createTRPCRouter({
       if (input.datasetIds.length === 0) return { metrics: [] };
 
       const [runsMetrics, itemsCounts] = await Promise.all([
-        env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "events_only"
+        ctx.session.user.v4BetaEnabled === true
           ? getDatasetExperimentMetricsFromEvents({
               projectId: input.projectId,
               datasetIds: input.datasetIds,

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "4.30.0",
+  "version": "4.31.0",
   "description": "",
   "license": "MIT",
   "private": true,

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "4.31.0",
+  "version": "4.32.0",
   "description": "",
   "license": "MIT",
   "private": true,

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -15,10 +15,11 @@ const originalCloudRegion = vi.hoisted(() => {
   return cloudRegion;
 });
 
-// Override recordIncrement + recordHistogram so the attempt counter and
-// per-stage timing metrics are assertable.
+// Override recordIncrement + recordHistogram + recordDistribution so the
+// attempt counter, per-stage timing, and freshness-lag metrics are assertable.
 const mockRecordIncrement = vi.hoisted(() => vi.fn());
 const mockRecordHistogram = vi.hoisted(() => vi.fn());
+const mockRecordDistribution = vi.hoisted(() => vi.fn());
 // Stubbable endpoint preflight — the customer-fault tests reject it to drive an
 // in-try failure without infra. Defaults to the real impl for other tests.
 const mockValidateBlobStorageEndpoint = vi.hoisted(() => vi.fn());
@@ -34,6 +35,7 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
     ...actual,
     recordIncrement: mockRecordIncrement,
     recordHistogram: mockRecordHistogram,
+    recordDistribution: mockRecordDistribution,
     validateBlobStorageEndpoint: mockValidateBlobStorageEndpoint,
   };
 });
@@ -54,7 +56,9 @@ import {
   createEventsCh,
   StorageService,
   StorageServiceFactory,
+  BlobStorageIntegrationProcessingQueue,
 } from "@langfuse/shared/src/server";
+import { EXPORT_FRESHNESS_LAG_METRIC } from "../services/exportFreshnessLagMetric";
 import { prisma } from "@langfuse/shared/src/db";
 import { Job } from "bullmq";
 import {
@@ -1836,6 +1840,78 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         updatedIntegration.nextSyncAt.getTime() - now.getTime(),
       );
       expect(timeDiff).toBeLessThan(5000); // Within 5 seconds
+    });
+
+    it("records freshness success when catch-up enqueue fails after the watermark advances", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+      const now = new Date();
+      const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
+
+      const trace = createTrace({
+        project_id: projectId,
+        timestamp: twoDaysAgo.getTime(),
+        name: "Old Trace",
+      });
+      await createTracesCh([trace]);
+
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId,
+          type: BlobStorageIntegrationType.S3,
+          bucketName,
+          prefix: s3Prefix,
+          accessKeyId: minioAccessKeyId,
+          secretAccessKey: encrypt(minioAccessKeySecret),
+          region: region ? region : "auto",
+          endpoint: minioEndpoint,
+          forcePathStyle:
+            env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+          enabled: true,
+          exportFrequency: "hourly",
+          lastSyncAt: twoDaysAgo,
+          compressed: false,
+        },
+      });
+
+      const add = vi.fn().mockRejectedValue(new Error("redis down"));
+      const getInstanceSpy = vi
+        .spyOn(BlobStorageIntegrationProcessingQueue, "getInstance")
+        .mockReturnValue({ add } as never);
+      mockRecordDistribution.mockClear();
+
+      try {
+        await expect(
+          handleBlobStorageIntegrationProjectJob({
+            data: { payload: { projectId } },
+          } as Job),
+        ).rejects.toThrow(/redis down/);
+
+        const updatedIntegration =
+          await prisma.blobStorageIntegration.findUnique({
+            where: { projectId },
+          });
+        expect(updatedIntegration?.lastSyncAt?.getTime()).toBe(
+          twoDaysAgo.getTime() + 60 * 60 * 1000,
+        );
+        expect(add).toHaveBeenCalled();
+        expect(mockRecordDistribution).toHaveBeenCalledWith(
+          EXPORT_FRESHNESS_LAG_METRIC,
+          expect.any(Number),
+          expect.objectContaining({
+            integration: "blob_storage",
+            window: "1h",
+            status: "success",
+          }),
+        );
+        expect(mockRecordDistribution).not.toHaveBeenCalledWith(
+          EXPORT_FRESHNESS_LAG_METRIC,
+          expect.anything(),
+          expect.objectContaining({ status: "failure" }),
+        );
+      } finally {
+        getInstanceSpy.mockRestore();
+      }
     });
 
     it("should coalesce a sub-second remainder instead of emitting a colliding chunk", async () => {

--- a/worker/src/__tests__/exportFreshnessLagMetric.test.ts
+++ b/worker/src/__tests__/exportFreshnessLagMetric.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const recordDistribution = vi.fn();
+vi.mock("@langfuse/shared/src/server", () => ({
+  recordDistribution: (...args: unknown[]) => recordDistribution(...args),
+}));
+
+import {
+  recordExportFreshnessLag,
+  windowClassFromBlobFrequency,
+  EXPORT_FRESHNESS_LAG_METRIC,
+} from "../services/exportFreshnessLagMetric";
+
+describe("recordExportFreshnessLag", () => {
+  const runStartTime = new Date("2026-09-08T12:00:00.000Z");
+
+  beforeEach(() => recordDistribution.mockClear());
+
+  it("emits runStart − watermark in seconds as a distribution, without project_id", () => {
+    recordExportFreshnessLag({
+      integration: "blob_storage",
+      window: "20m",
+      status: "success",
+      runStartTime,
+      maxExportedTimestamp: new Date("2026-09-08T11:40:00.000Z"),
+    });
+
+    expect(recordDistribution).toHaveBeenCalledWith(
+      EXPORT_FRESHNESS_LAG_METRIC,
+      1200,
+      {
+        integration: "blob_storage",
+        window: "20m",
+        status: "success",
+        unit: "seconds",
+      },
+    );
+    expect(recordDistribution.mock.calls[0][2]).not.toHaveProperty(
+      "project_id",
+    );
+    expect(recordDistribution.mock.calls[0][2]).not.toHaveProperty("projectId");
+  });
+
+  it("emits failing runs against the unchanged watermark so stall shows as rising lag", () => {
+    recordExportFreshnessLag({
+      integration: "posthog",
+      window: "1h",
+      status: "failure",
+      runStartTime,
+      maxExportedTimestamp: new Date("2026-09-08T06:00:00.000Z"),
+    });
+
+    expect(recordDistribution).toHaveBeenCalledWith(
+      EXPORT_FRESHNESS_LAG_METRIC,
+      6 * 60 * 60,
+      {
+        integration: "posthog",
+        window: "1h",
+        status: "failure",
+        unit: "seconds",
+      },
+    );
+  });
+
+  it("skips when there is no watermark yet", () => {
+    recordExportFreshnessLag({
+      integration: "mixpanel",
+      window: "1h",
+      status: "failure",
+      runStartTime,
+      maxExportedTimestamp: null,
+    });
+    recordExportFreshnessLag({
+      integration: "mixpanel",
+      window: "1h",
+      status: "success",
+      runStartTime,
+      maxExportedTimestamp: undefined,
+    });
+    expect(recordDistribution).not.toHaveBeenCalled();
+  });
+
+  it("clamps a watermark ahead of run start to zero", () => {
+    recordExportFreshnessLag({
+      integration: "blob_storage",
+      window: "1d",
+      status: "success",
+      runStartTime,
+      maxExportedTimestamp: new Date("2026-09-08T12:05:00.000Z"),
+    });
+    expect(recordDistribution).toHaveBeenCalledWith(
+      EXPORT_FRESHNESS_LAG_METRIC,
+      0,
+      expect.objectContaining({ status: "success", window: "1d" }),
+    );
+  });
+});
+
+describe("windowClassFromBlobFrequency", () => {
+  it("maps configured blob cadences to window classes", () => {
+    expect(windowClassFromBlobFrequency("every_20_minutes")).toBe("20m");
+    expect(windowClassFromBlobFrequency("hourly")).toBe("1h");
+    expect(windowClassFromBlobFrequency("daily")).toBe("1d");
+    expect(windowClassFromBlobFrequency("weekly")).toBe("1w");
+  });
+
+  it("rejects an unknown frequency", () => {
+    expect(() => windowClassFromBlobFrequency("monthly")).toThrow(
+      /Unsupported export frequency/,
+    );
+  });
+});

--- a/worker/src/__tests__/mixpanelIntegrationProjectJob.test.ts
+++ b/worker/src/__tests__/mixpanelIntegrationProjectJob.test.ts
@@ -128,6 +128,7 @@ vi.mock("@langfuse/shared/src/server", () => ({
   QueueName: { MixpanelIntegrationProcessingQueue: "mixpanel" },
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
   recordIncrement: vi.fn(),
+  recordDistribution: vi.fn(),
   getCurrentSpan: vi.fn(() => undefined),
   getTracesForAnalyticsIntegrations: vi.fn(() => h.fakeStream("traces")),
   getGenerationsForAnalyticsIntegrations: vi.fn(() =>
@@ -145,7 +146,10 @@ import {
 import {
   getScoresForAnalyticsIntegrations,
   recordIncrement,
+  recordDistribution,
 } from "@langfuse/shared/src/server";
+import { decrypt } from "@langfuse/shared/encryption";
+import { EXPORT_FRESHNESS_LAG_METRIC } from "../services/exportFreshnessLagMetric";
 import { env } from "../env";
 
 // Mirrors the real queue's defaultJobOptions (mixpanelIntegrationProcessingQueue.ts).
@@ -361,5 +365,27 @@ describe("handleMixpanelIntegrationProjectJob customer-fault observability", () 
     );
 
     expect(recordIncrement).not.toHaveBeenCalled();
+  });
+
+  it("emits freshness failure when decrypt throws before export work starts", async () => {
+    vi.mocked(decrypt).mockImplementationOnce(() => {
+      throw new Error("bad token");
+    });
+    vi.mocked(recordDistribution).mockClear();
+
+    await expect(
+      handleMixpanelIntegrationProjectJob(makeJob()),
+    ).rejects.toThrow(/bad token/);
+
+    expect(recordDistribution).toHaveBeenCalledWith(
+      EXPORT_FRESHNESS_LAG_METRIC,
+      expect.any(Number),
+      expect.objectContaining({
+        integration: "mixpanel",
+        window: "1h",
+        status: "failure",
+      }),
+    );
+    expect(h.mixpanelIntegrationUpdate).not.toHaveBeenCalled();
   });
 });

--- a/worker/src/__tests__/posthogIntegrationProjectJob.test.ts
+++ b/worker/src/__tests__/posthogIntegrationProjectJob.test.ts
@@ -92,6 +92,7 @@ const h = vi.hoisted(() => {
   // hostname) and the customer notification, both controllable per test.
   const validateWebhookURL = vi.fn(async () => {});
   const recordIncrement = vi.fn();
+  const recordDistribution = vi.fn();
   const dispatchProjectNotification = vi.fn(async () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     try {
@@ -143,6 +144,7 @@ const h = vi.hoisted(() => {
     notification,
     validateWebhookURL,
     recordIncrement,
+    recordDistribution,
     dispatchProjectNotification,
     OutboundUrlValidationError,
     getTraces,
@@ -174,6 +176,7 @@ vi.mock("@langfuse/shared/src/server", () => ({
   QueueName: { PostHogIntegrationProcessingQueue: "posthog" },
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
   recordIncrement: h.recordIncrement,
+  recordDistribution: h.recordDistribution,
   getCurrentSpan: vi.fn(() => undefined),
   validateWebhookURL: h.validateWebhookURL,
   dispatchProjectNotification: h.dispatchProjectNotification,
@@ -277,6 +280,7 @@ function resetSharedState() {
   h.notification.settled = false;
   h.notification.rejects = false;
   h.recordIncrement.mockClear();
+  h.recordDistribution.mockClear();
   h.validateWebhookURL.mockReset();
   h.validateWebhookURL.mockImplementation(async () => {});
   h.dispatchProjectNotification.mockClear();

--- a/worker/src/constants/VERSION.ts
+++ b/worker/src/constants/VERSION.ts
@@ -1,1 +1,1 @@
-export const VERSION = "v4.31.0";
+export const VERSION = "v4.32.0";

--- a/worker/src/constants/VERSION.ts
+++ b/worker/src/constants/VERSION.ts
@@ -1,1 +1,1 @@
-export const VERSION = "v4.30.0";
+export const VERSION = "v4.31.0";

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -76,6 +76,10 @@ import { env } from "../../env";
 import { assertExportSourceWritable } from "../exportWriteModeGuard";
 import { recordExportVolume } from "../../services/exportVolumeMetric";
 import {
+  recordExportFreshnessLag,
+  windowClassFromBlobFrequency,
+} from "../../services/exportFreshnessLagMetric";
+import {
   buildBlobExportManifest,
   buildBlobExportManifestKey,
   formatBlobExportTimestamp,
@@ -1216,9 +1220,10 @@ export const handleBlobStorageIntegrationProjectJob = async (
     return;
   }
 
+  const runStartTime = new Date();
   const { count: claimed } = await prisma.blobStorageIntegration.updateMany({
     where: { projectId },
-    data: { runStartedAt: new Date() },
+    data: { runStartedAt: runStartTime },
   });
   if (claimed === 0) {
     logger.info(
@@ -1275,6 +1280,15 @@ export const handleBlobStorageIntegrationProjectJob = async (
         lastErrorAt: null,
       },
     });
+    recordExportFreshnessLag({
+      integration: "blob_storage",
+      window: windowClassFromBlobFrequency(
+        blobStorageIntegration.exportFrequency,
+      ),
+      status: "success",
+      runStartTime,
+      maxExportedTimestamp: blobStorageIntegration.lastSyncAt,
+    });
     return;
   }
 
@@ -1282,6 +1296,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
   // self-hosted), so the deprecation notice below is Cloud-only too.
   const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
+  let watermarkAdvanced = false;
   try {
     // The catch persists lastError and notifies admins.
     assertExportSourceWritable(
@@ -1510,6 +1525,20 @@ export const handleBlobStorageIntegrationProjectJob = async (
       return;
     }
 
+    // The export watermark is committed. Catch-up enqueue below can still
+    // fail (Redis); that must not be recorded as an export-freshness failure
+    // against the pre-run lastSyncAt.
+    recordExportFreshnessLag({
+      integration: "blob_storage",
+      window: windowClassFromBlobFrequency(
+        blobStorageIntegration.exportFrequency,
+      ),
+      status: "success",
+      runStartTime,
+      maxExportedTimestamp: maxTimestamp,
+    });
+    watermarkAdvanced = true;
+
     // If still catching up, immediately queue the next chunk job
     if (!caughtUp) {
       const queue = BlobStorageIntegrationProcessingQueue.getInstance();
@@ -1550,6 +1579,18 @@ export const handleBlobStorageIntegrationProjectJob = async (
 
     if (outcome.kind === "integration-deleted") {
       return; // obsolete job: complete it rather than fail it
+    }
+
+    if (!watermarkAdvanced) {
+      recordExportFreshnessLag({
+        integration: "blob_storage",
+        window: windowClassFromBlobFrequency(
+          blobStorageIntegration.exportFrequency,
+        ),
+        status: "failure",
+        runStartTime,
+        maxExportedTimestamp: blobStorageIntegration.lastSyncAt,
+      });
     }
 
     switch (outcome.kind) {

--- a/worker/src/features/mixpanel/handleMixpanelIntegrationProjectJob.ts
+++ b/worker/src/features/mixpanel/handleMixpanelIntegrationProjectJob.ts
@@ -14,6 +14,7 @@ import {
 import { decrypt } from "@langfuse/shared/encryption";
 import { MixpanelClient } from "./mixpanelClient";
 import { recordExportVolume } from "../../services/exportVolumeMetric";
+import { recordExportFreshnessLag } from "../../services/exportFreshnessLagMetric";
 import {
   transformTraceForMixpanel,
   transformGenerationForMixpanel,
@@ -249,21 +250,23 @@ export const handleMixpanelIntegrationProjectJob = async (
     return;
   }
 
-  // Fetch relevant data and send it to Mixpanel
-  const executionConfig: MixpanelExecutionConfig = {
-    projectId,
-    projectName: mixpanelIntegration.project.name,
-    // Start from 2000-01-01 if no lastSyncAt. Workaround because 1970-01-01 leads to subtle bugs in ClickHouse
-    minTimestamp: mixpanelIntegration.lastSyncAt || new Date("2000-01-01"),
-    maxTimestamp: new Date(new Date().getTime() - 30 * 60 * 1000), // 30 minutes ago
-    decryptedMixpanelProjectToken: decrypt(
-      mixpanelIntegration.encryptedMixpanelProjectToken,
-    ),
-    mixpanelRegion: mixpanelIntegration.mixpanelRegion,
-    useGraceHash: job.attemptsMade > 0,
-  };
+  const runStartTime = new Date();
 
   try {
+    // Fetch relevant data and send it to Mixpanel
+    const executionConfig: MixpanelExecutionConfig = {
+      projectId,
+      projectName: mixpanelIntegration.project.name,
+      // Start from 2000-01-01 if no lastSyncAt. Workaround because 1970-01-01 leads to subtle bugs in ClickHouse
+      minTimestamp: mixpanelIntegration.lastSyncAt || new Date("2000-01-01"),
+      maxTimestamp: new Date(new Date().getTime() - 30 * 60 * 1000), // 30 minutes ago
+      decryptedMixpanelProjectToken: decrypt(
+        mixpanelIntegration.encryptedMixpanelProjectToken,
+      ),
+      mixpanelRegion: mixpanelIntegration.mixpanelRegion,
+      useGraceHash: job.attemptsMade > 0,
+    };
+
     // Fail loudly before exporting empty data and advancing lastSyncAt
     // (LFE-10148, LFE-11009); the catch below logs and BullMQ retries.
     assertExportSourceWritable(
@@ -314,10 +317,24 @@ export const handleMixpanelIntegrationProjectJob = async (
       bytes: mixpanel.getSerializedBytes(),
       projectId,
     });
+    recordExportFreshnessLag({
+      integration: "mixpanel",
+      window: "1h",
+      status: "success",
+      runStartTime,
+      maxExportedTimestamp: executionConfig.maxTimestamp,
+    });
     logger.info(
       `[MIXPANEL] Mixpanel integration processing complete for project ${projectId}`,
     );
   } catch (error) {
+    recordExportFreshnessLag({
+      integration: "mixpanel",
+      window: "1h",
+      status: "failure",
+      runStartTime,
+      maxExportedTimestamp: mixpanelIntegration.lastSyncAt,
+    });
     const mixpanelFaultReason = classifyCustomerFault(error);
     if (mixpanelFaultReason !== undefined) {
       recordIncrement(MIXPANEL_INTEGRATION_CUSTOMER_FAULT_METRIC, 1, {

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -28,6 +28,7 @@ import {
 import { decrypt } from "@langfuse/shared/encryption";
 import { PostHog } from "posthog-node";
 import { recordExportVolume } from "../../services/exportVolumeMetric";
+import { recordExportFreshnessLag } from "../../services/exportFreshnessLagMetric";
 import { assertExportSourceWritable } from "../exportWriteModeGuard";
 import { classifyCustomerFault } from "../integrations/customerFaultClassification";
 import { isRecordNotFoundError } from "../integrations/prismaErrors";
@@ -284,6 +285,8 @@ export const handlePostHogIntegrationProjectJob = async (
     return;
   }
 
+  const runStartTime = new Date();
+
   try {
     // Validate PostHog hostname to prevent SSRF attacks before sending data.
     // Rewrap preserving { cause } so the single catch below can classify the
@@ -327,6 +330,13 @@ export const handlePostHogIntegrationProjectJob = async (
       logger.info(
         `[POSTHOG] Skipping PostHog integration for project ${projectId}: empty sync window (min: ${minTimestamp.toISOString()}, max: ${maxTimestamp.toISOString()})`,
       );
+      recordExportFreshnessLag({
+        integration: "posthog",
+        window: "1h",
+        status: "success",
+        runStartTime,
+        maxExportedTimestamp: postHogIntegration.lastSyncAt,
+      });
       return;
     }
 
@@ -425,6 +435,13 @@ export const handlePostHogIntegrationProjectJob = async (
       bytes: executionConfig.volume.bytes,
       projectId,
     });
+    recordExportFreshnessLag({
+      integration: "posthog",
+      window: "1h",
+      status: "success",
+      runStartTime,
+      maxExportedTimestamp: executionConfig.maxTimestamp,
+    });
     logger.info(
       `[POSTHOG] PostHog integration processing complete for project ${projectId}`,
     );
@@ -443,6 +460,14 @@ export const handlePostHogIntegrationProjectJob = async (
     const message = (
       error instanceof Error ? error.message : String(error)
     ).slice(0, 1000);
+
+    recordExportFreshnessLag({
+      integration: "posthog",
+      window: "1h",
+      status: "failure",
+      runStartTime,
+      maxExportedTimestamp: postHogIntegration.lastSyncAt,
+    });
 
     if (reason === undefined) {
       // Defensive fallback: every code today either classifies above and

--- a/worker/src/services/exportFreshnessLagMetric.ts
+++ b/worker/src/services/exportFreshnessLagMetric.ts
@@ -1,0 +1,62 @@
+import { recordDistribution } from "@langfuse/shared/src/server";
+
+export const EXPORT_FRESHNESS_LAG_METRIC =
+  "langfuse.export.freshness_lag_seconds";
+
+export type ExportFreshnessIntegration =
+  | "blob_storage"
+  | "posthog"
+  | "mixpanel";
+
+export type ExportFreshnessWindow = "20m" | "1h" | "1d" | "1w";
+
+export type ExportFreshnessStatus = "success" | "failure";
+
+const BLOB_FREQUENCY_TO_WINDOW: Record<string, ExportFreshnessWindow> = {
+  every_20_minutes: "20m",
+  hourly: "1h",
+  daily: "1d",
+  weekly: "1w",
+};
+
+export const windowClassFromBlobFrequency = (
+  frequency: string,
+): ExportFreshnessWindow => {
+  const window = BLOB_FREQUENCY_TO_WINDOW[frequency];
+  if (!window) {
+    throw new Error(`Unsupported export frequency: ${frequency}`);
+  }
+  return window;
+};
+
+/**
+ * Seconds the newest successfully-exported timestamp lags this run's start.
+ * On success, pass the watermark just written (this run's maxTimestamp).
+ * On failure, pass the unchanged lastSyncAt so lag climbs until recovery.
+ * First runs with no watermark yet are skipped.
+ */
+export const recordExportFreshnessLag = ({
+  integration,
+  window,
+  status,
+  runStartTime,
+  maxExportedTimestamp,
+}: {
+  integration: ExportFreshnessIntegration;
+  window: ExportFreshnessWindow;
+  status: ExportFreshnessStatus;
+  runStartTime: Date;
+  maxExportedTimestamp: Date | null | undefined;
+}): void => {
+  if (!maxExportedTimestamp) {
+    return;
+  }
+  const lagSeconds =
+    (runStartTime.getTime() - maxExportedTimestamp.getTime()) / 1000;
+  recordDistribution(EXPORT_FRESHNESS_LAG_METRIC, Math.max(0, lagSeconds), {
+    integration,
+    window,
+    status,
+    unit: "seconds",
+  });
+};


### PR DESCRIPTION
## What does this PR do?

Fixes #17153

`generateConfusionMatrixData` keyed its lookup map on `` `${row_category}-${col_category}` ``. Since category names are user-defined categorical score values and can contain `-`, distinct (row, column) pairs could produce the same key, and the affected cells rendered the wrong count in the score comparison confusion matrix.

The map is now keyed on `JSON.stringify([row_category, col_category])`, which is unambiguous for any pair of strings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- Regression test added to `web/src/__tests__/heatmap-utils.clienttest.ts` ("should not collide cells when categories contain the key delimiter"): fails before the fix (cell for `a-b`/`c` returns 99 instead of 10), passes after.
- `heatmap-utils.clienttest.ts`: 14/14 tests pass (13 existing + 1 new).

Test caveat: I could not install the full monorepo dependencies in my environment (pnpm install repeatedly stalled on network), so I ran the relevant vitest suite directly against the repo sources with minimal module aliases (zod, `@langfuse/shared` shim, `@/src` alias), mirroring the suite's node environment. The touched module is dependency-free. As an additional sanity sweep, the other web client tests runnable this way also pass: 72/72 across filter-query-encoding-decoding, buildTableFilterHref, eventsTablePaths, evaluatorScoresUrl, ruleExecutionsUrl, and evaluatorMigrationUrls.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes score-comparison confusion-matrix key collisions by replacing delimiter-concatenated lookup keys with serialized string tuples.
- Uses the same unambiguous tuple encoding for map insertion and lookup.
- Adds a focused regression test covering two category pairs that previously generated the same key.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the new key representation is unambiguous for the function’s string inputs and is covered by an effective regression test.

Map writes and reads now use the same serialized two-string tuple, eliminating the reported delimiter collision without changing category enumeration, counts, or percentage calculations.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): use tuple key for confusion ma..."](https://github.com/langfuse/langfuse/commit/b3790db9a4bba93b113b6a8b9896d1b7b31783f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61466531)</sub>

<!-- /greptile_comment -->