### PR TITLE
fix(shared): align in-memory null filters with column semantics

### DIFF
--- a/packages/shared/src/server/services/InMemoryFilterService.ts
+++ b/packages/shared/src/server/services/InMemoryFilterService.ts
@@ -2,6 +2,10 @@ import { FilterCondition, FilterState } from "../../types";
 import { logger } from "../logger";
 import { encodeBooleanScoreEntry } from "../queries/clickhouse-sql/clickhouse-filter";
 
+export type InMemoryFilterOptions = {
+  emptyEqualsNullColumns?: ReadonlySet<string>;
+};
+
 export class InMemoryFilterService {
   /**
    * Evaluates whether a data object matches the given filter conditions.
@@ -9,12 +13,14 @@ export class InMemoryFilterService {
    * @param data - The data object to evaluate
    * @param filter - The filter conditions to apply
    * @param fieldMapper - Function to map filter column names to data object values
+   * @param options - Column-specific filter semantics
    * @returns true if the data matches all filter conditions, false otherwise
    */
   static evaluateFilter<T>(
     data: T,
     filter: FilterState,
     fieldMapper: (data: T, column: string) => unknown,
+    options?: InMemoryFilterOptions,
   ): boolean {
     try {
       // If no filters, data matches
@@ -24,7 +30,9 @@ export class InMemoryFilterService {
 
       // Evaluate each filter condition
       for (const condition of filter) {
-        if (!this.evaluateFilterCondition(data, condition, fieldMapper)) {
+        if (
+          !this.evaluateFilterCondition(data, condition, fieldMapper, options)
+        ) {
           return false;
         }
       }
@@ -47,6 +55,7 @@ export class InMemoryFilterService {
     data: T,
     condition: FilterCondition,
     fieldMapper: (data: T, column: string) => unknown,
+    options?: InMemoryFilterOptions,
   ): boolean {
     const { column, type, operator } = condition;
 
@@ -111,7 +120,11 @@ export class InMemoryFilterService {
           operator,
         );
       case "null":
-        return this.evaluateNullFilter(fieldValue, operator);
+        return this.evaluateNullFilter(
+          fieldValue,
+          operator,
+          options?.emptyEqualsNullColumns?.has(column) ?? false,
+        );
       case "positionInTrace":
         // Position filters are applied after all other filters in DB queries.
         // Ignore them in in-memory filtering.
@@ -434,14 +447,18 @@ export class InMemoryFilterService {
   private static evaluateNullFilter(
     fieldValue: unknown,
     operator: string,
+    emptyEqualsNull: boolean,
   ): boolean {
+    const isNull =
+      fieldValue === null ||
+      fieldValue === undefined ||
+      (emptyEqualsNull && fieldValue === "");
+
     switch (operator) {
       case "is null":
-        return (
-          fieldValue === null || fieldValue === undefined || fieldValue === ""
-        );
+        return isNull;
       case "is not null":
-        return fieldValue !== null && fieldValue !== undefined;
+        return !isNull;
       default:
         logger.error("Unsupported null filter operator", {
           operator,

--- a/worker/src/__tests__/inMemoryFilterService.test.ts
+++ b/worker/src/__tests__/inMemoryFilterService.test.ts
@@ -1093,6 +1093,33 @@ describe("InMemoryFilterService", () => {
       ).toBe(true);
     });
 
+    test("treats an empty string as a non-null value by default", () => {
+      const dataWithEmptyString = { ...mockData, release: "" };
+
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          dataWithEmptyString,
+          [{ column: "release", type: "null", operator: "is null", value: "" }],
+          fieldMapper,
+        ),
+      ).toBe(false);
+
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          dataWithEmptyString,
+          [
+            {
+              column: "release",
+              type: "null",
+              operator: "is not null",
+              value: "",
+            },
+          ],
+          fieldMapper,
+        ),
+      ).toBe(true);
+    });
+
     test("evaluates multiple filters with AND logic", () => {
       expect(
         InMemoryFilterService.evaluateFilter(

--- a/worker/src/__tests__/inMemoryFilterService.test.ts
+++ b/worker/src/__tests__/inMemoryFilterService.test.ts
@@ -1093,7 +1093,7 @@ describe("InMemoryFilterService", () => {
       ).toBe(true);
     });
 
-    test("treats an empty string as a non-null value by default", () => {
+    test("applies empty-string null semantics per column", () => {
       const dataWithEmptyString = { ...mockData, release: "" };
 
       expect(
@@ -1118,6 +1118,33 @@ describe("InMemoryFilterService", () => {
           fieldMapper,
         ),
       ).toBe(true);
+
+      const emptyEqualsNullColumns = new Set(["release"]);
+
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          dataWithEmptyString,
+          [{ column: "release", type: "null", operator: "is null", value: "" }],
+          fieldMapper,
+          { emptyEqualsNullColumns },
+        ),
+      ).toBe(true);
+
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          dataWithEmptyString,
+          [
+            {
+              column: "release",
+              type: "null",
+              operator: "is not null",
+              value: "",
+            },
+          ],
+          fieldMapper,
+          { emptyEqualsNullColumns },
+        ),
+      ).toBe(false);
     });
 
     test("evaluates multiple filters with AND logic", () => {

--- a/worker/src/features/evaluation/observationEval/__tests__/filterEvaluation.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/filterEvaluation.test.ts
@@ -1053,6 +1053,33 @@ describe("Filter Evaluation for Observation Evals", () => {
       expect(matched).toBe(true);
     });
 
+    it("should treat an empty parentObservationId as null", async () => {
+      const observation = createTestObservation({
+        project_id: projectId,
+        parent_span_id: "",
+      });
+
+      const isNullMatch = await testFilterMatch(observation, [
+        {
+          column: "parentObservationId",
+          type: "null",
+          operator: "is null",
+          value: "",
+        },
+      ]);
+      const isNotNullMatch = await testFilterMatch(observation, [
+        {
+          column: "parentObservationId",
+          type: "null",
+          operator: "is not null",
+          value: "",
+        },
+      ]);
+
+      expect(isNullMatch).toBe(true);
+      expect(isNotNullMatch).toBe(false);
+    });
+
     it("should not match observations where parentObservationId is not null (child observations)", async () => {
       const observation = createTestObservation({
         project_id: projectId,

--- a/worker/src/features/evaluation/observationEval/scheduleObservationEvals.ts
+++ b/worker/src/features/evaluation/observationEval/scheduleObservationEvals.ts
@@ -25,6 +25,10 @@ import {
 import { createW3CTraceId } from "../../utils";
 import { isInternalEvalEnvironment } from "../isEvalTargetEnvironmentAllowed";
 
+const OBSERVATION_FILTER_EMPTY_EQUALS_NULL_COLUMNS = new Set([
+  "parentObservationId",
+]);
+
 interface ScheduleObservationEvalsParams {
   observation: ObservationForEval;
   configs: ObservationEvalRule[];
@@ -375,6 +379,9 @@ function evaluateFilter(
         observation,
         filterConditions,
         fieldMapper,
+        {
+          emptyEqualsNullColumns: OBSERVATION_FILTER_EMPTY_EQUALS_NULL_COLUMNS,
+        },
       );
 
   return isFilterMatch;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17160 app preview](https://pr-17160.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Makes in-memory null filtering follow each column's ClickHouse empty-string semantics. Ordinary columns treat `""` as a regular non-null value, while the events-backed parent-observation column continues to treat `""` as null.

A global removal of empty-string handling would fix trace filters but regress observation eval scheduling: root events store `parent_span_id` as an empty string and their canonical ClickHouse mapping sets `emptyEqualsNull: true`. The service now accepts the same semantic explicitly per column, and both null operators are complementary.

Impacted packages: `@langfuse/shared`, `worker`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the affected call sites and ClickHouse mappings.
- [x] Added focused unit and observation-scheduler regression coverage.
- [x] Checked documentation impact; no user-facing contract changed.

## Verification

- Red test before implementation: `Tests 1 failed | 16 skipped (17)`; expected `false`, received `true` for an ordinary empty-string `is null` filter.
- In-memory filter suite: `Tests 17 passed (17)`.
- Observation filter scheduler suite: `Tests 61 passed (61)`.
- ClickHouse empty-equals-null contract suite: `Tests 19 passed (19)`.
- Forced lint: `Tasks: 7 successful, 7 total`; `Cached: 0 cached, 7 total`.
- Typecheck: `Tasks: 8 successful, 8 total`; `Cached: 2 cached, 8 total`.
- `pnpm exec knip`: exit code 0.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-16064](https://linear.app/clickhouse/issue/LFE-16064/bug-in-memory-is-not-null-filter-matches-empty-strings-diverging-from)

<div><a href="https://cursor.com/agents/bc-b9adb90f-569c-4a39-bea2-4ac9898c52b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9adb90f-569c-4a39-bea2-4ac9898c52b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds regression assertions intended to make in-memory null filtering treat empty strings as non-null by default.
- Adds coverage for both `"is null"` and `"is not null"` with an empty `release` value.
- Does not change the production null-filter implementation, so the new `"is null"` assertion contradicts current behavior.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR is not safe to merge until the in-memory null-filter implementation is updated to satisfy the new regression test.

The newly added `"is null"` assertion expects `false` for an empty string, while the unchanged service explicitly returns `true`, causing the test to fail and leaving the intended behavioral fix absent.

**Files Needing Attention:** worker/src/__tests__/inMemoryFilterService.test.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/__tests__/inMemoryFilterService.test.ts:1105
**Assertion fails against implementation**

This assertion expects `false` when `release` is an empty string, but the unchanged `evaluateNullFilter` implementation explicitly treats `""` as null and returns `true`. Because this PR changes only the test, the new regression test fails and the intended behavior is not implemented.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(worker): cover empty-string null fi..."](https://github.com/langfuse/langfuse/commit/6196afc63b72ecb83627253a74ed77d22ec8f7f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61476702)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->