### PR TITLE
feat(public-api): optional startTime on GET /observations/{id}

### DIFF
--- a/fern/apis/server/definition/legacy/observations-v1.yml
+++ b/fern/apis/server/definition/legacy/observations-v1.yml
@@ -17,6 +17,12 @@ service:
         observationId:
           type: string
           docs: The unique langfuse identifier of an observation, can be an event, span or generation
+      request:
+        name: GetObservationRequest
+        query-parameters:
+          startTime:
+            type: optional<datetime>
+            docs: The start time of the observation (ISO 8601 with offset, e.g. 2024-01-01T00:00:00Z). When provided, the lookup is restricted to the observation's start day, which makes the request substantially faster. Omit it to look up the observation without a time bound.
       response: commons.ObservationsViewSingle
     getMany:
       availability:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3013,6 +3013,18 @@ paths:
           required: true
           schema:
             type: string
+        - name: startTime
+          in: query
+          description: >-
+            The start time of the observation (ISO 8601 with offset, e.g.
+            2024-01-01T00:00:00Z). When provided, the lookup is restricted to
+            the observation's start day, which makes the request substantially
+            faster. Omit it to look up the observation without a time bound.
+          required: false
+          schema:
+            type: string
+            format: date-time
+            nullable: true
       responses:
         '200':
           description: ''

--- a/web/src/__tests__/server/observation-api.servertest.ts
+++ b/web/src/__tests__/server/observation-api.servertest.ts
@@ -7,7 +7,10 @@ import {
   createObservationsCh,
   createOrgProjectAndApiKey,
 } from "@langfuse/shared/src/server";
-import { makeZodVerifiedAPICall } from "@/src/__tests__/test-utils";
+import {
+  makeAPICall,
+  makeZodVerifiedAPICall,
+} from "@/src/__tests__/test-utils";
 import {
   GetObservationV1Response,
   GetObservationsV1Response,
@@ -165,6 +168,70 @@ describe("/api/public/observations API Endpoint", () => {
             input: observation.input,
             output: observation.output,
           });
+        });
+
+        it("should GET an observation when startTime matches its UTC day", async () => {
+          const observationId = uuidv4();
+          const traceId = uuidv4();
+          const startTime = new Date("2024-03-15T08:30:00.000Z").getTime();
+
+          const observation = createObservationData(useEventsTable, {
+            id: observationId,
+            project_id: projectId,
+            trace_id: traceId,
+            type: "GENERATION",
+            start_time: startTime * timeMultiplier,
+            event_ts: startTime * timeMultiplier,
+            end_time: startTime * timeMultiplier,
+          });
+
+          await insertObservations(useEventsTable, [observation]);
+
+          const getEventRes = await makeZodVerifiedAPICall(
+            GetObservationV1Response,
+            "GET",
+            `/api/public/observations/${observationId}?startTime=2024-03-15T23:59:59.000Z&useEventsTable=${useEventsTable}`,
+          );
+
+          expect(getEventRes.body).toMatchObject({
+            id: observationId,
+            traceId,
+            type: "GENERATION",
+          });
+        });
+
+        it("should 404 when startTime is on a different UTC day", async () => {
+          const observationId = uuidv4();
+          const traceId = uuidv4();
+          const startTime = new Date("2024-03-15T08:30:00.000Z").getTime();
+
+          const observation = createObservationData(useEventsTable, {
+            id: observationId,
+            project_id: projectId,
+            trace_id: traceId,
+            type: "GENERATION",
+            start_time: startTime * timeMultiplier,
+            event_ts: startTime * timeMultiplier,
+            end_time: startTime * timeMultiplier,
+          });
+
+          await insertObservations(useEventsTable, [observation]);
+
+          const res = await makeAPICall(
+            "GET",
+            `/api/public/observations/${observationId}?startTime=2024-03-16T00:00:00.000Z&useEventsTable=${useEventsTable}`,
+          );
+
+          expect(res.status).toBe(404);
+        });
+
+        it("should 400 when startTime lacks a timezone offset", async () => {
+          const res = await makeAPICall(
+            "GET",
+            `/api/public/observations/${uuidv4()}?startTime=2024-03-15T08:30:00&useEventsTable=${useEventsTable}`,
+          );
+
+          expect(res.status).toBe(400);
         });
 
         it.each([

--- a/web/src/__tests__/server/unit/get-observation-v1-query.servertest.ts
+++ b/web/src/__tests__/server/unit/get-observation-v1-query.servertest.ts
@@ -1,0 +1,28 @@
+import { GetObservationV1Query } from "@/src/features/public-api/types/observations";
+
+describe("GetObservationV1Query", () => {
+  it("parses without startTime (backwards compatible)", () => {
+    const result = GetObservationV1Query.safeParse({
+      observationId: "obs-1",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.startTime).toBeUndefined();
+  });
+
+  it("accepts an ISO datetime with a timezone offset", () => {
+    const result = GetObservationV1Query.safeParse({
+      observationId: "obs-1",
+      startTime: "2024-03-15T08:30:00.000Z",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.startTime).toBe("2024-03-15T08:30:00.000Z");
+  });
+
+  it("rejects a datetime without a timezone offset", () => {
+    const result = GetObservationV1Query.safeParse({
+      observationId: "obs-1",
+      startTime: "2024-03-15T08:30:00",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -239,6 +239,10 @@ export const GetObservationsV1Response = z
 // GET /observations/{observationId}
 export const GetObservationV1Query = z.object({
   observationId: z.string(),
+  // Optional timestamp on the observation's start (ISO 8601 with offset).
+  // When provided, it bounds the lookup to that UTC day, making the query
+  // dramatically cheaper. Omit it for the default full lookup.
+  startTime: stringDateTime,
   useEventsTable: useEventsTableSchema,
 });
 // `_deprecation` at the response level, not on the shared `APIObservation`

--- a/web/src/pages/api/public/observations/[observationId].ts
+++ b/web/src/pages/api/public/observations/[observationId].ts
@@ -31,17 +31,23 @@ export default withMiddlewares(
       rejectInEventsOnlyMode: true,
       deprecation: OBSERVATIONS_V1_DEPRECATION,
       fn: async ({ query, auth }) => {
+        const startTime = query.startTime
+          ? new Date(query.startTime)
+          : undefined;
+
         const clickhouseObservation = query.useEventsTable
           ? await getObservationByIdFromEventsTable({
               id: query.observationId,
               projectId: auth.scope.projectId,
               fetchWithInputOutput: true,
+              startTime,
             })
           : // eslint-disable-next-line @typescript-eslint/no-deprecated
             await getObservationById({
               id: query.observationId,
               projectId: auth.scope.projectId,
               fetchWithInputOutput: true,
+              startTime,
               preferredClickhouseService: "ReadOnly",
             });
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17193 app preview](https://pr-17193.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Adds an optional `startTime` query parameter to the public `GET /api/public/observations/{observationId}` endpoint. When provided, it bounds the ClickHouse lookup to the observation's UTC start day, turning a full by-id scan (which opens thousands of parts on high-volume projects) into a partition-pruned single-day query. This targets the read-amplification / latency profile of this endpoint (unsampled p90 ≈ 4s, p99 ≈ 13s at the shoulder) with a single query and no extra rounds.

- Threads `startTime` through both the events-table read path (`getObservationByIdFromEventsTable`) and the legacy observations-table path (`getObservationById`).
- Uses the repository's existing day-equality bound (`toDate(start_time) = toDate(startTime)`) — the same tight prune the UI's `observations.byId` procedure already relies on.
- Optional and fully backwards compatible: omitting `startTime` leaves behavior unchanged for existing SDK/REST callers.
- Updates the Fern source and regenerates the served OpenAPI spec; `pnpm run openapi:check` passes.

**Semantics / doubt to review:** the bound is UTC-day exact. A caller passing a timestamp on the wrong UTC day (e.g. clock skew across midnight) will get a 404. The docs tell callers to pass the observation's known `startTime` or another timestamp on the same UTC day. This does not address genuinely-not-found ids — that remains the domain of a separate structural index.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Added integration tests (match day / wrong-day 404 / missing-offset 400) for both the events-table and observations-table branches, plus a schema unit test.
- Lint, typecheck, the schema unit test, and `openapi:check` pass locally. The ClickHouse-backed integration tests were not run locally (no ClickHouse/web server in this environment) and run in CI.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an optional, timezone-aware `startTime` query parameter to the legacy public observation-by-ID endpoint so ClickHouse can constrain lookups to the observation’s UTC start day.

- Threads the parsed bound through both events-table and legacy observations-table retrieval paths.
- Updates the Fern source and generated OpenAPI contract.
- Adds schema and endpoint coverage for omission, matching dates, wrong dates, and missing timezone offsets.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with its runtime behavior, public contract, and tests aligned.

Both lookup paths consistently apply the optional UTC-day bound, validated inputs cannot produce invalid dates, omission preserves prior behavior, and no actionable contract or correctness failure remains.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[API client] --> R[GET observations by ID]
  R --> V{Validate startTime}
  V -->|omitted| U[Unbounded ID lookup]
  V -->|valid ISO datetime with offset| D[Convert to Date]
  D --> B{Storage path}
  B -->|events table| E[Events-table lookup]
  B -->|legacy table| L[Observations-table lookup]
  E --> F["Filter ID, project, and UTC start day"]
  L --> F
  U --> G[Return observation or 404]
  F --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): optional startTime on ..."](https://github.com/langfuse/langfuse/commit/f8d18860e748f3a00ebed674d739627018577553) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61600092)</sub>

**Context used:**

- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->