### PR TITLE
fix(shared): hoist system prompts to instructions for OpenAI responses mode

### DIFF
--- a/packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
@@ -13,6 +13,7 @@ import {
 import { generateLangfuseAIText } from "../langfuseAiCompletion";
 import {
   createLLMOutput,
+  createLLMToolSet,
   generateLLMText,
   mapLegacyLLMCompletionParams,
 } from "../llmText";
@@ -179,6 +180,7 @@ async function runCompletion(params: {
   extraHeaders?: Record<string, string>;
   llmConnectionConfig?: Record<string, string | boolean>;
   output?: ReturnType<typeof createLLMOutput>;
+  tools?: Parameters<typeof generateLLMText>[0]["tools"];
   response: unknown;
   trace?: TraceSinkParams;
 }) {
@@ -199,6 +201,7 @@ async function runCompletion(params: {
     }),
     timeout: 10_000,
     output: params.output,
+    tools: params.tools,
     trace: params.trace,
   });
 
@@ -246,7 +249,7 @@ describe("AI SDK request shapes", () => {
     ]);
   });
 
-  it("OpenAI responses mode: /v1/responses when useResponsesApi is set", async () => {
+  it("OpenAI responses mode: /v1/responses when useResponsesApi is set, system prompt hoisted to instructions", async () => {
     const { request } = await runCompletion({
       modelParams: {
         provider: "openai",
@@ -261,6 +264,52 @@ describe("AI SDK request shapes", () => {
     expect(request.url).toBe("https://api.openai.com/v1/responses");
     expect(request.headers.get("authorization")).toBe("Bearer sk-test");
     expect(request.body.model).toBe("gpt-4o");
+    // The Responses API rejects role-based system items on strict endpoints
+    // (e.g. Azure), so langfuse moves the system prompt to `instructions`.
+    expect(request.body.instructions).toBe("You are terse.");
+    const input = request.body.input as Array<Record<string, unknown>>;
+    expect(input.some((item) => item.role === "system")).toBe(false);
+    expect(input).toHaveLength(1);
+  });
+
+  it("OpenAI responses mode with tools: system prompt hoisted while tool definitions stay in the body", async () => {
+    const { request } = await runCompletion({
+      modelParams: {
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        model: "gpt-4o",
+      },
+      apiKey: "sk-test",
+      llmConnectionConfig: { useResponsesApi: true },
+      tools: createLLMToolSet([
+        {
+          name: "get_weather",
+          description: "Get the weather for a city",
+          parameters: {
+            type: "object",
+            properties: { city: { type: "string" } },
+            required: ["city"],
+            additionalProperties: false,
+          },
+        },
+      ]),
+      response: OPENAI_RESPONSES_RESPONSE,
+    });
+
+    expect(request.url).toBe("https://api.openai.com/v1/responses");
+    expect(request.body.instructions).toBe("You are terse.");
+    const input = request.body.input as Array<Record<string, unknown>>;
+    expect(input.some((item) => item.role === "system")).toBe(false);
+    const tools = request.body.tools as Array<Record<string, unknown>>;
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({
+      type: "function",
+      name: "get_weather",
+      description: "Get the weather for a city",
+    });
+    expect(tools[0]?.parameters).toEqual(
+      expect.objectContaining({ type: "object" }),
+    );
   });
 
   it("Langfuse AI first-party OpenAI credentials hit /v1/responses", async () => {

--- a/packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
@@ -181,6 +181,7 @@ async function runCompletion(params: {
   llmConnectionConfig?: Record<string, string | boolean>;
   output?: ReturnType<typeof createLLMOutput>;
   tools?: Parameters<typeof generateLLMText>[0]["tools"];
+  providerOptions?: Parameters<typeof generateLLMText>[0]["providerOptions"];
   response: unknown;
   trace?: TraceSinkParams;
 }) {
@@ -202,6 +203,9 @@ async function runCompletion(params: {
     timeout: 10_000,
     output: params.output,
     tools: params.tools,
+    ...(params.providerOptions !== undefined
+      ? { providerOptions: params.providerOptions }
+      : {}),
     trace: params.trace,
   });
 
@@ -310,6 +314,25 @@ describe("AI SDK request shapes", () => {
     expect(tools[0]?.parameters).toEqual(
       expect.objectContaining({ type: "object" }),
     );
+  });
+
+  it("OpenAI responses mode: explicit instructions win and system items are still stripped", async () => {
+    const { request } = await runCompletion({
+      modelParams: {
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        model: "gpt-4o",
+      },
+      apiKey: "sk-test",
+      llmConnectionConfig: { useResponsesApi: true },
+      providerOptions: { openai: { instructions: "Use French." } },
+      response: OPENAI_RESPONSES_RESPONSE,
+    });
+
+    expect(request.body.instructions).toBe("Use French.");
+    const input = request.body.input as Array<Record<string, unknown>>;
+    expect(input.some((item) => item.role === "system")).toBe(false);
+    expect(input).toHaveLength(1);
   });
 
   it("Langfuse AI first-party OpenAI credentials hit /v1/responses", async () => {

--- a/packages/shared/src/server/llm/llmText.ts
+++ b/packages/shared/src/server/llm/llmText.ts
@@ -305,6 +305,13 @@ async function prepareLLMTextCall<
     trace: options.trace,
   });
 
+  const hoisted = hoistSystemMessagesForResponses({
+    adapter: modelConfig.adapter,
+    apiMode: modelConfig.openAIApiMode,
+    messages: options.messages,
+    providerOptions,
+  });
+
   const apiKey = decrypt(options.connection.secretKey);
   const extraHeaders = decryptAndParseExtraHeaders(
     options.connection.extraHeaders,
@@ -349,14 +356,14 @@ async function prepareLLMTextCall<
     runInTraceContext: <T>(fn: () => T): T =>
       capture ? capture.run(fn) : fn(),
     callOptions: {
-      messages: options.messages,
+      messages: hoisted.messages,
       allowSystemInMessages: true,
       tools: options.tools,
       maxOutputTokens: options.maxOutputTokens,
       temperature: options.temperature,
       topP: options.topP,
       reasoning: options.reasoning,
-      providerOptions,
+      providerOptions: hoisted.providerOptions,
       maxRetries: options.maxRetries,
       timeout,
       abortSignal: options.abortSignal,
@@ -407,6 +414,69 @@ function isJsonObject(
   value: JSONValue | undefined,
 ): value is Record<string, JSONValue> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * OpenAI Responses requests reject role-based system items on endpoints that
+ * validate input strictly (notably Azure), because @ai-sdk/openai converts
+ * them without an explicit `type`. The Responses API's native system-prompt
+ * surface is the top-level `instructions` field, so hoist system messages out
+ * of the message list when the OpenAI/OpenAI-compatible connection runs in
+ * responses mode. An explicitly configured `instructions` provider option wins
+ * and disables the hoist.
+ */
+function hoistSystemMessagesForResponses(params: {
+  adapter: LLMAdapter;
+  apiMode?: "responses" | "chat-completions";
+  messages: ModelMessage[];
+  providerOptions?: ProviderOptions;
+}): { messages: ModelMessage[]; providerOptions?: ProviderOptions } {
+  if (params.adapter !== LLMAdapter.OpenAI || params.apiMode !== "responses") {
+    return {
+      messages: params.messages,
+      providerOptions: params.providerOptions,
+    };
+  }
+
+  const systemText = collectSystemMessageText(params.messages);
+  if (!systemText) {
+    return {
+      messages: params.messages,
+      providerOptions: params.providerOptions,
+    };
+  }
+
+  const openAIOptions = params.providerOptions?.openai ?? {};
+  if (openAIOptions.instructions !== undefined) {
+    return {
+      messages: params.messages,
+      providerOptions: params.providerOptions,
+    };
+  }
+
+  return {
+    messages: params.messages.filter((message) => message.role !== "system"),
+    providerOptions: {
+      ...params.providerOptions,
+      openai: {
+        ...openAIOptions,
+        instructions: systemText,
+      },
+    },
+  };
+}
+
+function collectSystemMessageText(
+  messages: ModelMessage[],
+): string | undefined {
+  const parts: string[] = [];
+  for (const message of messages) {
+    if (message.role !== "system") continue;
+    if (message.content.length > 0) {
+      parts.push(message.content);
+    }
+  }
+  return parts.length > 0 ? parts.join("\n\n") : undefined;
 }
 
 export function createEvaluatorMediaUrlPolicy(

--- a/packages/shared/src/server/llm/llmText.ts
+++ b/packages/shared/src/server/llm/llmText.ts
@@ -420,10 +420,10 @@ function isJsonObject(
  * OpenAI Responses requests reject role-based system items on endpoints that
  * validate input strictly (notably Azure), because @ai-sdk/openai converts
  * them without an explicit `type`. The Responses API's native system-prompt
- * surface is the top-level `instructions` field, so hoist system messages out
- * of the message list when the OpenAI/OpenAI-compatible connection runs in
- * responses mode. An explicitly configured `instructions` provider option wins
- * and disables the hoist.
+ * surface is the top-level `instructions` field, so drop system messages from
+ * the message list when the OpenAI/OpenAI-compatible connection runs in
+ * responses mode and forward their text as `instructions` unless the caller
+ * already configured that provider option.
  */
 function hoistSystemMessagesForResponses(params: {
   adapter: LLMAdapter;
@@ -438,24 +438,27 @@ function hoistSystemMessagesForResponses(params: {
     };
   }
 
-  const systemText = collectSystemMessageText(params.messages);
-  if (!systemText) {
+  if (!params.messages.some((message) => message.role === "system")) {
     return {
       messages: params.messages,
       providerOptions: params.providerOptions,
     };
   }
 
+  const messages = params.messages.filter(
+    (message) => message.role !== "system",
+  );
+  const systemText = collectSystemMessageText(params.messages);
   const openAIOptions = params.providerOptions?.openai ?? {};
-  if (openAIOptions.instructions !== undefined) {
+  if (openAIOptions.instructions !== undefined || !systemText) {
     return {
-      messages: params.messages,
+      messages,
       providerOptions: params.providerOptions,
     };
   }
 
   return {
-    messages: params.messages.filter((message) => message.role !== "system"),
+    messages,
     providerOptions: {
       ...params.providerOptions,
       openai: {


### PR DESCRIPTION
Fixes #17166

## Problem

OpenAI **Responses API** requests from Langfuse (OpenAI/OpenAI-compatible connections with the responses toggle) put the system prompt into `input` as a role-based item, e.g. `{"role":"system","content":"..."}`. `@ai-sdk/openai` emits these items without an explicit `type`, and strict endpoints — notably Azure — validate each item's `type` and reject them with:

```
Invalid value: ''. Supported values are: 'additional_tools', ... 'message', ...
```

OpenAI's own endpoint infers the item type, which is why the same request works there; Azure-compatible endpoints do not. The Responses API's native system-prompt surface is the top-level `instructions` field.

## Change

`prepareLLMTextCall` now hoists system messages out of the message list for Responses-mode OpenAI connections and forwards them as `providerOptions.openai.instructions` (the SDK maps this to the Responses `instructions` body field). Chat-completions mode, all other adapters, and an explicitly configured `instructions` provider option are unaffected.

## Tests

- Extended `requestShape.test.ts`: the Responses-mode test now asserts `instructions` is set and that `input` contains no `system` item (verified to fail against the pre-fix code).
- Added a Responses-mode + tools variant covering the issue's repro (system prompt + tool definitions): hoist holds and tool definitions stay on the wire.

## Verification

- `packages/shared/src/server/llm/ai-sdk/requestShape.test.ts`: 23 passed
- `packages/shared/src/server/llm/llmText.test.ts`: 24 passed
- web `chat-completion-handler.servertest.ts`: 6 passed
- `tsc` build + `eslint --max-warnings 0` (shared + pre-commit over all packages) + prettier: clean

## Known limitation

Multi-turn `user`/`assistant` history is still serialized by `@ai-sdk/openai` without `type: "message"` on some strict endpoints. That is an upstream SDK defect (vercel/ai#20180); this PR intentionally fixes the Langfuse-owned slice (system prompts), and the dependency bump will absorb the upstream fix once it ships.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adapts OpenAI Responses-mode requests by moving system-message text into the native `instructions` field and adds request-shape coverage.

- Filters system messages from Responses input while preserving user messages and tools.
- Leaves Chat Completions and non-OpenAI adapters unchanged.
- The new early-return behavior still leaves invalid system items on two reachable edge paths.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR is not yet safe to merge because valid Responses-mode configurations can still send role-based system items to strict endpoints.

Empty system content and explicitly configured OpenAI instructions both bypass filtering, preserving the malformed input shape and allowing deterministic provider rejection.

**Files Needing Attention:** packages/shared/src/server/llm/llmText.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Model messages and provider options] --> B{OpenAI Responses mode?}
  B -->|No| C[Forward messages unchanged]
  B -->|Yes| D{Non-empty system text and no explicit instructions?}
  D -->|Yes| E[Move system text to instructions]
  E --> F[Send input without system items]
  D -->|No| G[Current code retains original messages]
  G --> H[Strict endpoint may reject untyped system item]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/llm/llmText.ts:441-466
**System items bypass filtering**

When a system message is empty or `providerOptions.openai.instructions` is already set, these early returns preserve the original system message. The request then sends that role-based item in `input`, so strict OpenAI-compatible Responses endpoints can still reject it. Explicit instructions should take precedence without preventing system items from being removed.

```suggestion
  const systemText = collectSystemMessageText(params.messages);
  const hasSystemMessages = params.messages.some(
    (message) => message.role === "system",
  );
  if (!hasSystemMessages) {
    return {
      messages: params.messages,
      providerOptions: params.providerOptions,
    };
  }

  const openAIOptions = params.providerOptions?.openai ?? {};
  return {
    messages: params.messages.filter((message) => message.role !== "system"),
    providerOptions:
      openAIOptions.instructions !== undefined || !systemText
        ? params.providerOptions
        : {
            ...params.providerOptions,
            openai: {
              ...openAIOptions,
              instructions: systemText,
            },
          },
  };
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): hoist system prompts to ins..."](https://github.com/langfuse/langfuse/commit/3a34b737df1efc64029586c1fc22615806554971) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61549971)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Prompts, playground, and models](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/prompts-playground-and-models.md)
- Knowledge Base — [Remove unsupported evaluation prompt cache keys](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/reverts/revert_14944-20260709-openai-prompt-cache-key-cc85ed2.md)

<!-- /greptile_comment -->