### PR TITLE
fix(ci): harden cursor PR labeling

### DIFF
--- a/.github/workflows/label-cursor-prs.yml
+++ b/.github/workflows/label-cursor-prs.yml
@@ -29,8 +29,8 @@ jobs:
             const pr = context.payload.pull_request;
             const { owner, repo } = context.repo;
 
-            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
-              core.info("Fork PR; Cursor auto-label is limited to same-repo branches.");
+            if (pr.head.repo?.full_name !== `${owner}/${repo}`) {
+              core.info("Fork or deleted-head PR; Cursor auto-label is limited to same-repo branches.");
               return;
             }
 
@@ -46,7 +46,7 @@ jobs:
             const isCursorPr =
               author === "cursor[bot]" ||
               headRef.startsWith("cursor/") ||
-              body.includes("CURSOR_AGENT_PR_BODY_BEGIN");
+              body.includes("<!-- CURSOR_AGENT_PR_BODY_BEGIN -->");
 
             if (!isCursorPr) {
               core.info(

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -175,6 +175,8 @@ jobs:
       # by every AGENTS.md are resolved.
       - name: agent guidance paths resolve
         run: pnpm run agents:check
+      - name: cursor PR label tests
+        run: node --test scripts/github/label-cursor-prs.test.mjs
       - name: Load default env
         run: |
           cp .env.dev.example .env

--- a/scripts/github/is-cursor-pr.mjs
+++ b/scripts/github/is-cursor-pr.mjs
@@ -6,6 +6,6 @@ export function isCursorPr({ author = "", headRef = "", body = "" } = {}) {
   return (
     author === "cursor[bot]" ||
     headRef.startsWith("cursor/") ||
-    body.includes("CURSOR_AGENT_PR_BODY_BEGIN")
+    body.includes("<!-- CURSOR_AGENT_PR_BODY_BEGIN -->")
   );
 }

--- a/scripts/github/label-cursor-prs.test.mjs
+++ b/scripts/github/label-cursor-prs.test.mjs
@@ -47,6 +47,17 @@ test("ordinary maintainer PRs are not labeled", () => {
   );
 });
 
+test("a prose mention of the marker name is not enough", () => {
+  assert.equal(
+    isCursorPr({
+      author: "maxdeichmann",
+      headRef: "lfe-15605-discuss-marker",
+      body: "Detect Cursor PRs via CURSOR_AGENT_PR_BODY_BEGIN in the workflow.",
+    }),
+    false,
+  );
+});
+
 test("workflow stays on pull_request and does not check out PR code", () => {
   assert.match(workflow, /^on:\n  pull_request:/m);
   assert.doesNotMatch(workflow, /^on:\n  pull_request_target:/m);
@@ -60,7 +71,11 @@ test("workflow stays on pull_request and does not check out PR code", () => {
 test("workflow uses the same three Cursor signals as isCursorPr", () => {
   assert.match(workflow, /author === "cursor\[bot]"/);
   assert.match(workflow, /headRef\.startsWith\("cursor\/"\)/);
-  assert.match(workflow, /body\.includes\("CURSOR_AGENT_PR_BODY_BEGIN"\)/);
+  assert.match(
+    workflow,
+    /body\.includes\("<!-- CURSOR_AGENT_PR_BODY_BEGIN -->"\)/,
+  );
+  assert.match(workflow, /pr\.head\.repo\?\.full_name/);
 });
 
 test("workflow treats a concurrent createLabel 422 as success", () => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17167 app preview](https://pr-17167.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Follow-up to the Cursor PR labeler after Claude's review on the merged change.

- Guard `pr.head.repo?.full_name` so a deleted fork head does not fail the check red.
- Require the machine-emitted HTML comment marker, not a prose mention of the marker name.
- Run `node --test scripts/github/label-cursor-prs.test.mjs` in the lint job so the workflow and helper cannot drift unnoticed.

Skipped Claude's suggestion to stop re-applying the label after a human removes it. The backstop is meant to recover a missed label on later pushes; a false-positive `cursor/` branch is rarer than an agent that forgets the tag.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Impacted packages

- `.github/workflows/`
- `scripts/github/`

## Verification

- `node --test scripts/github/label-cursor-prs.test.mjs` — `tests 8`, `pass 8`, `fail 0`
- Pre-commit: `Tasks:    7 successful, 7 total` (turbo lint), `Cached:    1 cached, 7 total`

Skipped product tests: no application code.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15605](https://linear.app/clickhouse/issue/LFE-15605/make-cursor-mark-its-prs-with-cursor-tag)

<div><a href="https://cursor.com/agents/bc-b755e8d7-a044-4911-80f7-42321acd231f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b755e8d7-a044-4911-80f7-42321acd231f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens automated Cursor PR labeling and adds its regression suite to lint CI.
- Treats missing head repositories as fork or deleted-head PRs without failing the workflow.
- Requires the exact machine-emitted Cursor HTML marker rather than a prose reference.
- Runs the Cursor label tests under the repository’s configured Node 24 lint environment.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the hardening matches the documented payload condition and the added tests are runnable in CI.

No actionable failure remains: nullable `head.repo` values return cleanly, genuine exact markers remain recognized, prose mentions are rejected, and the new test command has the required files and Node runtime.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): harden cursor PR labeling"](https://github.com/langfuse/langfuse/commit/52b3311814f1b693d4b64220d9cf4c77980aea59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61500605)</sub>

<!-- /greptile_comment -->