### PR TITLE
refactor(web): Fix no-null-render: ChevronButton.tsx

### DIFF
--- a/web/src/features/dashboard/components/cards/ChevronButton.tsx
+++ b/web/src/features/dashboard/components/cards/ChevronButton.tsx
@@ -1,24 +1,15 @@
-/* eslint-disable @repo/no-null-render */
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 
 export const ExpandListButton = ({
   isExpanded,
   setExpanded,
-  totalLength,
-  maxLength,
   expandText = "See more",
 }: {
   isExpanded: boolean;
   setExpanded: (isExpanded: boolean) => void;
-  totalLength: number;
-  maxLength: number;
   expandText?: string;
 }) => {
-  if (totalLength <= maxLength) {
-    return null;
-  }
-
   return (
     <Button
       className="mt-2"

--- a/web/src/features/dashboard/components/cards/DashboardTable.tsx
+++ b/web/src/features/dashboard/components/cards/DashboardTable.tsx
@@ -97,12 +97,10 @@ export const DashboardTable = ({
               </table>
             </div>
           </div>
-          {collapse ? (
+          {collapse && rows.length > (collapsedCount ?? collapse.collapsed) ? (
             <ExpandListButton
               isExpanded={isExpanded}
               setExpanded={setExpanded}
-              totalLength={rows.length}
-              maxLength={collapsedCount ?? collapse.collapsed}
               expandText={
                 rows.length > collapse.expanded
                   ? `Show top ${collapse.expanded}`


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17173 app preview](https://pr-17173.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the null-rendering path from `ExpandListButton` by moving its visibility condition into `DashboardTable`.
- Removes the obsolete `totalLength` and `maxLength` button props.
- Preserves the existing row-count condition at the sole call site.
- Removes the associated ESLint suppression.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the visibility guard is preserved at the component’s sole call site.

The removed component-level condition and the new caller-level condition use the same row count and collapsed limit, with no other consumers affected.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): Fix non-null-render: Chev..."](https://github.com/langfuse/langfuse/commit/936e998e6056994b11339f3334416ab0af03424e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61528199)</sub>

<!-- /greptile_comment -->