### PR TITLE
fix(web): keep filtered traces paging past the first page

### DIFF
--- a/web/src/__tests__/server/traces-ui-table.servertest.ts
+++ b/web/src/__tests__/server/traces-ui-table.servertest.ts
@@ -10,7 +10,7 @@ import {
   type ObservationRecordInsertType,
   type TraceRecordInsertType,
 } from "@langfuse/shared/src/server";
-import { type FilterState } from "@langfuse/shared";
+import { type FilterState, type TracingSearchType } from "@langfuse/shared";
 
 describe("Traces table API test", () => {
   it("should get a correct trace without observation", async () => {
@@ -275,11 +275,12 @@ describe("Traces table API test", () => {
           value: documentId,
         },
       ];
+      const searchType: TracingSearchType[] = ["content"];
       const query = {
         projectId: project_id,
         filter,
         searchQuery: needle,
-        searchType: ["content"],
+        searchType,
         orderBy: { column: "timestamp" as const, order },
         limit: 5,
       };

--- a/web/src/__tests__/server/traces-ui-table.servertest.ts
+++ b/web/src/__tests__/server/traces-ui-table.servertest.ts
@@ -279,7 +279,7 @@ describe("Traces table API test", () => {
         projectId: project_id,
         filter,
         searchQuery: needle,
-        searchType: ["content"] as const,
+        searchType: ["content"],
         orderBy: { column: "timestamp" as const, order },
         limit: 5,
       };

--- a/web/src/__tests__/server/traces-ui-table.servertest.ts
+++ b/web/src/__tests__/server/traces-ui-table.servertest.ts
@@ -5,6 +5,7 @@ import {
   createObservation,
   createTrace,
   getTracesTable,
+  getTracesTableCount,
   type TracesTableUiReturnType,
   type ObservationRecordInsertType,
   type TraceRecordInsertType,
@@ -247,4 +248,56 @@ describe("Traces table API test", () => {
       });
     });
   });
+
+  it.each(["ASC", "DESC"] as const)(
+    "pages past the first page with a metadata filter and content search (%s)",
+    async (order) => {
+      const project_id = v4();
+      const documentId = `doc-${v4()}`;
+      const needle = `needle-${v4()}`;
+      const traces = Array.from({ length: 12 }, (_, i) =>
+        createTrace({
+          id: `trace-${String(i).padStart(2, "0")}-${v4()}`,
+          project_id,
+          timestamp: Date.now() - i * 1_000,
+          metadata: { documentId },
+          input: `${needle} payload ${i}`,
+        }),
+      );
+      await createTracesCh(traces);
+
+      const filter: FilterState = [
+        {
+          column: "metadata",
+          type: "stringObject",
+          key: "documentId",
+          operator: "=",
+          value: documentId,
+        },
+      ];
+      const query = {
+        projectId: project_id,
+        filter,
+        searchQuery: needle,
+        searchType: ["content"] as const,
+        orderBy: { column: "timestamp" as const, order },
+        limit: 5,
+      };
+
+      const [page0, page1, totalCount] = await Promise.all([
+        getTracesTable({ ...query, page: 0 }),
+        getTracesTable({ ...query, page: 1 }),
+        getTracesTableCount({
+          ...query,
+          searchType: ["content"],
+        }),
+      ]);
+
+      expect(totalCount).toBe(12);
+      expect(page0).toHaveLength(5);
+      expect(page1).toHaveLength(5);
+      const page0Ids = new Set(page0.map((row) => row.id));
+      expect(page1.every((row) => !page0Ids.has(row.id))).toBe(true);
+    },
+  );
 });

--- a/web/src/__tests__/server/traces-ui-table.servertest.ts
+++ b/web/src/__tests__/server/traces-ui-table.servertest.ts
@@ -287,8 +287,12 @@ describe("Traces table API test", () => {
       const [page0, page1, totalCount] = await Promise.all([
         getTracesTable({ ...query, page: 0 }),
         getTracesTable({ ...query, page: 1 }),
+        // Count matches the UI: orderBy is always null so the aggregate
+        // is not wrapped in a timestamp ORDER BY.
         getTracesTableCount({
-          ...query,
+          projectId: project_id,
+          filter,
+          searchQuery: needle,
           searchType: ["content"],
         }),
       ]);

--- a/web/src/components/table/data-table-pagination.tsx
+++ b/web/src/components/table/data-table-pagination.tsx
@@ -79,10 +79,14 @@ export function DataTablePagination<TData>({
   const pageCount = table.getPageCount();
   const setPageIndex = table.setPageIndex;
   useEffect(() => {
+    // Count queries re-key on a filter/pin change and report pageCount as
+    // unknown or 1 while in flight. Snapping back then traps the reader on
+    // page 1 even though more rows exist.
+    if (isLoading) return;
     if (currentPage > pageCount && pageCount > 0) {
       setPageIndex(0);
     }
-  }, [currentPage, pageCount, setPageIndex]);
+  }, [currentPage, pageCount, setPageIndex, isLoading]);
 
   const handlePageNavigation = (newValue: string) => {
     if (newValue === "") {

--- a/web/src/components/table/hooks/usePaginationWindowPin.clienttest.ts
+++ b/web/src/components/table/hooks/usePaginationWindowPin.clienttest.ts
@@ -114,4 +114,38 @@ describe("usePaginationWindowPin", () => {
     rerender({ pageIndex: 1, enabled: false });
     expect(result.current.range?.to).toBeUndefined();
   });
+
+  it("pins to now when a live-tail sort is turned on past page 1", () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        usePaginationWindowPin(LIVE, 1, { enabled }),
+      { initialProps: { enabled: false } },
+    );
+
+    expect(result.current.range?.to).toBeUndefined();
+
+    const later = new Date(START.getTime() + 40_000);
+    vi.setSystemTime(later);
+    rerender({ enabled: true });
+    expect(result.current.range?.to).toEqual(later);
+  });
+
+  it("does not reuse a stale pin when the live tail is turned back on", () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        usePaginationWindowPin(LIVE, 1, { enabled }),
+      { initialProps: { enabled: true } },
+    );
+
+    act(() => result.current.pinOnLeavingFirstPage(1, NEWEST_ON_PAGE_1));
+    expect(result.current.range?.to).toEqual(NEWEST_ON_PAGE_1);
+
+    rerender({ enabled: false });
+    expect(result.current.range?.to).toBeUndefined();
+
+    const later = new Date(START.getTime() + 40_000);
+    vi.setSystemTime(later);
+    rerender({ enabled: true });
+    expect(result.current.range?.to).toEqual(later);
+  });
 });

--- a/web/src/components/table/hooks/usePaginationWindowPin.clienttest.ts
+++ b/web/src/components/table/hooks/usePaginationWindowPin.clienttest.ts
@@ -1,11 +1,36 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, vi } from "vitest";
 
-import { usePaginationWindowPin } from "./usePaginationWindowPin";
+import {
+  isLiveTailTimeSort,
+  usePaginationWindowPin,
+} from "./usePaginationWindowPin";
 
 const START = new Date("2026-08-12T12:00:00.000Z");
 const LIVE = { from: new Date("2026-08-11T12:00:00.000Z"), to: undefined };
 const NEWEST_ON_PAGE_1 = new Date("2026-08-12T11:59:58.000Z");
+const OLDEST_ON_PAGE_1 = new Date("2026-08-11T12:05:00.000Z");
+
+describe("isLiveTailTimeSort", () => {
+  it("is true for the default time-DESC sort and false for ASC or other columns", () => {
+    expect(isLiveTailTimeSort(null, "timestamp")).toBe(true);
+    expect(
+      isLiveTailTimeSort({ column: "timestamp", order: "DESC" }, "timestamp"),
+    ).toBe(true);
+    expect(
+      isLiveTailTimeSort({ column: "startTime", order: "DESC" }, "startTime"),
+    ).toBe(true);
+    expect(
+      isLiveTailTimeSort({ column: "timestamp", order: "ASC" }, "timestamp"),
+    ).toBe(false);
+    expect(
+      isLiveTailTimeSort({ column: "startTime", order: "ASC" }, "startTime"),
+    ).toBe(false);
+    expect(
+      isLiveTailTimeSort({ column: "name", order: "DESC" }, "timestamp"),
+    ).toBe(false);
+  });
+});
 
 describe("usePaginationWindowPin", () => {
   beforeEach(() => {
@@ -59,5 +84,34 @@ describe("usePaginationWindowPin", () => {
     };
     const closed = renderHook(() => usePaginationWindowPin(absolute, 2));
     expect(closed.result.current.range).toBe(absolute);
+  });
+
+  it("does not pin a live window when the sort has no live tail", () => {
+    const { result, rerender } = renderHook(
+      ({ pageIndex }: { pageIndex: number }) =>
+        usePaginationWindowPin(LIVE, pageIndex, { enabled: false }),
+      { initialProps: { pageIndex: 0 } },
+    );
+
+    act(() => result.current.pinOnLeavingFirstPage(1, OLDEST_ON_PAGE_1));
+    rerender({ pageIndex: 1 });
+
+    expect(result.current.range?.to).toBeUndefined();
+    expect(result.current.range).toBe(LIVE);
+  });
+
+  it("releases an existing pin when the sort stops being a live tail", () => {
+    const { result, rerender } = renderHook(
+      ({ pageIndex, enabled }: { pageIndex: number; enabled: boolean }) =>
+        usePaginationWindowPin(LIVE, pageIndex, { enabled }),
+      { initialProps: { pageIndex: 0, enabled: true } },
+    );
+
+    act(() => result.current.pinOnLeavingFirstPage(1, NEWEST_ON_PAGE_1));
+    rerender({ pageIndex: 1, enabled: true });
+    expect(result.current.range?.to).toEqual(NEWEST_ON_PAGE_1);
+
+    rerender({ pageIndex: 1, enabled: false });
+    expect(result.current.range?.to).toBeUndefined();
   });
 });

--- a/web/src/components/table/hooks/usePaginationWindowPin.ts
+++ b/web/src/components/table/hooks/usePaginationWindowPin.ts
@@ -52,6 +52,17 @@ export function usePaginationWindowPin(
   const [pinnedAt, setPinnedAt] = useState<Date | null>(() =>
     enabled && pageIndex > 0 ? new Date() : null,
   );
+  const [wasEnabled, setWasEnabled] = useState(enabled);
+
+  // Switching onto a live-tail sort while already past page 1 is the same as
+  // opening that page directly: there is no page-1 newest row to align with.
+  // Pin to now so the window is not left open (or pinned to a stale ASC visit).
+  if (enabled !== wasEnabled) {
+    setWasEnabled(enabled);
+    if (enabled && pageIndex > 0) {
+      setPinnedAt(new Date());
+    }
+  }
 
   const pin = enabled && pageIndex > 0 ? pinnedAt : null;
 

--- a/web/src/components/table/hooks/usePaginationWindowPin.ts
+++ b/web/src/components/table/hooks/usePaginationWindowPin.ts
@@ -1,6 +1,24 @@
 import { useCallback, useMemo, useState } from "react";
 import { type TableDateRange } from "@/src/utils/date-range-utils";
 
+type TimeOrderBy = { column: string; order: "ASC" | "DESC" } | null | undefined;
+
+/**
+ * Offset paging is only unstable on a live, open-ended timestamp-DESC set:
+ * new rows arrive at the top and shift every later page. Timestamp-ASC (and
+ * any non-time sort) appends or interleaves without moving page 1's offsets,
+ * so a pin would only shrink the window.
+ *
+ * Null orderBy follows the tables' default (time DESC).
+ */
+export function isLiveTailTimeSort(
+  orderBy: TimeOrderBy,
+  timeColumn: string,
+): boolean {
+  if (!orderBy) return true;
+  return orderBy.column === timeColumn && orderBy.order === "DESC";
+}
+
 /**
  * Holds the paged result set still while the reader is past the first page.
  *
@@ -20,16 +38,22 @@ import { type TableDateRange } from "@/src/utils/date-range-utils";
  * returning to page 1 goes live again. Opening a later page directly has no page
  * 1 to align with, so it pins to that first render instead. An already-closed
  * window (an absolute range) is left alone.
+ *
+ * Pass `enabled: false` for sorts that do not have a live tail (time ASC, or
+ * a non-time column). Pinning those to `rows[0]`'s timestamp collapses the
+ * window to the first page and the pagination clamp snaps the reader back.
  */
 export function usePaginationWindowPin(
   range: TableDateRange | undefined,
   pageIndex: number,
+  options?: { enabled?: boolean },
 ) {
+  const enabled = options?.enabled ?? true;
   const [pinnedAt, setPinnedAt] = useState<Date | null>(() =>
-    pageIndex > 0 ? new Date() : null,
+    enabled && pageIndex > 0 ? new Date() : null,
   );
 
-  const pin = pageIndex > 0 ? pinnedAt : null;
+  const pin = enabled && pageIndex > 0 ? pinnedAt : null;
 
   const pinnedRange = useMemo(
     () => (range && !range.to && pin ? { from: range.from, to: pin } : range),
@@ -39,9 +63,10 @@ export function usePaginationWindowPin(
   /** Call from the pagination handler, where the leaving page's rows are known. */
   const pinOnLeavingFirstPage = useCallback(
     (nextPageIndex: number, newestVisible: Date | undefined) => {
+      if (!enabled) return;
       if (nextPageIndex > 0) setPinnedAt(newestVisible ?? new Date());
     },
-    [],
+    [enabled],
   );
 
   return { range: pinnedRange, pinOnLeavingFirstPage };

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -56,7 +56,10 @@ import { ConnectedIOTableCell } from "@/src/components/table/ConnectedIOTableCel
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
 import { useLiveTableDateRange } from "@/src/hooks/useLiveTableDateRange";
 import { usePendingRowIds } from "@/src/components/table/hooks/usePendingRowIds";
-import { usePaginationWindowPin } from "@/src/components/table/hooks/usePaginationWindowPin";
+import {
+  isLiveTailTimeSort,
+  usePaginationWindowPin,
+} from "@/src/components/table/hooks/usePaginationWindowPin";
 import { joinTableCoreAndMetrics } from "@/src/components/table/utils/joinTableCoreAndMetrics";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
@@ -279,6 +282,7 @@ function TracesTableInternal({
     usePaginationWindowPin(
       dateRange,
       limitRows ? 0 : paginationState.pageIndex,
+      { enabled: isLiveTailTimeSort(orderByState, "timestamp") },
     );
   const rowsDateRangeFilter: FilterState = toTimestampFilter(rowsDateRange);
   const userIdFilter: FilterState = userId
@@ -1454,6 +1458,9 @@ function TracesTableInternal({
                   : {
                       totalCount,
                       isTotalCountLoading: totalCountQuery.isPending,
+                      hasNextPage:
+                        (traces.data?.traces.length ?? 0) ===
+                        paginationState.pageSize,
                       onChange: (updater) => {
                         const next =
                           typeof updater === "function"

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1458,9 +1458,6 @@ function TracesTableInternal({
                   : {
                       totalCount,
                       isTotalCountLoading: totalCountQuery.isPending,
-                      hasNextPage:
-                        (traces.data?.traces.length ?? 0) ===
-                        paginationState.pageSize,
                       onChange: (updater) => {
                         const next =
                           typeof updater === "function"

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -69,7 +69,10 @@ import {
 } from "@/src/components/table/data-table-row-height-switch";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
 import { useLiveTableDateRange } from "@/src/hooks/useLiveTableDateRange";
-import { usePaginationWindowPin } from "@/src/components/table/hooks/usePaginationWindowPin";
+import {
+  isLiveTailTimeSort,
+  usePaginationWindowPin,
+} from "@/src/components/table/hooks/usePaginationWindowPin";
 import {
   type TableDateRange,
   TABLE_AGGREGATION_OPTIONS,
@@ -492,7 +495,11 @@ export default function ObservationsEventsTable({
   // row/count queries take the pinned upper bound instead, so offset paging does
   // not repeat or skip rows while the window keeps taking in newly ingested ones.
   const { range: rowsDateRange, pinOnLeavingFirstPage } =
-    usePaginationWindowPin(dateRange, limitRows ? 0 : paginationState.page - 1);
+    usePaginationWindowPin(
+      dateRange,
+      limitRows ? 0 : paginationState.page - 1,
+      { enabled: isLiveTailTimeSort(orderByState, "startTime") },
+    );
   const dateRangeFilter: FilterState = toStartTimeFilterState(rowsDateRange);
 
   const appRootDefault = useAppRootDefault({


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17192 app preview](https://pr-17192.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Pagination on the Tracing table stayed on page 1 after clicking next when a metadata `stringObject` filter and content search were active. Two frontend bugs stacked:

1. The live-tail window pin (close the open-ended `to` at `rows[0]`'s timestamp when leaving page 1) ran for every sort. That is correct only for time DESC. Time ASC (and any non-time sort) made `rows[0]` the oldest visible row, so the query collapsed to roughly the first page and page 2 came back empty.
2. The pagination clamp then saw `pageCount === 1` (or a count still in flight after the pin re-keyed it) and snapped the reader back to page 1.

This change:

- Pins the window only for time-DESC (the live tail). Time ASC and other columns leave the range open.
- When the sort becomes time-DESC while already past page 1, pins to now (same as a deep link to that page) instead of leaving the window open or reusing a stale pin.
- Skips the out-of-range page clamp while the table or count query is loading.
- Leaves the v3 traces table on its exact `countAll` for Next (no full-page `hasNextPage` guess).

Impacted packages: `web`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed

## Verification

- `pnpm --filter web run test-client usePaginationWindowPin` — Tests 7 passed (7)
- `pnpm --filter web run test traces-ui-table.servertest` — Tests 9 passed (9)
- `pnpm exec turbo run lint --force --filter=web` — Tasks: 4 successful, 4 total; Cached: 0 cached, 4 total

## Test this

Preview: https://pr-17192.preview.langfuse.com (Mon–Fri 08:00–24:00 Europe/Berlin)

1. Open Tracing, set page size 50, add a metadata `documentId` equals filter that matches hundreds of traces, and a content search that still leaves more than 50 rows.
2. Sort start time ASC, click next — you should land on page 2 with a different set of rows, not snap back to page 1.
3. Sort start time DESC and repeat.

Data: demo project is enough if it has >50 matching rows; otherwise seed `many-traces`.
Sandbox: same path on `http://localhost:3000` after the Cloud stack is rebuilt from this branch.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-16085](https://linear.app/clickhouse/issue/LFE-16085/fix-pagination-stuck-on-first-page-in-filtered-traces)

<div><a href="https://cursor.com/agents/bc-2a812e05-6acd-42cd-b01f-44bca42d070e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a812e05-6acd-42cd-b01f-44bca42d070e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adjusts trace and event pagination so live-window pinning applies only to descending time sorts and transient count loading does not force users back to the first page.

- Adds sort-aware pagination-window pinning for trace and event tables.
- Defers out-of-range clamping while rows or totals are loading.
- Uses full result pages as a temporary next-page signal until the exact count arrives.
- Adds client and server coverage for sorting and filtered pagination.
- One sort-transition lifecycle gap remains when descending-time pinning is enabled while already beyond the first page.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until enabling time-DESC sorting on an existing later page establishes a current pagination-window pin or resets to the first page.

The primary loading and next-page changes are consistent with the surrounding pagination plumbing, but the new sort-dependent pin state is not synchronized when pinning transitions from disabled to enabled, leaving a realistic duplicate-or-skipped-row path.

**Files Needing Attention:** web/src/components/table/hooks/usePaginationWindowPin.ts, web/src/components/table/use-cases/traces.tsx, web/src/features/events/components/EventsTable.tsx
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[User views a later page] --> B{Current sort}
  B -->|Time DESC| C[Use closed live-window upper bound]
  B -->|Time ASC or another column| D[Keep date range open]
  D --> E[User changes sort to time DESC]
  E --> F{Was pinnedAt initialized?}
  F -->|No: hook stayed mounted| G[Range remains open-ended]
  F -->|Stale prior value| H[Old upper bound is reused]
  G --> I[New rows shift offset pages]
  H --> J[Results use an outdated snapshot]
  I --> K[Rows may be duplicated or skipped]
  J --> K
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/table/hooks/usePaginationWindowPin.ts:56
**Pin Stays Uninitialized**

When a user switches from an ASC or non-time sort to time-DESC while already past page 1, sorting does not reset the page and `pinnedAt` is not initialized because its initializer only runs on mount. The time-DESC query therefore remains open-ended, allowing new rows to shift offsets and cause duplicate or skipped traces or events. If pinning was previously active, switching back to DESC can instead reuse a stale timestamp. Initialize a fresh pin when `enabled` becomes true on a later page, or reset pagination when the sort changes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): keep filtered traces paging pa..."](https://github.com/langfuse/langfuse/commit/7d543dec17ded5c98a6f3c51aaf06050a5750eaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61587081)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->