### PR TITLE
feat(previews): introduce "Improved Message Rendering" feature with normalized I/O parser

### DIFF
--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -81,9 +81,11 @@
   `@langfuse/shared/src/server/clickhouse/clickhouseIdentifiers`,
   `@langfuse/shared/src/server/ee/ingestionMasking`,
   `@langfuse/shared/src/server/llm/llmText`, and
-  `@langfuse/shared/src/utils/chatml`. The experimental
-  `@langfuse/shared/src/utils/normalized-io` parser is client-safe but **do not
-  use it yet**; its public contract is still being validated.
+  `@langfuse/shared/src/utils/chatml`. The
+  `@langfuse/shared/src/utils/normalized-io` parser is client-safe and powers
+  the web "Improved Message Rendering" feature preview (the normalized Formatted
+  trace/observation view). Its public contract is still settling, so treat other
+  consumers as experimental until it stabilizes.
 
 When changing export surfaces, keep `package.json#exports`, the relevant barrel
 file (`src/index.ts`, `src/server/index.ts`, etc.), and this guide aligned in

--- a/web/src/__tests__/server/organization-feature-flags.servertest.ts
+++ b/web/src/__tests__/server/organization-feature-flags.servertest.ts
@@ -209,6 +209,7 @@ describe("organization feature preview defaults", () => {
       // here. Asserting that two REGISTERED defaults resolve differently needs
       // a second preview; add that half back with the next one.
       modernSession: false,
+      normalizedIoPreview: false,
     });
   });
 
@@ -439,7 +440,10 @@ describe("organization member feature preview overrides", () => {
 
     // The state map surfaces every preview; the raw `featureFlags` array stays
     // hidden, which is what this guards.
-    expect(row?.featurePreviews).toEqual({ modernSession: true });
+    expect(row?.featurePreviews).toEqual({
+      modernSession: true,
+      normalizedIoPreview: false,
+    });
     expect(row?.user).not.toHaveProperty("featureFlags");
     expect(row).not.toHaveProperty("organizationIds");
   });

--- a/web/src/features/feature-flags/available-flags.ts
+++ b/web/src/features/feature-flags/available-flags.ts
@@ -1,6 +1,9 @@
 import { assertUnreachable } from "@langfuse/shared";
 
-export const featurePreviewFlags = ["modernSession"] as const;
+export const featurePreviewFlags = [
+  "modernSession",
+  "normalizedIoPreview",
+] as const;
 
 export type FeaturePreviewFlag = (typeof featurePreviewFlags)[number];
 
@@ -15,6 +18,7 @@ export const filterFeaturePreviewFlags = (
 
 export const featurePreviewLabels = {
   modernSession: "Compact Session View",
+  normalizedIoPreview: "Improved Message Rendering",
 } satisfies Record<FeaturePreviewFlag, string>;
 
 export type FeaturePreviewAvailabilityContext = {
@@ -29,6 +33,10 @@ export const isFeaturePreviewAvailable = (
     return context.v4BetaEnabled;
   }
 
+  if (flag === "normalizedIoPreview") {
+    return true;
+  }
+
   return assertUnreachable(flag);
 };
 
@@ -40,7 +48,4 @@ export const availableFlags = [
   "v4BetaToggleVisible",
   "observationEvals",
   "experimentsV4Enabled",
-  // Internal flag (deliberately NOT in featurePreviewFlags): gates the
-  // normalized-parser formatted trace view for admins/flagged users only.
-  "normalizedIoPreview",
 ] as const;

--- a/web/src/features/feature-flags/components/UserFeaturePreviewsPopover.clienttest.tsx
+++ b/web/src/features/feature-flags/components/UserFeaturePreviewsPopover.clienttest.tsx
@@ -123,6 +123,7 @@ describe("UserFeaturePreviewsControl", () => {
       userId: "user-1",
       featurePreviews: {
         modernSession: false,
+        normalizedIoPreview: false,
       },
       management: {
         allowed: false,
@@ -149,6 +150,7 @@ describe("UserFeaturePreviewsControl", () => {
       userId: "user-1",
       featurePreviews: {
         modernSession: false,
+        normalizedIoPreview: false,
       },
       management: { allowed: true },
     });
@@ -184,6 +186,7 @@ describe("UserFeaturePreviewsControl", () => {
       userId: "user-1",
       featurePreviews: {
         modernSession: false,
+        normalizedIoPreview: false,
       },
       management: { allowed: true },
     });
@@ -210,6 +213,7 @@ describe("UserFeaturePreviewsControl", () => {
       userId: "user-1",
       featurePreviews: {
         modernSession: false,
+        normalizedIoPreview: false,
       },
       management: { allowed: true },
     });

--- a/web/src/features/feature-previews/assets/improved-message-rendering-dark.svg
+++ b/web/src/features/feature-previews/assets/improved-message-rendering-dark.svg
@@ -1,0 +1,31 @@
+<svg width="1200" height="700" viewBox="0 0 1200 700" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="700" fill="#09090B"/>
+  <rect x="32" y="28" width="1136" height="644" rx="18" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <rect x="32" y="28" width="1136" height="72" rx="18" fill="#0F172A"/>
+  <path d="M32 100H1168" stroke="#334155" stroke-width="2"/>
+  <rect x="62" y="50" width="108" height="28" rx="8" fill="#172554" stroke="#60A5FA" stroke-width="2"/>
+  <rect x="82" y="60" width="68" height="8" rx="4" fill="#3B82F6"/>
+  <rect x="178" y="50" width="80" height="28" rx="8" fill="#1E293B"/>
+  <rect x="198" y="60" width="40" height="8" rx="4" fill="#475569"/>
+  <rect x="54" y="124" width="1092" height="92" rx="12" fill="#172554" stroke="#60A5FA" stroke-width="2"/>
+  <rect x="74" y="144" width="72" height="22" rx="6" fill="#1E3A8A"/>
+  <rect x="88" y="151" width="44" height="8" rx="4" fill="#60A5FA"/>
+  <rect x="74" y="182" width="640" height="10" rx="5" fill="#64748B"/>
+  <rect x="54" y="232" width="1092" height="116" rx="12" fill="#0F172A" stroke="#334155"/>
+  <rect x="74" y="252" width="96" height="22" rx="6" fill="#334155"/>
+  <rect x="88" y="259" width="60" height="8" rx="4" fill="#94A3B8"/>
+  <rect x="74" y="290" width="960" height="10" rx="5" fill="#475569"/>
+  <rect x="74" y="312" width="760" height="10" rx="5" fill="#475569"/>
+  <rect x="54" y="364" width="1092" height="120" rx="12" fill="#0A2E22" stroke="#34D399" stroke-width="2"/>
+  <rect x="74" y="384" width="128" height="22" rx="6" fill="#065F46"/>
+  <rect x="88" y="391" width="88" height="8" rx="4" fill="#34D399"/>
+  <rect x="74" y="418" width="1052" height="48" rx="8" fill="#0F3D2E"/>
+  <rect x="90" y="432" width="220" height="8" rx="4" fill="#34D399"/>
+  <rect x="90" y="448" width="420" height="8" rx="4" fill="#059669"/>
+  <rect x="54" y="500" width="1092" height="140" rx="12" fill="#1E1B4B" stroke="#A78BFA" stroke-width="2"/>
+  <rect x="74" y="520" width="112" height="22" rx="6" fill="#4C1D95"/>
+  <rect x="88" y="527" width="72" height="8" rx="4" fill="#A78BFA"/>
+  <rect x="74" y="558" width="1000" height="10" rx="5" fill="#6D28D9"/>
+  <rect x="74" y="580" width="880" height="10" rx="5" fill="#6D28D9"/>
+  <rect x="74" y="602" width="640" height="10" rx="5" fill="#4C1D95"/>
+</svg>

--- a/web/src/features/feature-previews/assets/improved-message-rendering-light.svg
+++ b/web/src/features/feature-previews/assets/improved-message-rendering-light.svg
@@ -1,0 +1,31 @@
+<svg width="1200" height="700" viewBox="0 0 1200 700" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="700" fill="#F8FAFC"/>
+  <rect x="32" y="28" width="1136" height="644" rx="18" fill="white" stroke="#E2E8F0" stroke-width="2"/>
+  <rect x="32" y="28" width="1136" height="72" rx="18" fill="#F8FAFC"/>
+  <path d="M32 100H1168" stroke="#E2E8F0" stroke-width="2"/>
+  <rect x="62" y="50" width="108" height="28" rx="8" fill="#DBEAFE" stroke="#60A5FA" stroke-width="2"/>
+  <rect x="82" y="60" width="68" height="8" rx="4" fill="#3B82F6"/>
+  <rect x="178" y="50" width="80" height="28" rx="8" fill="#F1F5F9"/>
+  <rect x="198" y="60" width="40" height="8" rx="4" fill="#CBD5E1"/>
+  <rect x="54" y="124" width="1092" height="92" rx="12" fill="#EFF6FF" stroke="#60A5FA" stroke-width="2"/>
+  <rect x="74" y="144" width="72" height="22" rx="6" fill="#BFDBFE"/>
+  <rect x="88" y="151" width="44" height="8" rx="4" fill="#3B82F6"/>
+  <rect x="74" y="182" width="640" height="10" rx="5" fill="#94A3B8"/>
+  <rect x="54" y="232" width="1092" height="116" rx="12" fill="#F8FAFC" stroke="#E2E8F0"/>
+  <rect x="74" y="252" width="96" height="22" rx="6" fill="#E2E8F0"/>
+  <rect x="88" y="259" width="60" height="8" rx="4" fill="#64748B"/>
+  <rect x="74" y="290" width="960" height="10" rx="5" fill="#CBD5E1"/>
+  <rect x="74" y="312" width="760" height="10" rx="5" fill="#CBD5E1"/>
+  <rect x="54" y="364" width="1092" height="120" rx="12" fill="#F0FDF4" stroke="#34D399" stroke-width="2"/>
+  <rect x="74" y="384" width="128" height="22" rx="6" fill="#A7F3D0"/>
+  <rect x="88" y="391" width="88" height="8" rx="4" fill="#059669"/>
+  <rect x="74" y="418" width="1052" height="48" rx="8" fill="#DCFCE7"/>
+  <rect x="90" y="432" width="220" height="8" rx="4" fill="#10B981"/>
+  <rect x="90" y="448" width="420" height="8" rx="4" fill="#6EE7B7"/>
+  <rect x="54" y="500" width="1092" height="140" rx="12" fill="#F5F3FF" stroke="#A78BFA" stroke-width="2"/>
+  <rect x="74" y="520" width="112" height="22" rx="6" fill="#DDD6FE"/>
+  <rect x="88" y="527" width="72" height="8" rx="4" fill="#7C3AED"/>
+  <rect x="74" y="558" width="1000" height="10" rx="5" fill="#C4B5FD"/>
+  <rect x="74" y="580" width="880" height="10" rx="5" fill="#C4B5FD"/>
+  <rect x="74" y="602" width="640" height="10" rx="5" fill="#DDD6FE"/>
+</svg>

--- a/web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx
@@ -61,6 +61,19 @@ export function ControlledFeaturePreviewModal({
       onToggle: onToggle("modernSession"),
       isToggling: setFeaturePreviewEnabled.isPending,
     },
+    normalizedIoPreview: {
+      enabled:
+        authSession.data?.user?.featureFlags.normalizedIoPreview === true ||
+        authSession.data?.environment.enableExperimentalFeatures === true,
+      disabled:
+        authSession.data?.environment.enableExperimentalFeatures === true,
+      warningReason:
+        authSession.data?.environment.enableExperimentalFeatures === true
+          ? "This preview is enabled by LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES, so a per-user opt-out does not disable it."
+          : undefined,
+      onToggle: onToggle("normalizedIoPreview"),
+      isToggling: setFeaturePreviewEnabled.isPending,
+    },
   };
 
   return (

--- a/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
@@ -19,6 +19,8 @@ import {
 
 import modernSessionDarkIllustration from "../assets/modern-session-dark.svg";
 import modernSessionLightIllustration from "../assets/modern-session-light.svg";
+import improvedMessageRenderingDarkIllustration from "../assets/improved-message-rendering-dark.svg";
+import improvedMessageRenderingLightIllustration from "../assets/improved-message-rendering-light.svg";
 
 /** Flags the Feature Preview modal can toggle. Keep in sync with the
  *  userAccount.setFeaturePreviewEnabled allowlist and available-flags.ts. */
@@ -64,6 +66,19 @@ const PREVIEW_REGISTRY: PreviewRegistryItem[] = [
       light: modernSessionLightIllustration,
       dark: modernSessionDarkIllustration,
       alt: "Compact Session View showing a trace minimap beside a continuous session conversation feed.",
+    },
+  },
+  {
+    flag: "normalizedIoPreview",
+    description:
+      "Render the Formatted view of trace and observation input/output more faithfully — chat messages, tool calls, and reasoning are recognized across a wide range of model providers and frameworks.",
+    details:
+      "A new parser understands the conventions of OpenAI, Anthropic, Gemini, LangChain, the Vercel AI SDK, OpenTelemetry GenAI, Pydantic AI, and more. Messages, tool calls, tool results, and reasoning render as structured blocks in the Formatted view instead of falling back to raw JSON. When enabled, the Formatted tab is powered by this parser everywhere trace and observation I/O is shown.",
+    feedbackUrl: "https://github.com/orgs/langfuse/discussions",
+    illustration: {
+      light: improvedMessageRenderingLightIllustration,
+      dark: improvedMessageRenderingDarkIllustration,
+      alt: "Formatted trace view rendering a user message, an assistant reply, a tool call, and a reasoning block as distinct structured cards.",
     },
   },
 ];

--- a/web/src/features/traces/components/IOPreview/IOPreview.tsx
+++ b/web/src/features/traces/components/IOPreview/IOPreview.tsx
@@ -151,9 +151,10 @@ export function IOPreview({
   showCorrections = true,
 }: IOPreviewProps) {
   const capture = usePostHogClientCapture();
-  // The normalized-parser formatted view is gated to admins and explicitly
-  // flagged users; it must never surface for regular users.
-  const showPrettyBeta = useIsFeatureEnabled("normalizedIoPreview", {
+  // "Improved Message Rendering" feature preview: when enabled, the Formatted
+  // view is powered by the normalized parser instead of the legacy one.
+  const improvedRenderingEnabled = useIsFeatureEnabled("normalizedIoPreview", {
+    enableForAdmins: false,
     projectId,
   });
   const [dismissedTraceViewNotifications, setDismissedTraceViewNotifications] =
@@ -164,7 +165,13 @@ export function IOPreview({
     "jsonViewPreference",
     "pretty",
   );
-  const selectedView = currentView ?? localCurrentView;
+  // A previously persisted "pretty-beta" preference is no longer a view mode;
+  // fall back to the Formatted view.
+  const normalizedLocalView: ViewMode =
+    (localCurrentView as string) === "pretty-beta"
+      ? "pretty"
+      : localCurrentView;
+  const selectedView = currentView ?? normalizedLocalView;
   const showViewToggle = currentView === undefined;
 
   const [compensateScrollRef, startPreserveScroll] =
@@ -232,8 +239,6 @@ export function IOPreview({
           selectedView={selectedView}
           onViewChange={handleViewChange}
           compensateScrollRef={compensateScrollRef}
-          showPrettyBeta={showPrettyBeta}
-          prettyBetaDisabled={chatMLParserResult !== undefined}
         />
       )}
 
@@ -306,11 +311,9 @@ export function IOPreview({
         <IOPreviewPretty
           {...sharedProps}
           parser={
-            // Precomputed legacy parses win inside the parser hook, so a
-            // beta-labeled view must never claim them as normalized output.
-            selectedView === "pretty-beta" &&
-            showPrettyBeta &&
-            chatMLParserResult === undefined
+            // Precomputed legacy parses win inside the parser hook, so the
+            // Formatted view must never claim them as normalized output.
+            improvedRenderingEnabled && chatMLParserResult === undefined
               ? "normalized"
               : "legacy"
           }

--- a/web/src/features/traces/components/IOPreview/components/ViewModeToggle.tsx
+++ b/web/src/features/traces/components/IOPreview/components/ViewModeToggle.tsx
@@ -1,42 +1,26 @@
 import { Tabs } from "@/src/components/design-system/Tabs/Tabs";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/src/components/ui/hover-card";
 import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { useJsonBetaToggle } from "@/src/features/traces/hooks/useJsonBetaToggle";
 
-export type ViewMode = "pretty" | "pretty-beta" | "json" | "json-beta";
+export type ViewMode = "pretty" | "json" | "json-beta";
 
 export interface ViewModeToggleProps {
   selectedView: ViewMode;
   onViewChange: (view: ViewMode) => void;
   compensateScrollRef: React.RefObject<HTMLDivElement | null>;
-  /** Admin-only normalized-parser formatted view. */
-  showPrettyBeta?: boolean;
-  /** Surface supplies a precomputed legacy parse, so the beta parser cannot
-   * apply here: the trigger renders disabled with an explanation. */
-  prettyBetaDisabled?: boolean;
 }
 
 export function ViewModeToggle({
   selectedView,
   onViewChange,
   compensateScrollRef,
-  showPrettyBeta = false,
-  prettyBetaDisabled = false,
 }: ViewModeToggleProps) {
   const {
     jsonBetaEnabled,
     selectedViewTab,
     handleViewTabChange,
     handleBetaToggle,
-  } = useJsonBetaToggle(
-    selectedView,
-    onViewChange,
-    showPrettyBeta && !prettyBetaDisabled,
-  );
+  } = useJsonBetaToggle(selectedView, onViewChange);
 
   return (
     <div className="flex w-full flex-row items-center justify-start gap-1.5">
@@ -47,29 +31,6 @@ export function ViewModeToggle({
           onValueChange={handleViewTabChange}
         >
           <Tabs.List size="sm">
-            {showPrettyBeta &&
-              (prettyBetaDisabled ? (
-                <HoverCard openDelay={200}>
-                  <HoverCardTrigger asChild>
-                    <Tabs.Trigger
-                      value="pretty-beta"
-                      size="sm"
-                      disabled
-                      label="Normalized (beta)"
-                    />
-                  </HoverCardTrigger>
-                  <HoverCardContent align="start" className="w-64 text-sm">
-                    Shown with the standard parser for now — beta parsing is not
-                    applied to precomputed views yet.
-                  </HoverCardContent>
-                </HoverCard>
-              ) : (
-                <Tabs.Trigger
-                  value="pretty-beta"
-                  size="sm"
-                  label="Normalized (beta)"
-                />
-              ))}
             <Tabs.Trigger value="pretty" size="sm" label="Formatted" />
             <Tabs.Trigger value="json" size="sm" label="JSON" />
           </Tabs.List>

--- a/web/src/features/traces/components/ObservationDetailView/ConnectedObservationDetailView.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/ConnectedObservationDetailView.tsx
@@ -64,7 +64,6 @@ import {
 } from "@/src/features/traces/fns/traceAggregation";
 import { useHasProjectAccess } from "@/src/features/rbac";
 import { useSession } from "next-auth/react";
-import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeatureEnabled";
 import { ObservationPreview } from "./ObservationPreview";
 
 export interface ConnectedObservationDetailViewProps {
@@ -177,29 +176,14 @@ export function ConnectedObservationDetailView({
     setGlobalSelectedTab(tab);
   };
 
-  // The normalized-parser formatted view is gated to admins and explicitly
-  // flagged users; it must never surface for regular users.
-  const showPrettyBeta = useIsFeatureEnabled("normalizedIoPreview", {
-    projectId,
-  });
-
   // Map jsonViewPreference to currentView format expected by child components
   const currentView = jsonViewPreference;
-  // A persisted "pretty-beta" preference clamps to "pretty" when the beta
-  // tab is unavailable, so the highlighted tab matches the rendered parser.
-  const selectedViewTab =
-    currentView === "pretty-beta"
-      ? showPrettyBeta
-        ? "pretty-beta"
-        : "pretty"
-      : currentView === "pretty"
-        ? "pretty"
-        : "json";
+  const selectedViewTab = currentView === "pretty" ? "pretty" : "json";
   const [isPrettyViewAvailable, setIsPrettyViewAvailable] = useState(true);
 
   const handleViewTabChange = useCallback(
     (tab: string) => {
-      if (tab === "pretty" || tab === "pretty-beta") {
+      if (tab === "pretty") {
         setJsonViewPreference(tab);
       } else {
         // When switching to JSON, use beta preference
@@ -374,9 +358,7 @@ export function ConnectedObservationDetailView({
                   <div className="ml-auto h-fit px-2 py-0.5">
                     <Tabs
                       value={
-                        selectedTab === "log" &&
-                        (isLogViewVirtualized ||
-                          selectedViewTab === "pretty-beta")
+                        selectedTab === "log" && isLogViewVirtualized
                           ? "pretty"
                           : selectedViewTab
                       }
@@ -392,15 +374,6 @@ export function ConnectedObservationDetailView({
                       }}
                     >
                       <Tabs.List size="sm">
-                        {/* Log view never runs the normalized parser, so the
-                          beta tab only renders on the preview tab. */}
-                        {showPrettyBeta && selectedTab !== "log" && (
-                          <Tabs.Trigger
-                            value="pretty-beta"
-                            size="sm"
-                            label="Normalized (beta)"
-                          />
-                        )}
                         <Tabs.Trigger
                           value="pretty"
                           size="sm"

--- a/web/src/features/traces/components/ObservationDetailView/ObservationPreview.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/ObservationPreview.tsx
@@ -34,12 +34,12 @@ export function ObservationPreview({
       {tags && tags.length > 0 ? (
         <>
           <div
-            className={`px-2 pt-2 text-sm font-bold ${currentView && currentView !== "pretty" && currentView !== "pretty-beta" ? "shrink-0" : ""}`}
+            className={`px-2 pt-2 text-sm font-bold ${currentView && currentView !== "pretty" ? "shrink-0" : ""}`}
           >
             Tags
           </div>
           <div
-            className={`flex flex-wrap gap-x-1 gap-y-1 px-2 pb-2 ${currentView && currentView !== "pretty" && currentView !== "pretty-beta" ? "shrink-0" : ""}`}
+            className={`flex flex-wrap gap-x-1 gap-y-1 px-2 pb-2 ${currentView && currentView !== "pretty" ? "shrink-0" : ""}`}
           >
             <TagList selectedTags={tags} isLoading={false} />
           </div>

--- a/web/src/features/traces/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/features/traces/components/TraceDetailView/TraceDetailView.tsx
@@ -43,7 +43,6 @@ import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";
 import { useCommentedPaths } from "@/src/features/comments/hooks/useCommentedPaths";
 import { useHasProjectAccess } from "@/src/features/rbac";
 import { useSession } from "next-auth/react";
-import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeatureEnabled";
 
 // Extracted components
 import { TraceDetailViewHeader } from "./components/TraceDetailViewHeader";
@@ -101,32 +100,17 @@ export function TraceDetailView({
     isAnnotationMode,
   } = useViewPreferences();
 
-  // The normalized-parser formatted view is gated to admins and explicitly
-  // flagged users; it must never surface for regular users.
-  const showPrettyBeta = useIsFeatureEnabled("normalizedIoPreview", {
-    projectId,
-  });
-
   // Map jsonViewPreference to currentView format expected by child components
   const currentView = jsonViewPreference;
-  // Both formatted variants share the pretty layout; JSON views differ.
-  const isPrettyLikeView =
-    currentView === "pretty" || currentView === "pretty-beta";
+  // The Formatted view shares the pretty layout; JSON views differ.
+  const isPrettyLikeView = currentView === "pretty";
 
-  // A persisted "pretty-beta" preference clamps to "pretty" when the beta
-  // tab is unavailable, so the highlighted tab matches the rendered parser.
   const selectedViewTab =
-    jsonViewPreference === "pretty-beta"
-      ? showPrettyBeta
-        ? "pretty-beta"
-        : "pretty"
-      : jsonViewPreference === "pretty"
-        ? "pretty"
-        : ("json" as const);
+    jsonViewPreference === "pretty" ? "pretty" : ("json" as const);
 
   const handleViewTabChange = useCallback(
     (tab: string) => {
-      if (tab === "pretty" || tab === "pretty-beta") {
+      if (tab === "pretty") {
         setJsonViewPreference(tab);
       } else {
         setJsonViewPreference(jsonBetaEnabled ? "json-beta" : "json");
@@ -286,9 +270,7 @@ export function TraceDetailView({
                   <div className="ml-auto h-fit px-2 py-0.5">
                     <Tabs
                       value={
-                        selectedTab === "log" &&
-                        (isLogViewVirtualized ||
-                          selectedViewTab === "pretty-beta")
+                        selectedTab === "log" && isLogViewVirtualized
                           ? "pretty"
                           : selectedViewTab
                       }
@@ -305,15 +287,6 @@ export function TraceDetailView({
                       }}
                     >
                       <Tabs.List size="sm">
-                        {/* Log view never runs the normalized parser, so the
-                          beta tab only renders on the preview tab. */}
-                        {showPrettyBeta && selectedTab !== "log" && (
-                          <Tabs.Trigger
-                            value="pretty-beta"
-                            size="sm"
-                            label="Normalized (beta)"
-                          />
-                        )}
                         <Tabs.Trigger
                           value="pretty"
                           size="sm"

--- a/web/src/features/traces/components/TraceLogView/LogViewExpandedContent.tsx
+++ b/web/src/features/traces/components/TraceLogView/LogViewExpandedContent.tsx
@@ -15,7 +15,7 @@ export interface LogViewExpandedContentProps {
   node: TreeNode;
   traceId: string;
   projectId: string;
-  currentView?: "pretty" | "pretty-beta" | "json" | "json-beta";
+  currentView?: "pretty" | "json" | "json-beta";
   /** Optional external expansion state for JSON tree (non-virtualized mode) */
   externalExpansionState?: Record<string, boolean> | boolean;
   /** Callback when expansion state changes (non-virtualized mode) */
@@ -83,12 +83,8 @@ export const LogViewExpandedContent = memo(function LogViewExpandedContent({
       {jsonData && !isLoading && (
         <PrettyJsonView
           json={jsonData}
-          // Map beta modes to "pretty" for PrettyJsonView since it only supports "pretty" | "json"
-          currentView={
-            currentView === "json-beta" || currentView === "pretty-beta"
-              ? "pretty"
-              : currentView
-          }
+          // Map json-beta to "pretty" for PrettyJsonView since it only supports "pretty" | "json"
+          currentView={currentView === "json-beta" ? "pretty" : currentView}
           isLoading={false}
           showNullValues={false}
           stickyTopLevelKey={false}

--- a/web/src/features/traces/components/TraceLogView/LogViewToolbar.tsx
+++ b/web/src/features/traces/components/TraceLogView/LogViewToolbar.tsx
@@ -55,8 +55,8 @@ export interface LogViewToolbarProps {
   onCopyJson?: () => void;
   /** Callback to download JSON */
   onDownloadJson?: () => void;
-  /** Current view type (pretty/pretty-beta/json/json-beta) */
-  currentView?: "pretty" | "pretty-beta" | "json" | "json-beta";
+  /** Current view type (pretty/json/json-beta) */
+  currentView?: "pretty" | "json" | "json-beta";
   /** Whether indent visualization is enabled */
   indentEnabled?: boolean;
   /** Whether indent toggle is disabled (tree too deep) */

--- a/web/src/features/traces/components/TraceLogView/TraceLogView.tsx
+++ b/web/src/features/traces/components/TraceLogView/TraceLogView.tsx
@@ -54,7 +54,7 @@ import { flattenTreeOrder } from "@/src/features/traces/components/TraceLogView/
 export interface TraceLogViewProps {
   traceId: string;
   projectId: string;
-  currentView?: "pretty" | "pretty-beta" | "json" | "json-beta";
+  currentView?: "pretty" | "json" | "json-beta";
 }
 
 // Import configuration constants
@@ -315,9 +315,7 @@ export const TraceLogView = ({
       {/* Table view mode - render as expandable table */}
       {/* "json-beta" uses table mode since advanced I/O viewer works in expandable rows */}
       {flatItems.length > 0 &&
-        (currentView === "pretty" ||
-          currentView === "pretty-beta" ||
-          currentView === "json-beta") && (
+        (currentView === "pretty" || currentView === "json-beta") && (
           <JSONTableView
             items={flatItems}
             columns={columns}

--- a/web/src/features/traces/contexts/ViewPreferencesContext.tsx
+++ b/web/src/features/traces/contexts/ViewPreferencesContext.tsx
@@ -26,13 +26,8 @@ export type LogViewMode = "chronological" | "tree-order";
 /** Log view tree visualization style (only applies in tree-order mode) */
 export type LogViewTreeStyle = "flat" | "indented";
 
-/** JSON view preference (formatted/pretty vs raw JSON vs advanced JSON beta).
- * "pretty-beta" is the admin-only normalized-parser formatted view. */
-export type JsonViewPreference =
-  | "pretty"
-  | "pretty-beta"
-  | "json"
-  | "json-beta";
+/** JSON view preference (formatted/pretty vs raw JSON vs advanced JSON beta). */
+export type JsonViewPreference = "pretty" | "json" | "json-beta";
 
 /** Context in which trace is rendered - affects feature availability */
 type TraceRenderContext = "fullscreen" | "peek" | "annotation";
@@ -139,8 +134,14 @@ export function ViewPreferencesProvider({
   );
   const [logViewTreeStyle, setLogViewTreeStyle] =
     useLocalStorage<LogViewTreeStyle>("logViewTreeStyle", "flat");
-  const [jsonViewPreference, setJsonViewPreference] =
+  const [storedJsonViewPreference, setJsonViewPreference] =
     useLocalStorage<JsonViewPreference>("jsonViewPreference", "pretty");
+  // A previously persisted "pretty-beta" preference is no longer a view mode;
+  // degrade it to the Formatted view rather than breaking the toggle.
+  const jsonViewPreference: JsonViewPreference =
+    (storedJsonViewPreference as string) === "pretty-beta"
+      ? "pretty"
+      : storedJsonViewPreference;
   // Migration: default to true if user had json-beta selected previously
   // TODO: Remove migration logic after 2025-01-26 (2 weeks) when user settings are migrated
   const [jsonBetaEnabled, setJsonBetaEnabled] = useLocalStorage<boolean>(

--- a/web/src/features/traces/hooks/useJsonBetaToggle.ts
+++ b/web/src/features/traces/hooks/useJsonBetaToggle.ts
@@ -1,6 +1,6 @@
 import useLocalStorage from "@/src/components/useLocalStorage";
 
-type ViewMode = "pretty" | "pretty-beta" | "json" | "json-beta";
+type ViewMode = "pretty" | "json" | "json-beta";
 
 /**
  * Hook for managing JSON Beta toggle state alongside view preference.
@@ -13,10 +13,6 @@ type ViewMode = "pretty" | "pretty-beta" | "json" | "json-beta";
 export function useJsonBetaToggle(
   currentView: ViewMode,
   setCurrentView: (view: ViewMode) => void,
-  /** Whether the pretty-beta tab is selectable here. A persisted
-   * "pretty-beta" preference clamps to "pretty" when it is not, so the
-   * highlighted tab always matches the parser that produced the content. */
-  prettyBetaAvailable = false,
 ) {
   // Migration: default to true if user had json-beta selected previously
   // TODO: Remove migration logic after 2025-01-26 (2 weeks) when user settings are migrated
@@ -26,18 +22,15 @@ export function useJsonBetaToggle(
       localStorage.getItem("jsonViewPreference") === '"json-beta"',
   );
 
-  // Derive UI tab selection (pretty, flag-gated pretty-beta, or json)
+  // Derive UI tab selection (pretty or json). A previously persisted
+  // "pretty-beta" preference falls back to the Formatted tab.
   const selectedViewTab =
-    currentView === "pretty-beta"
-      ? prettyBetaAvailable
-        ? ("pretty-beta" as const)
-        : ("pretty" as const)
-      : currentView === "pretty"
-        ? ("pretty" as const)
-        : ("json" as const);
+    currentView === "pretty" || (currentView as string) === "pretty-beta"
+      ? ("pretty" as const)
+      : ("json" as const);
 
   const handleViewTabChange = (tab: string) => {
-    if (tab === "pretty" || tab === "pretty-beta") {
+    if (tab === "pretty") {
       setCurrentView(tab);
     } else {
       // When switching to JSON, use beta preference


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17169 app preview](https://pr-17169.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR promotes normalized I/O rendering into a user-facing feature preview and replaces the separate normalized beta tab with the existing Formatted view.

- Adds preview registration, illustrations, persistence state, and feature-flag availability.
- Migrates persisted `pretty-beta` preferences to `pretty`.
- Selects normalized parsing inside IOPreview when the preview is enabled.
- The normalized parser is still bypassed for modern-session observations with precomputed parser results and is not integrated into the trace log view.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until Improved Message Rendering actually applies to modern-session observations that currently retain legacy precomputed output.

The flag and preference migration paths are coherent, but a common session observation path bypasses the normalized parser entirely; the log view also falls outside the preview’s advertised scope.

**Files Needing Attention:** web/src/features/traces/components/IOPreview/IOPreview.tsx, web/src/features/feature-previews/components/FeaturePreviewModal.tsx
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Improved Message Rendering enabled] --> B{I/O surface}
  B -->|Trace or observation preview| C[IOPreview]
  C --> D{Precomputed ChatML result?}
  D -->|No| E[Normalized parser]
  D -->|Yes: modern session observation| F[Legacy precomputed result]
  B -->|Trace log view| G[JSONTableView]
  G --> H[PrettyJsonView]
  H --> I[No normalized parsing]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/traces/components/IOPreview/IOPreview.tsx:314-315
**Normalized Parser Is Bypassed**

When Improved Message Rendering is enabled, modern session observations still supply a precomputed `chatMLParserResult`. This condition selects the legacy parser, and the parser hook returns that precomputed result before normalized parsing can run. As a result, the feature has no effect on formatted observation content in the modern session view.

### Issue 2
web/src/features/feature-previews/components/FeaturePreviewModal.tsx:75-76
**Preview Overstates Rendering Coverage**

The preview says the normalized parser powers the Formatted tab everywhere trace and observation I/O is shown. However, the trace log view renders formatted content directly through `PrettyJsonView` without invoking that parser. This gives users inconsistent behavior and makes the preview description misleading; either integrate that surface or describe the narrower scope.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(previews): introduce &quot;Improved Mess..."](https://github.com/langfuse/langfuse/commit/a5d277e9212ce284d48852d0b03f9ed03753d058) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61509460)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->