### PR TITLE
Restrict score source on public ingestion to API and ANNOTATION

### DIFF
--- a/packages/shared/src/server/ingestion/types.test.ts
+++ b/packages/shared/src/server/ingestion/types.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { createIngestionEventSchema } from "./types";
+
+const scoreCreateEvent = (source?: string) => ({
+  id: "evt-1",
+  type: "score-create",
+  timestamp: "2026-01-01T00:00:00.000Z",
+  body: {
+    name: "answer-correctness",
+    value: 1,
+    dataType: "NUMERIC",
+    traceId: "trace-1",
+    ...(source ? { source } : {}),
+  },
+});
+
+describe("ingestion score-create source restrictions", () => {
+  it("rejects source EVAL on the public ingestion schema", () => {
+    const schema = createIngestionEventSchema(false);
+    const result = schema.safeParse(scoreCreateEvent("EVAL"));
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts source API on the public ingestion schema", () => {
+    const schema = createIngestionEventSchema(false);
+    const result = schema.safeParse(scoreCreateEvent("API"));
+    expect(result.success).toBe(true);
+  });
+
+  it("defaults an omitted source to API on the public ingestion schema", () => {
+    const schema = createIngestionEventSchema(false);
+    const result = schema.safeParse(scoreCreateEvent());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as any).body.source).toBe("API");
+    }
+  });
+
+  it("keeps source EVAL available on the internal ingestion schema", () => {
+    const schema = createIngestionEventSchema(true);
+    const result = schema.safeParse(scoreCreateEvent("EVAL"));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as any).body.source).toBe("EVAL");
+    }
+  });
+});

--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { NonEmptyString, jsonSchema } from "../../utils/zod";
 import { ModelUsageUnit } from "../../constants";
 import { ScoreSourceType } from "../../domain";
-import { TEXT_SCORE_MAX_LENGTH } from "../../domain/scores";
+import { PublicApiCreateScoreSourceDomain, TEXT_SCORE_MAX_LENGTH } from "../../domain/scores";
 import { applyScoreValidation } from "../../utils/scores";
 
 export const idSchema = z
@@ -538,9 +538,16 @@ const createAllIngestionSchemas = ({
     observationId: z.string().nullish(),
     comment: z.string().nullish(),
     metadata: jsonSchema.nullish(),
-    source: z
-      .enum(["API", "EVAL", "ANNOTATION"])
-      .default("API" as ScoreSourceType),
+    // Measurement provenance must not be caller-declared on the public
+    // ingestion path: EVAL is reserved for the evaluation worker and
+    // ANNOTATION for authenticated annotator sessions, mirroring the
+    // restriction POST /api/public/scores already enforces via
+    // PublicApiCreateScoreSourceDomain. Internal ingestion (the evaluation
+    // worker itself) keeps the full enum.
+    source: (isPublic
+      ? PublicApiCreateScoreSourceDomain
+      : z.enum(["API", "EVAL", "ANNOTATION"])
+    ).default("API" as ScoreSourceType),
     executionTraceId: z.string().nullish(),
     queueId: z.string().nullish(),
   });


### PR DESCRIPTION
## Description

`POST /api/public/scores` restricts the score `source` to `API` and `ANNOTATION` via `PublicApiCreateScoreSourceDomain`, and the domain type documents that "EVAL is reserved for internal evaluator outputs". The public ingestion endpoint accepted `score-create` events with any source, including `EVAL`, and stored the client-declared timestamp verbatim.

The ingestion path is reachable with the public key alone (Bearer auth yields accessLevel `scores`, and `score-create` is authorized at that level), and public keys are by design embedded in client-side applications. Any holder could therefore append scores that the product presents as evaluator output, flowing into the same score-name aggregations as real evaluator scores in dashboards and experiments.

This applies the same restriction to the public ingestion schema variant, mirroring the existing `isPublic` gating of dataset run item creation in the same factory. The internal variant (the evaluation worker itself) keeps the full enum.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue; public-key callers can no longer forge EVAL provenance, ANNOTATION with a config keeps working exactly as `POST /api/public/scores` allows)

## Verification

New tests in `packages/shared/src/server/ingestion/types.test.ts`:

- `source: "EVAL"` is rejected by the public ingestion schema and accepted by the internal one
- `source: "API"` and an omitted source (defaulting to API) are accepted on the public schema

The EVAL-rejection test fails on the pre-fix code. Full local run: 24 passed across `types.test.ts` and the existing `ingestionAttribution.test.ts`.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents public ingestion callers from assigning evaluator provenance to scores while retaining the full source enum for internal ingestion.

- Uses the existing public create-score source domain for public `score-create` events.
- Continues accepting API and ANNOTATION sources and defaults omitted sources to API.
- Adds regression coverage for public rejection and internal acceptance of EVAL.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the source restriction correctly scoped to public ingestion and covered by regression tests.

The public and internal schema variants use the intended polarity, the reused public source domain matches the existing create-score contract, and no behavioral or repository-rule violations remain.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[score-create event] --> B{Internal ingestion?}
    B -- No --> C[Public source schema]
    C --> D[API or ANNOTATION]
    C --> E[EVAL rejected]
    B -- Yes --> F[Internal source schema]
    F --> G[API, ANNOTATION, or EVAL]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Restrict score source on public ingestio..."](https://github.com/langfuse/langfuse/commit/e9018679e154a7ccbf354417964f5180d9a22036) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61482751)</sub>

<!-- /greptile_comment -->