### PR TITLE
fix(datasets): read v4 dataset metrics when preview is enabled

### DIFF
--- a/web/src/__tests__/server/datasets-metrics-events-only.servertest.ts
+++ b/web/src/__tests__/server/datasets-metrics-events-only.servertest.ts
@@ -1,11 +1,7 @@
 import { vi } from "vitest";
 
 const eventsTableAvailable = vi.hoisted(() => {
-  const enabled =
-    process.env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true";
-  process.env.LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
-  process.env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
-  return enabled;
+  return process.env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true";
 });
 
 import type { Session } from "next-auth";
@@ -22,7 +18,7 @@ describe("datasets metrics events-only liveness", () => {
   it("does not hang when the events table is unavailable", () => {});
 });
 
-maybe("datasets.allDatasetsMetrics in events_only write mode", () => {
+maybe("datasets.allDatasetsMetrics with v4 preview enabled", () => {
   const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
 
   const session: Session = {
@@ -73,7 +69,7 @@ maybe("datasets.allDatasetsMetrics in events_only write mode", () => {
   const caller = appRouter.createCaller({ ...ctx, prisma });
 
   it("reads experiment count and latest start time from events", async () => {
-    expect(env.LANGFUSE_MIGRATION_V4_WRITE_MODE).toBe("events_only");
+    expect(env.LANGFUSE_MIGRATION_V4_WRITE_MODE).toBeDefined();
 
     const datasetId = randomUUID();
     const olderExperimentId = randomUUID();

--- a/web/src/__tests__/server/datasets-metrics-events-only.servertest.ts
+++ b/web/src/__tests__/server/datasets-metrics-events-only.servertest.ts
@@ -1,7 +1,11 @@
 import { vi } from "vitest";
 
 const eventsTableAvailable = vi.hoisted(() => {
-  return process.env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true";
+  const enabled =
+    process.env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true";
+  process.env.LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
+  process.env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+  return enabled;
 });
 
 import type { Session } from "next-auth";
@@ -18,7 +22,7 @@ describe("datasets metrics events-only liveness", () => {
   it("does not hang when the events table is unavailable", () => {});
 });
 
-maybe("datasets.allDatasetsMetrics with v4 preview enabled", () => {
+maybe("datasets.allDatasetsMetrics in events_only write mode", () => {
   const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
 
   const session: Session = {
@@ -69,7 +73,7 @@ maybe("datasets.allDatasetsMetrics with v4 preview enabled", () => {
   const caller = appRouter.createCaller({ ...ctx, prisma });
 
   it("reads experiment count and latest start time from events", async () => {
-    expect(env.LANGFUSE_MIGRATION_V4_WRITE_MODE).toBeDefined();
+    expect(env.LANGFUSE_MIGRATION_V4_WRITE_MODE).toBe("events_only");
 
     const datasetId = randomUUID();
     const olderExperimentId = randomUUID();

--- a/web/src/__tests__/server/datasets-metrics.servertest.ts
+++ b/web/src/__tests__/server/datasets-metrics.servertest.ts
@@ -44,7 +44,7 @@ const session: Session = {
       experimentsV4Enabled: false,
       searchBar: false,
     },
-    v4BetaEnabled: true,
+    v4BetaEnabled: false,
     admin: true,
   },
   environment: {} as any,

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -492,7 +492,7 @@ export const datasetRouter = createTRPCRouter({
       if (input.datasetIds.length === 0) return { metrics: [] };
 
       const [runsMetrics, itemsCounts] = await Promise.all([
-        env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "events_only"
+        ctx.session.user.v4BetaEnabled === true
           ? getDatasetExperimentMetricsFromEvents({
               projectId: input.projectId,
               datasetIds: input.datasetIds,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17171 app preview](https://pr-17171.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Cloud is dual-write. Dataset list run-count and last-run time were gated on `events_only`, so preview users stayed on Postgres. The gate now follows the session v4 preview flag, same as other v4 read paths.

Impacted packages: `web`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm --filter web run test src/__tests__/server/datasets-metrics-events-only.servertest.ts src/__tests__/server/datasets-metrics.servertest.ts` — `Tests 6 passed (6)`
- Commit hook: `turbo run lint` — `Tasks: 7 successful, 7 total` / `Cached: 5 cached, 7 total`

The Postgres metrics suite uses a non-preview session so it still hits `dataset_runs`. No other test rewrite.

## Checklist

- [x] No documentation changes are required.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88f7fdbf-8a07-4b3c-9388-e7ecf3496d9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88f7fdbf-8a07-4b3c-9388-e7ecf3496d9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes dataset list run-count and last-run metrics follow the authenticated session's v4 preview state rather than the global write mode.
- Preview-enabled sessions now read experiment metrics from events.
- Non-preview sessions retain the Postgres-backed metrics path.
- Existing server tests were adjusted to cover both session states, although the preview regression test does not explicitly pin dual-write mode.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The production change appears safe to merge, with a non-blocking test-hardening issue around explicitly exercising dual-write mode.

Session derivation guarantees that events-only users remain on the events path, while preview users in dual mode now receive the intended v4 metrics; the remaining concern is that the regression test can silently exercise events-only mode and therefore may not detect a future reversion.

**Files Needing Attention:** web/src/__tests__/server/datasets-metrics-events-only.servertest.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/datasets-metrics-events-only.servertest.ts:72
**Test Leaves Mode Unpinned**

This assertion only checks that the write mode exists, so the regression test does not guarantee that it runs in `dual` mode. Because an unspecified mode defaults to `events_only`, the test could still pass with the old production condition and fail to detect a future regression. Explicitly configure or assert `dual` here so the test reliably proves that `v4BetaEnabled` controls the read path.

```suggestion
    expect(env.LANGFUSE_MIGRATION_V4_WRITE_MODE).toBe("dual");
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(datasets): read v4 dataset metrics w..."](https://github.com/langfuse/langfuse/commit/58d1fa363fff763909f2ab789835fb5b6f9ac89d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61525783)</sub>

<!-- /greptile_comment -->