### PR TITLE
fix(web): span multi-unit score-analytics time buckets by count units, not count - 1

### DIFF
--- a/web/src/__tests__/server/unit/fill-time-series-gaps.servertest.ts
+++ b/web/src/__tests__/server/unit/fill-time-series-gaps.servertest.ts
@@ -1,0 +1,143 @@
+/**
+ * @fileoverview Regression tests for fill-time-series-gaps multi-unit bucket aggregation.
+ *
+ * Covers the bug in `aggregateIntoMultiUnitBuckets` and the mirrored
+ * `aggregateCategoricalIntoMultiUnitBuckets` where the bucket-start loop went
+ * back `count - 1` units while the next bucket's end stepped back `count`
+ * units, leaving a one-unit gap between consecutive buckets and silently
+ * dropping any single-unit points that fell into a gap.
+ *
+ * Reference: langfuse/langfuse#17157.
+ */
+
+import {
+  fillTimeSeriesGaps,
+  fillCategoricalTimeSeriesGaps,
+} from "@/src/utils/fill-time-series-gaps";
+
+// Build dates from UTC components to keep tests timezone-independent:
+// `toStartOfSingleUnit` uses local time (date-fns startOfDay etc.), so a
+// `new Date("2026-01-01T00:00:00Z")` literal would shift under non-UTC
+// locales and the test would assert against the wrong day.
+const utc = (y: number, m: number, d: number, h = 0, mi = 0, s = 0) =>
+  new Date(Date.UTC(y, m - 1, d, h, mi, s));
+
+describe("fill-time-series-gaps multi-unit buckets", () => {
+  describe("aggregateIntoMultiUnitBuckets (numeric)", () => {
+    it("includes every point in range across contiguous 2-day buckets (issue #17157)", () => {
+      // 5 daily points; range Jan 1 00:00 to Jan 5 14:30; interval { count: 2, unit: "day" }.
+      // Before the fix the output counts were [10, 30, 50] (Jan 2 and Jan 4 dropped).
+      // After the fix the buckets tile contiguously back from toDate and every
+      // point lands in exactly one bucket, giving averages [10, 25, 45].
+      const data = [
+        { timestamp: utc(2026, 1, 1, 0, 0, 0), value: 10 },
+        { timestamp: utc(2026, 1, 2, 0, 0, 0), value: 20 },
+        { timestamp: utc(2026, 1, 3, 0, 0, 0), value: 30 },
+        { timestamp: utc(2026, 1, 4, 0, 0, 0), value: 40 },
+        { timestamp: utc(2026, 1, 5, 0, 0, 0), value: 50 },
+      ];
+      const fromDate = utc(2026, 1, 1, 0, 0, 0);
+      const toDate = utc(2026, 1, 5, 14, 30, 0);
+
+      const result = fillTimeSeriesGaps(data, fromDate, toDate, {
+        count: 2,
+        unit: "day",
+      });
+
+      expect(result.map((d) => d.value)).toEqual([10, 25, 45]);
+      // The rightmost bucket's timestamp should be toDate, not startOfUnit(toDate).
+      expect(result[result.length - 1]!.timestamp.toISOString()).toBe(
+        toDate.toISOString(),
+      );
+    });
+
+    it("assigns a point on a shared boundary to the later (newer) bucket", () => {
+      // When toDate is itself start-of-unit, bucket boundaries land on the
+      // same time-of-day as the single-unit points, so a point can sit on
+      // both a previous bucket's end and the next bucket's start. The newer
+      // bucket wins so the rightmost bucket stays anchored at toDate.
+      const data = [
+        { timestamp: utc(2026, 1, 1, 0, 0, 0), value: 10 },
+        { timestamp: utc(2026, 1, 2, 0, 0, 0), value: 20 },
+        { timestamp: utc(2026, 1, 3, 0, 0, 0), value: 30 },
+        { timestamp: utc(2026, 1, 4, 0, 0, 0), value: 40 },
+        { timestamp: utc(2026, 1, 5, 0, 0, 0), value: 50 },
+      ];
+      const fromDate = utc(2026, 1, 1, 0, 0, 0);
+      const toDate = utc(2026, 1, 5, 0, 0, 0);
+
+      const result = fillTimeSeriesGaps(data, fromDate, toDate, {
+        count: 2,
+        unit: "day",
+      });
+
+      // Three contiguous 2-day buckets tile back from toDate:
+      //   [Dec 30 00:00, Jan 1 00:00] -> empty
+      //   [Jan  1 00:00, Jan 3 00:00] -> Jan 1, Jan 2 -> avg 15
+      //   [Jan  3 00:00, Jan 5 00:00] -> Jan 3, Jan 4, Jan 5 -> avg 40
+      // The boundary point (Jan 3 00:00) is assigned to the newer bucket
+      // (bucket 2), not the older one (bucket 1) - an oldest-first
+      // assignment would have produced [10, 25, 45] instead.
+      expect(result.map((d) => d.value)).toEqual([null, 15, 40]);
+      expect(result[result.length - 1]!.timestamp.toISOString()).toBe(
+        toDate.toISOString(),
+      );
+    });
+
+    it("keeps count=1 single-unit behavior unchanged", () => {
+      // The multi-unit path is the only one touched by the fix; this guards
+      // against an accidental change in the fillGapsInSingleUnitData path.
+      const data = [
+        { timestamp: utc(2026, 1, 1, 0, 0, 0), value: 10 },
+        { timestamp: utc(2026, 1, 3, 0, 0, 0), value: 30 },
+        { timestamp: utc(2026, 1, 5, 0, 0, 0), value: 50 },
+      ];
+      const fromDate = utc(2026, 1, 1, 0, 0, 0);
+      const toDate = utc(2026, 1, 5, 0, 0, 0);
+
+      const result = fillTimeSeriesGaps(data, fromDate, toDate, {
+        count: 1,
+        unit: "day",
+      });
+
+      expect(result.map((d) => d.value)).toEqual([10, null, 30, null, 50]);
+    });
+  });
+
+  describe("aggregateCategoricalIntoMultiUnitBuckets", () => {
+    it("sums per-category counts into contiguous 2-day buckets", () => {
+      // Same shape as the numeric reproducer, with two categories per day.
+      // The categorical path uses SUM (not average) per category per bucket,
+      // and emits one row per (bucket, category).
+      type Row = { timestamp: Date; category: string; count: number };
+      const data: Row[] = [
+        { timestamp: utc(2026, 1, 1, 0, 0, 0), category: "A", count: 10 },
+        { timestamp: utc(2026, 1, 1, 0, 0, 0), category: "B", count: 100 },
+        { timestamp: utc(2026, 1, 2, 0, 0, 0), category: "A", count: 20 },
+        { timestamp: utc(2026, 1, 2, 0, 0, 0), category: "B", count: 200 },
+        { timestamp: utc(2026, 1, 3, 0, 0, 0), category: "A", count: 30 },
+        { timestamp: utc(2026, 1, 3, 0, 0, 0), category: "B", count: 300 },
+        { timestamp: utc(2026, 1, 4, 0, 0, 0), category: "A", count: 40 },
+        { timestamp: utc(2026, 1, 4, 0, 0, 0), category: "B", count: 400 },
+        { timestamp: utc(2026, 1, 5, 0, 0, 0), category: "A", count: 50 },
+        { timestamp: utc(2026, 1, 5, 0, 0, 0), category: "B", count: 500 },
+      ];
+      const fromDate = utc(2026, 1, 1, 0, 0, 0);
+      const toDate = utc(2026, 1, 5, 14, 30, 0);
+
+      const result = fillCategoricalTimeSeriesGaps(data, fromDate, toDate, {
+        count: 2,
+        unit: "day",
+      });
+
+      // Three contiguous 2-day buckets, oldest first, A then B per bucket:
+      //   [Nov 30 14:30, Jan 1 14:30] -> A: 10,  B: 100
+      //   [Jan  1 14:30, Jan 3 14:30] -> A: 50,  B: 500
+      //   [Jan  3 14:30, Jan 5 14:30] -> A: 90,  B: 900
+      expect(result.map((d) => d.count)).toEqual([10, 100, 50, 500, 90, 900]);
+      expect(result[result.length - 1]!.timestamp.toISOString()).toBe(
+        toDate.toISOString(),
+      );
+    });
+  });
+});

--- a/web/src/utils/fill-time-series-gaps.ts
+++ b/web/src/utils/fill-time-series-gaps.ts
@@ -228,7 +228,7 @@ function aggregateIntoMultiUnitBuckets<
     let bucketStart = bucketEnd;
 
     // Go back `count` units
-    for (let i = 0; i < count - 1; i++) {
+    for (let i = 0; i < count; i++) {
       bucketStart = subtractSingleUnit(bucketStart);
     }
 
@@ -251,7 +251,11 @@ function aggregateIntoMultiUnitBuckets<
   for (const dataPoint of data) {
     const ts = toStartOfSingleUnit(dataPoint.timestamp);
 
-    for (const bucket of buckets) {
+    // Iterate newest-first so a point that falls on a shared boundary
+    // is assigned to the later (higher-end) bucket. The rightmost bucket
+    // still includes toDate because ts <= bucket.end holds at the top.
+    for (let i = buckets.length - 1; i >= 0; i--) {
+      const bucket = buckets[i]!;
       if (ts >= bucket.start && ts <= bucket.end) {
         bucket.dataPoints.push(dataPoint);
         break;
@@ -536,7 +540,7 @@ function aggregateCategoricalIntoMultiUnitBuckets<
     let bucketStart = bucketEnd;
 
     // Go back `count` units
-    for (let i = 0; i < count - 1; i++) {
+    for (let i = 0; i < count; i++) {
       bucketStart = subtractSingleUnit(bucketStart);
     }
 
@@ -559,7 +563,10 @@ function aggregateCategoricalIntoMultiUnitBuckets<
   for (const dataPoint of data) {
     const ts = toStartOfSingleUnit(dataPoint.timestamp);
 
-    for (const bucket of buckets) {
+    // Iterate newest-first so a point that falls on a shared boundary
+    // is assigned to the later (higher-end) bucket.
+    for (let i = buckets.length - 1; i >= 0; i--) {
+      const bucket = buckets[i]!;
       if (ts >= bucket.start && ts <= bucket.end) {
         bucket.dataPoints.push(dataPoint);
         break;


### PR DESCRIPTION
## Summary

Fix a silent data-loss bug in score analytics charts where multi-unit time buckets were not contiguous and dropped roughly a third of single-unit data points.

Fixes #17157

## Problem

`aggregateIntoMultiUnitBuckets` and `aggregateCategoricalIntoMultiUnitBuckets` in `web/src/utils/fill-time-series-gaps.ts` walked back `count - 1` units to compute each bucket's start, but the next bucket's end then stepped back by the full `count` units. Consecutive buckets were not contiguous, so single-unit points that landed in a one-unit gap matched no bucket and were silently dropped from the chart.

## Reproducer

5 daily points (Jan 1–5, midnight-aligned, counts 10/20/30/40/50) over `Jan 1 00:00 → Jan 5 14:30` with interval `{ count: 2, unit: "day" }`:

| | Before | After |
|---|---|---|
| Output averages | `[10, 30, 50]` (Jan 2 and Jan 4 dropped) | `[10, 25, 45]` |

## Proposed solution

Two changes in `web/src/utils/fill-time-series-gaps.ts`:

1. **Span each bucket by `count` units, not `count - 1`.** A one-character fix at lines 231 and 543; the bucket-start loop and the next-bucket-end loop now use the same step, so buckets tile contiguously back from `toDate`.
2. **Iterate newest-first when assigning points to buckets.** A point that sits exactly on a shared boundary is now assigned to the later (higher-end) bucket. The rightmost bucket still includes `toDate` because `ts <= bucket.end` holds at the top of the loop. This is a small, contained change recommended by the issue.

`count === 1` and the `count === 7 && unit === "day"` short-circuits at the top of the public functions still route to the single-unit path, so single-unit behavior is unchanged.

## Scope

- `web/src/utils/fill-time-series-gaps.ts` — 11 insertions, 4 deletions across two symmetric functions
- `web/src/__tests__/server/unit/fill-time-series-gaps.servertest.ts` — new regression tests (143 lines, no other test infra touched)

## Acceptance criteria

- The issue reproducer returns `[10, 25, 45]`, not `[10, 30, 50]`.
- A point at a shared bucket boundary is assigned to the newer bucket.
- The rightmost bucket's timestamp equals `toDate`.
- `count = 1` and the 7-day-week single-unit path are unchanged.
- The categorical path produces identical per-bucket sums (it has the same gap bug and the same fix).

## Backward compatibility

The fix changes only the multi-unit aggregation path. Single-unit intervals short-circuit before this code runs. The output shape (array of bucket entries with `timestamp` and the same per-key fields) is unchanged. The bucket widths change from `count - 1` to `count` units, which is the intended semantic.

## Risks

Low. The fix is symmetric across the two aggregation functions and matches the structure recommended in the issue. The only behavior change for any non-buggy input is that boundary points now go to the newer bucket instead of the older one; in practice, boundary points are rare because ClickHouse returns single-unit data aligned to the start of the unit, and the boundary sits at `toDate - k * count * unit` rather than at start-of-unit.

## Testing

- `prettier --check` clean on both files
- `tsc --noEmit -p web/tsconfig.json` reports no new errors in the changed files
- Local smoke test (4 cases) all pass:
  - Issue #17157 reproducer → `[10, 25, 45]`
  - Boundary point (Jan 3 00:00 with `toDate = Jan 5 00:00`) → `[null, 15, 40]` (boundary goes to newer bucket)
  - `count = 1` single-unit regression → `[10, null, 30, null, 50]`
  - Categorical sums → `[10, 100, 50, 500, 90, 900]`
- Regression test file added to the vitest `server-unit` project; tests will run on CI

## Future work

- The leftmost bucket in a range can extend well before `fromDate` when the range is not a multiple of the bucket width. A separate, larger change could clip it. Out of scope for this PR.

## Notes

Second-opinion review (OpenCode headless, the `consult-kiro` flow) was not run: the local OpenCode model server has been non-responsive for the last 12 consecutive cycles on this machine. The change is small, mechanical, and symmetric across the two functions; reviewers can spot-check the four-line loop body and the assignment-loop change.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes multi-unit score-analytics buckets contiguous by using the full interval count for each bucket span and resolves shared boundaries in favor of the newer bucket.

- Applies equivalent bucket construction and assignment changes to numeric and categorical aggregation.
- Adds regression coverage for dropped points, numeric boundary assignment, single-unit routing, and categorical sums.
- The implementation appears behaviorally sound, with non-blocking test portability, coverage, and documentation concerns.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The bucket aggregation fix appears safe to merge, with only non-blocking test portability, coverage, and comment-accuracy issues.

The full-count bucket spans now align with the existing full-count end advancement, and newest-first boundary handling is deliberate and tested for numeric data; no blocking behavioral failure remains.

**Files Needing Attention:** web/src/__tests__/server/unit/fill-time-series-gaps.servertest.ts, web/src/utils/fill-time-series-gaps.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/unit/fill-time-series-gaps.servertest.ts:22-23
**Tests Remain Timezone Sensitive**

The `utc` helper creates the same fixed UTC instants as the ISO literals described in the comment, while the production date-fns helpers normalize and subtract dates in local time. If these tests run in a non-UTC timezone, the points use different local-day boundaries and assertions such as `[10, 25, 45]` fail. Construct local calendar dates or explicitly configure the test project's timezone.

### Issue 2
web/src/utils/fill-time-series-gaps.ts:563-568
**Categorical Boundary Is Untested**

The categorical regression test covers the wider bucket spans but not this separately changed newest-first assignment. Its `toDate` is at 14:30, so none of its midnight data points lies on a shared boundary. Add a categorical equivalent of the numeric boundary test so a future reversal of this loop cannot silently restore different boundary behavior for categorical scores.

### Issue 3
web/src/__tests__/server/unit/fill-time-series-gaps.servertest.ts:134
**Bucket Month Is Incorrect**

The comment says the first bucket starts on November 30, but subtracting two days from January 1 yields December 30. This makes the regression explanation describe the wrong bucket geometry.

```suggestion
      //   [Dec 30 14:30, Jan 1 14:30] -> A: 10,  B: 100
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): span multi-unit time-series bu..."](https://github.com/langfuse/langfuse/commit/d87dc00416d1676c430769c5a697985f024f7bd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61553542)</sub>

<!-- /greptile_comment -->