### PR TITLE
chore(agents): apply cursor label to Cursor PRs

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -209,6 +209,8 @@ langfuse/
 - Open a same-repo reviewable PR after local verification (not a draft) and
   test the resulting `pr-<N>.preview.langfuse.com` deployment with synthetic
   data. Previews normally run Mon-Fri 08:00-24:00 Europe/Berlin.
+- After opening a PR, apply the GitHub `cursor` label. Do not wait for a
+  human to add it.
 - Use Linear's git branch name (`lfe-XXXX-short-title`). Never create a
   `cursor/` branch, even if a Cursor Cloud prompt suggests that prefix.
   Repo guidance wins.

--- a/.agents/skills/cursor-agents-workflow/SKILL.md
+++ b/.agents/skills/cursor-agents-workflow/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: cursor-agents-workflow
 description: |
-  Human handoff, Linear branch names, reviewable (non-draft) PRs, Claude,
-  Greptile, and Codex review comments, preview test steps, proof of work
-  posted on the GitHub PR, and review-doubt notes for Cursor agents. Use
-  when a Cursor Cloud or Cursor desktop agent implements a Linear issue,
-  opens a GitHub PR, asks a human to test, posts screenshots or videos,
-  or handles Claude, Greptile, or Codex code-review comments.
+  Human handoff, Linear branch names, reviewable (non-draft) PRs, the
+  `cursor` GitHub label, Claude, Greptile, and Codex review comments,
+  preview test steps, proof of work posted on the GitHub PR, and
+  review-doubt notes for Cursor agents. Use when a Cursor Cloud or
+  Cursor desktop agent implements a Linear issue, opens a GitHub PR,
+  asks a human to test, posts screenshots or videos, or handles Claude,
+  Greptile, or Codex code-review comments.
 ---
 
 # Cursor Agents Workflow
@@ -50,6 +51,13 @@ practice being followed.
 Open the GitHub PR as reviewable, not as a draft. Draft PRs hide the work
 from reviewers and skip Claude/Greptile review workflows. Use a draft only
 when a human asks for one.
+
+After opening the PR, apply the GitHub `cursor` label. Use the PR label
+tool. Do not wait for a human to add it, and do not substitute a `codex`
+or other agent label. A same-repo workflow also applies `cursor` when the
+author is `cursor[bot]`, the branch starts with `cursor/`, or the PR body
+contains the Cursor agent marker — still apply it yourself so the tag is
+present immediately.
 
 Cursor Cloud PRs are opened as the Langfuse user who launched the agent. On
 a non-draft same-repo PR from a write-access user, github-actions posts

--- a/.agents/skills/cursor-agents-workflow/agents/openai.yaml
+++ b/.agents/skills/cursor-agents-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Cursor Agents Workflow"
-  short_description: "Linear branches, PR proof, and review notes"
-  default_prompt: "Use $cursor-agents-workflow for Cursor agent branch names, reviewable (non-draft) PRs, Claude/Greptile/Codex review comments, human preview test steps, proof-of-work posted on the GitHub PR, and review-doubt PR notes."
+  short_description: "Linear branches, cursor PR label, and review notes"
+  default_prompt: "Use $cursor-agents-workflow for Cursor agent branch names, reviewable (non-draft) PRs, the cursor GitHub label, Claude/Greptile/Codex review comments, human preview test steps, proof-of-work posted on the GitHub PR, and review-doubt PR notes."

--- a/.agents/skills/git-workflow/SKILL.md
+++ b/.agents/skills/git-workflow/SKILL.md
@@ -56,6 +56,8 @@ operations.
 - When a change is too large for one reviewable PR, split it into a chained
   stack instead of widening the PR: use `pr-stack-workflow`.
 - Open PRs as reviewable, not as drafts, unless a human asks for a draft.
+- Cursor agents apply the GitHub `cursor` label after opening a PR; see
+  `cursor-agents-workflow`. Do not leave that tag for a human.
 - Do not post GitHub PR comments as the human author. Cursor agents that
   comment as Cursor should leave one last comment with proof of user-visible
   work (screenshot, video, or before/after on the PR, not only in chat) and

--- a/.agents/skills/langfuse-codebase-navigator/SKILL.md
+++ b/.agents/skills/langfuse-codebase-navigator/SKILL.md
@@ -25,7 +25,7 @@ Use this as the first stop for Langfuse org navigation. Your job is to choose th
 ## Quick Skill Routing
 
 - Product implementation in `langfuse/langfuse`: choose the matching repo-local skill under `.agents/skills`, such as `backend-dev-guidelines`, `frontend-browser-review`, `clickhouse-best-practices`, `add-model-price`, `turborepo`, `pnpm-upgrade-package`, `code-review`, or production-debug skills as applicable.
-- Cursor Cloud or Cursor desktop agents implementing a Linear issue, opening a PR, asking a human to test, or handling Claude, Greptile, or Codex review comments: use `cursor-agents-workflow`.
+- Cursor Cloud or Cursor desktop agents implementing a Linear issue, opening a PR, applying the `cursor` GitHub label, asking a human to test, or handling Claude, Greptile, or Codex review comments: use `cursor-agents-workflow`.
 - A change too large for one reviewable PR, splitting a long-lived branch into PRs, or propagating and retargeting a stack: use `pr-stack-workflow`.
 - Someone new, or you do not know whether you are talking to an outside contributor or a maintainer: use `langfuse-onboarding`.
 - "What should I do today", or preparing a weekly project update: use `linear-work-rhythm`.

--- a/.agents/skills/langfuse-codebase-navigator/references/repository-map.md
+++ b/.agents/skills/langfuse-codebase-navigator/references/repository-map.md
@@ -93,7 +93,7 @@ Repo-local skills in `langfuse/.agents/skills`:
 - `changelog-writing`: user-facing release notes.
 - `clickhouse-best-practices`: ClickHouse schema/query/migration review.
 - `code-review`: repo-specific correctness/regression review.
-- `cursor-agents-workflow`: Cursor agent Linear branch names, human test steps, proof of work posted on the GitHub PR, Claude/Greptile/Codex review comments, and review-doubt PR notes.
+- `cursor-agents-workflow`: Cursor agent Linear branch names, the `cursor` GitHub label, human test steps, proof of work posted on the GitHub PR, Claude/Greptile/Codex review comments, and review-doubt PR notes.
 - `datadog-query-recipes`: reusable Datadog query shapes for production research.
 - `debug-issue-with-datadog`: production debugging tied to Langfuse code paths.
 - `frontend-browser-review`: user-visible `web/**` changes and browser verification.

--- a/.github/workflows/label-cursor-prs.yml
+++ b/.github/workflows/label-cursor-prs.yml
@@ -1,0 +1,80 @@
+name: Label Cursor PRs
+
+# Apply the `cursor` label to PRs opened by Cursor. Skill guidance tells the
+# agent to add the label itself; this workflow is the backstop when it does
+# not — cursor[bot] authorship, a `cursor/` head ref, or the Cursor agent
+# PR-body marker.
+#
+# Uses the plain `pull_request` trigger (NOT pull_request_target): no cloud
+# credentials, no checkout, no PR-code execution — only GitHub API calls.
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+permissions: {}
+
+jobs:
+  label-cursor:
+    name: Apply cursor label
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Label Cursor PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const LABEL = "cursor";
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+
+            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+              core.info("Fork PR; Cursor auto-label is limited to same-repo branches.");
+              return;
+            }
+
+            const alreadyLabeled = pr.labels.some((label) => label.name === LABEL);
+            if (alreadyLabeled) {
+              core.info(`PR #${pr.number} already has the '${LABEL}' label.`);
+              return;
+            }
+
+            const author = pr.user?.login ?? "";
+            const headRef = pr.head?.ref ?? "";
+            const body = pr.body ?? "";
+            const isCursorPr =
+              author === "cursor[bot]" ||
+              headRef.startsWith("cursor/") ||
+              body.includes("CURSOR_AGENT_PR_BODY_BEGIN");
+
+            if (!isCursorPr) {
+              core.info(
+                `PR #${pr.number} is not a Cursor PR (author=${author}, head=${headRef}).`,
+              );
+              return;
+            }
+
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: LABEL });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: LABEL,
+                color: "000000",
+                description: "Opened by a Cursor agent",
+              });
+              core.info("Created missing 'cursor' repository label.");
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: pr.number,
+              labels: [LABEL],
+            });
+            core.info(`Applied '${LABEL}' label to PR #${pr.number}.`);

--- a/.github/workflows/label-cursor-prs.yml
+++ b/.github/workflows/label-cursor-prs.yml
@@ -61,14 +61,23 @@ jobs:
               if (error.status !== 404) {
                 throw error;
               }
-              await github.rest.issues.createLabel({
-                owner,
-                repo,
-                name: LABEL,
-                color: "000000",
-                description: "Opened by a Cursor agent",
-              });
-              core.info("Created missing 'cursor' repository label.");
+              try {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: LABEL,
+                  color: "000000",
+                  description: "Opened by a Cursor agent",
+                });
+                core.info("Created missing 'cursor' repository label.");
+              } catch (createError) {
+                // Concurrent runs can both see 404 and race createLabel.
+                // 422 means the other run won; continue to addLabels.
+                if (createError.status !== 422) {
+                  throw createError;
+                }
+                core.info("Label already exists; continuing to apply it.");
+              }
             }
 
             await github.rest.issues.addLabels({

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,7 +194,8 @@ catalog described in `.agents/README.md`; credentials and OAuth grants belong
 in Cursor, never in repository files.
 
 After local verification, a Cursor agent should open a same-repo reviewable
-PR (not a draft) and test its `pr-<N>.preview.langfuse.com` deployment.
+PR (not a draft), apply the GitHub `cursor` label, and test its
+`pr-<N>.preview.langfuse.com` deployment.
 Use Linear's git branch name (`lfe-XXXX-short-title`), not a `cursor/` prefix.
 When handing work to a human, give a one-sentence TL;DR, a preview URL with
 exact test steps (including how to seed or hit the same path on

--- a/scripts/github/is-cursor-pr.mjs
+++ b/scripts/github/is-cursor-pr.mjs
@@ -1,0 +1,11 @@
+/**
+ * Whether a GitHub pull request should receive the `cursor` label.
+ * Keep the same three signals in `.github/workflows/label-cursor-prs.yml`.
+ */
+export function isCursorPr({ author = "", headRef = "", body = "" } = {}) {
+  return (
+    author === "cursor[bot]" ||
+    headRef.startsWith("cursor/") ||
+    body.includes("CURSOR_AGENT_PR_BODY_BEGIN")
+  );
+}

--- a/scripts/github/label-cursor-prs.test.mjs
+++ b/scripts/github/label-cursor-prs.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { isCursorPr } from "./is-cursor-pr.mjs";
+
+const workflow = readFileSync(
+  join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../../.github/workflows/label-cursor-prs.yml",
+  ),
+  "utf8",
+);
+
+test("cursor[bot] authorship is enough", () => {
+  assert.equal(isCursorPr({ author: "cursor[bot]" }), true);
+});
+
+test("cursor/ head ref is enough", () => {
+  assert.equal(
+    isCursorPr({ author: "nkabardin", headRef: "cursor/label-prs-231f" }),
+    true,
+  );
+});
+
+test("Cursor agent PR-body marker is enough", () => {
+  assert.equal(
+    isCursorPr({
+      author: "nkabardin",
+      headRef: "lfe-15605-cursor-pr-tag",
+      body: "<!-- CURSOR_AGENT_PR_BODY_BEGIN -->\nhello\n",
+    }),
+    true,
+  );
+});
+
+test("ordinary maintainer PRs are not labeled", () => {
+  assert.equal(
+    isCursorPr({
+      author: "maxdeichmann",
+      headRef: "lfe-12345-fix-filters",
+      body: "## What does this PR do?\n",
+    }),
+    false,
+  );
+});
+
+test("workflow stays on pull_request and does not check out PR code", () => {
+  assert.match(workflow, /^on:\n  pull_request:/m);
+  assert.doesNotMatch(workflow, /^on:\n  pull_request_target:/m);
+  assert.match(
+    workflow,
+    /uses: actions\/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3/,
+  );
+  assert.doesNotMatch(workflow, /actions\/checkout@/);
+});
+
+test("workflow uses the same three Cursor signals as isCursorPr", () => {
+  assert.match(workflow, /author === "cursor\[bot]"/);
+  assert.match(workflow, /headRef\.startsWith\("cursor\/"\)/);
+  assert.match(workflow, /body\.includes\("CURSOR_AGENT_PR_BODY_BEGIN"\)/);
+});

--- a/scripts/github/label-cursor-prs.test.mjs
+++ b/scripts/github/label-cursor-prs.test.mjs
@@ -62,3 +62,8 @@ test("workflow uses the same three Cursor signals as isCursorPr", () => {
   assert.match(workflow, /headRef\.startsWith\("cursor\/"\)/);
   assert.match(workflow, /body\.includes\("CURSOR_AGENT_PR_BODY_BEGIN"\)/);
 });
+
+test("workflow treats a concurrent createLabel 422 as success", () => {
+  assert.match(workflow, /createError\.status !== 422/);
+  assert.match(workflow, /Label already exists; continuing to apply it/);
+});


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17165 app preview](https://pr-17165.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Cursor PRs were untagged, while Codex PRs already carry a `codex` label. This makes Cursor mark its own PRs with a `cursor` GitHub label.

1. Cursor agents apply the `cursor` label after opening a PR (skill + AGENTS.md + CONTRIBUTING).
2. A same-repo workflow backstops that when the author is `cursor[bot]`, the branch starts with `cursor/`, or the PR body contains the Cursor agent marker. It creates the repository label if it is missing.
3. Detection rules are pinned by `node --test scripts/github/label-cursor-prs.test.mjs`.

This PR was labeled `cursor` by the new workflow (`Applied 'cursor' label to PR #17165`) and by the PR label tool.

![PR #17165 showing the cursor label](https://cursor.com/artifacts/c/art-e67966f9-3b76-4063-a4b9-43043936968d)

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [x] This change requires a documentation update

## Impacted packages

- `.agents/` (cursor-agents-workflow and related guidance)
- `.github/workflows/label-cursor-prs.yml`
- `scripts/github/`
- `CONTRIBUTING.md`

## Verification

- `node --test scripts/github/label-cursor-prs.test.mjs` — `tests 6`, `pass 6`, `fail 0`
- `pnpm run agents:sync`
- `pnpm run agents:check`
- Pre-commit: `Tasks:    7 successful, 7 total` (turbo lint), `Cached:    0 cached, 7 total`
- `Label Cursor PRs / Apply cursor label`: `Applied 'cursor' label to PR #17165`

Skipped product tests and browser review: this is agent guidance plus a label-only GitHub Action with no checkout and no product code.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Followed the contributing guide
- No application code, so format/lint/test surface is the agent-setup checks and the label-detection tests above
- Documentation updated in `.agents/` and `CONTRIBUTING.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15605](https://linear.app/clickhouse/issue/LFE-15605/make-cursor-mark-its-prs-with-cursor-tag)

<div><a href="https://cursor.com/agents/bc-b755e8d7-a044-4911-80f7-42321acd231f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b755e8d7-a044-4911-80f7-42321acd231f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds guidance and an automated GitHub workflow for applying the `cursor` label to Cursor-created pull requests.

- Documents the labeling requirement across Cursor and Git workflow guidance.
- Detects qualifying same-repository PRs using authorship, branch, or body-marker signals.
- Creates the repository label when absent and applies it through the GitHub API.
- Adds a Node test suite for the detection rules, though its workflow coverage and CI integration need strengthening.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after addressing non-blocking reliability and test-coverage weaknesses in the new labeling automation.

Current detection behavior is sound, but simultaneous first-time workflow runs can leave one PR unlabeled, and the tests neither verify the production Boolean expression robustly nor run in routine CI.

**Files Needing Attention:** .github/workflows/label-cursor-prs.yml; scripts/github/label-cursor-prs.test.mjs
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[pull_request event] --> B{Same-repository branch?}
  B -- No --> Z[Skip]
  B -- Yes --> C{Already has cursor label?}
  C -- Yes --> Z
  C -- No --> D{Cursor author, branch, or body marker?}
  D -- No --> Z
  D -- Yes --> E{Repository label exists?}
  E -- No --> F[Create cursor label]
  E -- Yes --> G[Apply cursor label]
  F --> G
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/label-cursor-prs.yml:64-70
**Label creation race**

When the `cursor` label is initially absent, concurrent qualifying runs can both receive a 404 from `getLabel` and attempt to create it. GitHub rejects the second creation, so that run stops before `addLabels` and can leave its PR unlabeled. Treat an already-created conflict as success or otherwise make label creation idempotent.

### Issue 2
scripts/github/label-cursor-prs.test.mjs:60-63
**Workflow logic remains untested**

These assertions only check that each signal's text appears somewhere in the workflow. Changing the production expression from OR to AND, or negating a signal, would still pass every assertion while changing which PRs receive the label. Assert the complete decision expression or test the production implementation directly.

### Issue 3
scripts/github/label-cursor-prs.test.mjs:16
**Test is absent from CI**

This new Node test is not referenced by a package test script or GitHub workflow, so routine CI does not run it. Detection regressions can therefore merge unless someone remembers to invoke the manual command. Add this suite to the repository's automated test pipeline.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(agents): apply cursor label to Cur..."](https://github.com/langfuse/langfuse/commit/718c80cf072c3365182f51d3fdb85a7a2aa9b7b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61496645)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->