### PR TITLE
refactor(web): Fix no-null-render: LogViewTreeIndent.tsx

### DIFF
--- a/web/src/features/traces/components/TraceLogView/LogViewTreeIndent.tsx
+++ b/web/src/features/traces/components/TraceLogView/LogViewTreeIndent.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @repo/no-null-render */
 /**
  * LogViewTreeIndent - Tree indentation lines for log view rows.
  *
@@ -13,8 +12,6 @@ export interface LogViewTreeIndentProps {
   treeLines: boolean[];
   /** Whether this node is the last sibling at its level */
   isLastSibling: boolean;
-  /** Current depth level */
-  depth: number;
 }
 
 /**
@@ -23,10 +20,7 @@ export interface LogViewTreeIndentProps {
 export const LogViewTreeIndent = memo(function LogViewTreeIndent({
   treeLines,
   isLastSibling,
-  depth,
 }: LogViewTreeIndentProps) {
-  if (depth <= 0) return null;
-
   return (
     <div className="flex shrink-0">
       {/* Vertical lines for each ancestor level */}

--- a/web/src/features/traces/components/TraceLogView/TraceLogView.tsx
+++ b/web/src/features/traces/components/TraceLogView/TraceLogView.tsx
@@ -170,7 +170,6 @@ export const TraceLogView = ({
         <LogViewTreeIndent
           treeLines={item.treeLines}
           isLastSibling={item.isLastSibling}
-          depth={item.node.depth}
         />
       );
     },


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17175 app preview](https://pr-17175.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes a redundant depth prop and component-level null-render guard from `LogViewTreeIndent`.
- Depth-zero rows remain filtered by `TraceLogView` before the component is rendered.
- The sole callsite and props interface remain consistent.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable regressions identified.

The only caller continues to suppress indentation for depth-zero rows, and all references are consistent with the simplified component interface.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): Fix non-null-render: LogV..."](https://github.com/langfuse/langfuse/commit/56e6311ba2c2f41bb8c2cfa826d8694d182d3fa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61528372)</sub>

<!-- /greptile_comment -->