### PR TITLE
fix(rbac): reject duplicate project member before creating org membership

### DIFF
--- a/web/src/__tests__/server/members-trpc.servertest.ts
+++ b/web/src/__tests__/server/members-trpc.servertest.ts
@@ -881,6 +881,13 @@ describe("membersRouter.create - duplicate project membership", () => {
       code: "BAD_REQUEST",
       message: "User is already a member of this project",
     });
+
+    // The duplicate is rejected before the org membership is created, so no
+    // partial write (or consumed seat) is left behind in the target org.
+    const orgMembership = await prisma.organizationMembership.findFirst({
+      where: { orgId: org.id, userId: user.id },
+    });
+    expect(orgMembership).toBeNull();
   });
 });
 

--- a/web/src/features/rbac/server/membersRouter.ts
+++ b/web/src/features/rbac/server/membersRouter.ts
@@ -310,6 +310,26 @@ export const membersRouter = createTRPCRouter({
           });
         }
 
+        // A project membership can outlive this org's membership (e.g. a stray
+        // row referencing another org). Reject the duplicate before creating
+        // the org membership so a failed project insert cannot leave a
+        // committed org membership (and consumed seat) behind.
+        if (
+          project &&
+          input.projectRole &&
+          input.projectRole !== Role.NONE &&
+          (await ctx.prisma.projectMembership.findUnique({
+            where: {
+              projectId_userId: { projectId: project.id, userId: user.id },
+            },
+          }))
+        ) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "User is already a member of this project",
+          });
+        }
+
         // create org membership as user is not a member yet, unless that
         // would exceed the member limit
         const orgMembership = await createWithinEntitlementLimit({

--- a/web/src/features/rbac/server/membersRouter.ts
+++ b/web/src/features/rbac/server/membersRouter.ts
@@ -113,7 +113,7 @@ async function createProjectMembershipOrThrowIfDuplicate({
   prisma,
   data,
 }: {
-  prisma: PrismaClient;
+  prisma: PrismaClient | Prisma.TransactionClient;
   data: {
     userId: string;
     projectId: string;
@@ -331,22 +331,44 @@ export const membersRouter = createTRPCRouter({
         }
 
         // create org membership as user is not a member yet, unless that
-        // would exceed the member limit
-        const orgMembership = await createWithinEntitlementLimit({
-          prisma: ctx.prisma,
-          orgId: input.orgId,
-          entitlementLimit: "organization-member-count",
-          sessionUser: ctx.session.user,
-          countCurrentUsage: countSeatsInUse,
-          create: (tx) =>
-            tx.organizationMembership.create({
-              data: {
-                userId: user.id,
-                orgId: input.orgId,
-                role: input.orgRole,
-              },
-            }),
-        });
+        // would exceed the member limit. On limited plans this runs inside the
+        // entitlement transaction, so creating the project membership here too
+        // keeps both inserts atomic: a duplicate-project-membership rejection
+        // rolls back the org membership instead of leaving a consumed seat.
+        const { orgMembership, projectMembership } =
+          await createWithinEntitlementLimit({
+            prisma: ctx.prisma,
+            orgId: input.orgId,
+            entitlementLimit: "organization-member-count",
+            sessionUser: ctx.session.user,
+            countCurrentUsage: countSeatsInUse,
+            create: async (tx) => {
+              const createdOrgMembership =
+                await tx.organizationMembership.create({
+                  data: {
+                    userId: user.id,
+                    orgId: input.orgId,
+                    role: input.orgRole,
+                  },
+                });
+              const createdProjectMembership =
+                project && input.projectRole && input.projectRole !== Role.NONE
+                  ? await createProjectMembershipOrThrowIfDuplicate({
+                      prisma: tx,
+                      data: {
+                        userId: user.id,
+                        projectId: project.id,
+                        role: input.projectRole,
+                        orgMembershipId: createdOrgMembership.id,
+                      },
+                    })
+                  : null;
+              return {
+                orgMembership: createdOrgMembership,
+                projectMembership: createdProjectMembership,
+              };
+            },
+          });
         await auditLog({
           session: ctx.session,
           resourceType: "orgMembership",
@@ -361,17 +383,7 @@ export const membersRouter = createTRPCRouter({
           email: user.email,
           role: input.orgRole,
         });
-        if (project && input.projectRole && input.projectRole !== Role.NONE) {
-          const projectMembership =
-            await createProjectMembershipOrThrowIfDuplicate({
-              prisma: ctx.prisma,
-              data: {
-                userId: user.id,
-                projectId: project.id,
-                role: input.projectRole,
-                orgMembershipId: orgMembership.id,
-              },
-            });
+        if (projectMembership) {
           await auditLog({
             session: ctx.session,
             resourceType: "projectMembership",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17191 app preview](https://pr-17191.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

When `members.create` adds a **new** org member together with a project role, the organization membership is created (and committed, consuming an entitlement seat) before the project-membership insert. If a `ProjectMembership` row for that `(projectId, userId)` already exists — e.g. a stray row referencing another org — the project insert hits the unique constraint and returns `BAD_REQUEST "User is already a member of this project"`, but the just-created org membership is left behind. A retry then fails with "already a member of this organization", and each attempt leaks another seat.

This PR moves the duplicate check ahead of the org-membership creation: if a project membership already exists, the request is rejected before any write happens, so no partial org membership (or consumed seat) remains.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## How to test

Covered by `web/src/__tests__/server/members-trpc.servertest.ts`:
- `membersRouter.create - duplicate project membership > returns BAD_REQUEST when adding a new org member who already has a project membership` now also asserts that no organization membership is created in the target org after the rejection.

## Verification

- `pnpm --filter web run test src/__tests__/server/members-trpc.servertest.ts` — `Tests 27 passed (27)`
- `pnpm turbo run lint typecheck --filter=web` — `Tasks: 5 successful, 5 total`

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an early project-membership duplicate check before creating a new organization membership and extends the server test to verify that sequential duplicate requests leave no organization membership behind.

- Prevents the demonstrated sequential partial-write case.
- The preflight check remains separated from the dependent writes, leaving the same partial-write outcome possible under concurrent project-membership creation.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because concurrent project-membership creation can still produce the organization-membership and entitlement-seat leak this fix targets.

The early lookup handles pre-existing duplicates, but organization and project memberships are still committed separately, allowing another writer to create the project membership between the lookup and insert and leave the organization membership committed after the resulting conflict.

**Files Needing Attention:** web/src/features/rbac/server/membersRouter.ts
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as members.create
  participant B as Concurrent membership path
  participant DB as Database
  A->>DB: findUnique(projectId, userId)
  DB-->>A: Not found
  A->>DB: Create and commit organization membership
  B->>DB: Insert same project membership
  A->>DB: Insert project membership
  DB-->>A: Unique-constraint failure
  Note over A,DB: Organization membership remains committed
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/rbac/server/membersRouter.ts:321-325
**Duplicate Check Is Nonatomic**

Another membership path can insert the same `(projectId, userId)` after this check but before the later insert. Because `createWithinEntitlementLimit` commits the organization membership separately, the resulting unique-constraint failure still leaves that membership behind and consumes a seat. The duplicate check and dependent writes need to be atomic, or the failure path needs compensating cleanup.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rbac): reject duplicate project memb..."](https://github.com/langfuse/langfuse/commit/a37b1afbdf60ec3fc8bf27e7daaf810db07cefb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61586991)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->