### PR TITLE
refactor(web): Fix no-null-render: evaluator-detail.tsx

### DIFF
--- a/web/src/features/evals/components/evaluator-detail.tsx
+++ b/web/src/features/evals/components/evaluator-detail.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @repo/no-null-render */
 import * as React from "react";
 import { api } from "@/src/utils/api";
 import { useRouter } from "next/router";
@@ -11,27 +10,11 @@ import { generateJobExecutionCounts } from "@/src/features/evals/utils/job-execu
 import { EvaluatorPausedCallout } from "@/src/features/evals/components/evaluator-paused-callout";
 import {
   type EvalTargetObject,
-  type EvaluatorExecutionStatusCount,
   validateEvaluatorFiltersForTarget,
 } from "@langfuse/shared";
 import { useLazyEvaluatorExecutionCounts } from "@/src/features/evals/hooks/useLazyEvaluatorExecutionCounts";
 import { Alert } from "@/src/components/design-system/Alert/Alert";
 import { AlertTriangle } from "lucide-react";
-
-const JobExecutionCounts = ({
-  isLoading,
-  jobExecutionCounts,
-}: {
-  isLoading?: boolean;
-  jobExecutionCounts?: EvaluatorExecutionStatusCount[];
-}) => {
-  if (!isLoading && (!jobExecutionCounts || jobExecutionCounts.length === 0)) {
-    return null;
-  }
-
-  const counts = generateJobExecutionCounts(jobExecutionCounts);
-  return <LevelCountsDisplay counts={counts} isLoading={isLoading} />;
-};
 
 export const EvaluatorDetail = () => {
   const router = useRouter();
@@ -115,9 +98,11 @@ export const EvaluatorDetail = () => {
           <>
             {shouldRenderExecutionCounts && (
               <div className="bg-muted-gray flex min-h-6 min-w-24 flex-col items-center justify-center rounded-md px-2">
-                <JobExecutionCounts
+                <LevelCountsDisplay
+                  counts={generateJobExecutionCounts(
+                    lazyExecutionCounts.jobExecutionCounts,
+                  )}
                   isLoading={lazyExecutionCounts.isLoading}
-                  jobExecutionCounts={lazyExecutionCounts.jobExecutionCounts}
                 />
               </div>
             )}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17172 app preview](https://pr-17172.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the `@repo/no-null-render` suppression by inlining `LevelCountsDisplay` into `EvaluatorDetail` and deleting the redundant wrapper component. The existing outer render condition preserves loading, populated, and empty-state behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the refactor preserves the existing execution-count rendering conditions.

No actionable failures remain; the existing outer condition prevents rendering completed empty results, while loading and populated states continue to render as before.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): Fix non-null-render: eval..."](https://github.com/langfuse/langfuse/commit/64454604783052b99aa1abeeece776781f87e9e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61527932)</sub>

<!-- /greptile_comment -->