### PR TITLE
fix(rbac): return 400 when re-adding an existing project member

### DIFF
--- a/web/src/__tests__/server/members-trpc.servertest.ts
+++ b/web/src/__tests__/server/members-trpc.servertest.ts
@@ -806,6 +806,84 @@ describe("membersRouter.updateProjectRole - orgMembership/userId consistency", (
   });
 });
 
+describe("membersRouter.create - duplicate project membership", () => {
+  it("returns BAD_REQUEST when re-adding an existing org member to a project they already belong to", async () => {
+    const { org, project, caller } = await prepare("cloud:team");
+    const user = await createTestUser();
+    const orgMembership = await prisma.organizationMembership.create({
+      data: {
+        userId: user.id,
+        orgId: org.id,
+        role: Role.MEMBER,
+      },
+    });
+    await prisma.projectMembership.create({
+      data: {
+        userId: user.id,
+        projectId: project.id,
+        role: Role.VIEWER,
+        orgMembershipId: orgMembership.id,
+      },
+    });
+
+    await expect(
+      caller.members.create({
+        orgId: org.id,
+        email: user.email!,
+        orgRole: Role.NONE,
+        projectId: project.id,
+        projectRole: Role.VIEWER,
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "User is already a member of this project",
+    });
+  });
+
+  it("returns BAD_REQUEST when adding a new org member who already has a project membership", async () => {
+    const { org, project, caller } = await prepare("cloud:team");
+    const user = await createTestUser();
+    // Project memberships require an orgMembershipId FK. Seed the unique
+    // (project_id, user_id) collision via a membership in another org so this
+    // request still takes the "create org membership, then project
+    // membership" branch.
+    const otherOrg = await prisma.organization.create({
+      data: {
+        id: uuidv4(),
+        name: `Other Org ${uuidv4().substring(0, 8)}`,
+      },
+    });
+    const otherOrgMembership = await prisma.organizationMembership.create({
+      data: {
+        userId: user.id,
+        orgId: otherOrg.id,
+        role: Role.MEMBER,
+      },
+    });
+    await prisma.projectMembership.create({
+      data: {
+        userId: user.id,
+        projectId: project.id,
+        role: Role.VIEWER,
+        orgMembershipId: otherOrgMembership.id,
+      },
+    });
+
+    await expect(
+      caller.members.create({
+        orgId: org.id,
+        email: user.email!,
+        orgRole: Role.MEMBER,
+        projectId: project.id,
+        projectRole: Role.VIEWER,
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "User is already a member of this project",
+    });
+  });
+});
+
 describe("membersRouter.updateProjectRole - project organization consistency", () => {
   it("rejects a project from another organization without writing membership or audit log", async () => {
     const { org, ownerUser, caller } = await prepare("cloud:team");

--- a/web/src/features/rbac/server/membersRouter.ts
+++ b/web/src/features/rbac/server/membersRouter.ts
@@ -109,6 +109,34 @@ async function throwIfHigherProjectRole({
   }
 }
 
+async function createProjectMembershipOrThrowIfDuplicate({
+  prisma,
+  data,
+}: {
+  prisma: PrismaClient;
+  data: {
+    userId: string;
+    projectId: string;
+    role: Role;
+    orgMembershipId: string;
+  };
+}) {
+  try {
+    return await prisma.projectMembership.create({ data });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "User is already a member of this project",
+      });
+    }
+    throw error;
+  }
+}
+
 export const membersRouter = createTRPCRouter({
   ...allMembersRoutes,
   ...allInvitesRoutes,
@@ -256,7 +284,8 @@ export const membersRouter = createTRPCRouter({
           ) {
             // Create project role for user
             const newProjectMembership =
-              await ctx.prisma.projectMembership.create({
+              await createProjectMembershipOrThrowIfDuplicate({
+                prisma: ctx.prisma,
                 data: {
                   userId: user.id,
                   projectId: project.id,
@@ -313,14 +342,16 @@ export const membersRouter = createTRPCRouter({
           role: input.orgRole,
         });
         if (project && input.projectRole && input.projectRole !== Role.NONE) {
-          const projectMembership = await ctx.prisma.projectMembership.create({
-            data: {
-              userId: user.id,
-              projectId: project.id,
-              role: input.projectRole,
-              orgMembershipId: orgMembership.id,
-            },
-          });
+          const projectMembership =
+            await createProjectMembershipOrThrowIfDuplicate({
+              prisma: ctx.prisma,
+              data: {
+                userId: user.id,
+                projectId: project.id,
+                role: input.projectRole,
+                orgMembershipId: orgMembership.id,
+              },
+            });
           await auditLog({
             session: ctx.session,
             resourceType: "projectMembership",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17182 app preview](https://pr-17182.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

`members.create` mapped a duplicate project membership (`P2002` on `(project_id, user_id)`) to a generic tRPC 500. Enough retries of that user mistake tripped the Other tRPC APIs Error Rate pager. The invitation path in the same procedure already converted `P2002` to `BAD_REQUEST`; the two `projectMembership.create()` sites did not.

Both inserts now go through one helper that turns that unique-constraint failure into `BAD_REQUEST` with "User is already a member of this project".

This is an expected 4xx. It is not captured to Sentry.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test src/__tests__/server/members-trpc.servertest.ts` — `Tests  27 passed (27)`
- `pnpm exec turbo run lint --filter=web --force` — `Tasks: 4 successful, 4 total` / `Cached: 0 cached, 4 total`

Skipped typecheck, knip, and a browser pass: this is a tRPC error-mapping change with no UI.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Tests cover the duplicate-project-member case for both create branches (existing org member + new org member).

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-16074](https://linear.app/clickhouse/issue/LFE-16074/bugrbac-memberscreate-returns-500-instead-of-400-when-re-adding-an)

<div><a href="https://cursor.com/agents/bc-cfa2d547-b558-4933-b9d6-a19bcaaad4d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfa2d547-b558-4933-b9d6-a19bcaaad4d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes project-membership creation so duplicate `(projectId, userId)` conflicts return a `BAD_REQUEST`, and adds regression coverage for both member-creation branches.

- Duplicate error mapping is correct for the model’s sole unique constraint.
- The new-org-member path still leaves a committed organization membership when the subsequent project insert fails.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the new-org-member duplicate path avoids leaving a committed organization membership after returning failure.

One reachable branch performs the organization write before the duplicate-prone project write, and the new error mapping does not roll back that partial state.

**Files Needing Attention:** web/src/features/rbac/server/membersRouter.ts, web/src/__tests__/server/members-trpc.servertest.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/rbac/server/membersRouter.ts:346-354
**Partial membership persists**

In the new-org-member branch, the organization membership is committed before this project membership insert. When the duplicate case covered by the new test occurs, this helper returns `BAD_REQUEST` without rolling back the earlier write. The request therefore reports failure even though the user has been granted organization membership, and a retry then fails because the user is already in the organization. The duplicate handling should avoid or roll back that partial write, and the test should assert the resulting membership state.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rbac): return 400 when re-adding an ..."](https://github.com/langfuse/langfuse/commit/5081c019f48b5acb2e2e77b10c6f1e066a6302e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61546066)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->