### PR TITLE
fix(clickhouse): classify memory limit variants as ClickHouseResourceError

### DIFF
--- a/packages/shared/src/features/monitors/processor/processor.ts
+++ b/packages/shared/src/features/monitors/processor/processor.ts
@@ -164,7 +164,7 @@ export class MonitorProcessor {
       metricMap["count_count"] = parseNumericValue(row["count_count"]);
     } catch (error) {
       // Resource pressure is transient, not a bad query; rethrow so the monitor stays ACTIVE and the scheduler retries.
-      if (error instanceof ClickHouseResourceError) {
+      if (ClickHouseResourceError.is(error)) {
         logger.warn("queryMetrics hit a ClickHouse resource limit; retrying", {
           errorType: error.errorType,
           projectId: event.projectId,

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -55,6 +55,12 @@ const ERROR_TYPE_CONFIG: Record<
     discriminators: string[];
   }
 > = {
+  // Order matters: matched top-to-bottom, first hit wins. OvercommitTracker
+  // kills also carry a "Memory limit … exceeded" phrase, so OVERCOMMIT must
+  // precede MEMORY_LIMIT to keep the more specific cause in the outcome metric.
+  OVERCOMMIT: {
+    discriminators: ["overcommittracker"],
+  },
   MEMORY_LIMIT: {
     discriminators: [
       "memory limit exceeded",
@@ -63,9 +69,6 @@ const ERROR_TYPE_CONFIG: Record<
       "memory limit (for user) exceeded",
       "memory limit",
     ],
-  },
-  OVERCOMMIT: {
-    discriminators: ["overcommittracker"],
   },
   TIMEOUT: {
     discriminators: ["timeout", "timed out"],

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -56,13 +56,19 @@ const ERROR_TYPE_CONFIG: Record<
   }
 > = {
   MEMORY_LIMIT: {
-    discriminators: ["memory limit exceeded"],
+    discriminators: [
+      "memory limit exceeded",
+      "memory limit (for query) exceeded",
+      "memory limit (total) exceeded",
+      "memory limit (for user) exceeded",
+      "memory limit",
+    ],
   },
   OVERCOMMIT: {
-    discriminators: ["OvercommitTracker"],
+    discriminators: ["overcommittracker"],
   },
   TIMEOUT: {
-    discriminators: ["Timeout", "timeout", "timed out"],
+    discriminators: ["timeout", "timed out"],
   },
 };
 
@@ -89,11 +95,18 @@ export class ClickHouseResourceError extends Error {
     }
   }
 
+  static is(error: unknown): error is ClickHouseResourceError {
+    return (
+      error instanceof ClickHouseResourceError ||
+      (error instanceof Error && error.name === "ClickHouseResourceError")
+    );
+  }
+
   static wrapIfResourceError(
     originalError: Error,
     tags?: NormalizedClickHouseQueryTags,
   ): Error {
-    const errorMessage = originalError.message || "";
+    const errorMessage = (originalError.message || "").toLowerCase();
 
     for (const [type, config] of Object.entries(ERROR_TYPE_CONFIG) as Array<
       [
@@ -102,7 +115,7 @@ export class ClickHouseResourceError extends Error {
       ]
     >) {
       const hasDiscriminator = config.discriminators.some((discriminator) =>
-        errorMessage.includes(discriminator),
+        errorMessage.includes(discriminator.toLowerCase()),
       );
 
       if (hasDiscriminator) {

--- a/packages/shared/src/server/repositories/clickhouseResourceError.test.ts
+++ b/packages/shared/src/server/repositories/clickhouseResourceError.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { ClickHouseResourceError } from "./clickhouse";
+
+describe("ClickHouseResourceError", () => {
+  describe("wrapIfResourceError", () => {
+    const cases = [
+      {
+        name: "capitalized per-query memory limit",
+        message:
+          "Memory limit (for query) exceeded: would use 2.25 GiB (attempt to allocate chunk of 0.00 B), current RSS: 1.42 GiB, maximum: 2.25 GiB",
+        expectedType: "MEMORY_LIMIT",
+      },
+      {
+        name: "capitalized total memory limit",
+        message:
+          "Memory limit (total) exceeded: would use 2.25 GiB, current RSS: 1.42 GiB, maximum: 2.25 GiB",
+        expectedType: "MEMORY_LIMIT",
+      },
+      {
+        name: "capitalized user memory limit",
+        message: "Memory limit (for user) exceeded: would use 2.25 GiB",
+        expectedType: "MEMORY_LIMIT",
+      },
+      {
+        name: "lowercase total memory limit",
+        message:
+          "(total) memory limit exceeded: would use 2.25 GiB (attempt to allocate chunk of 0.00 B)",
+        expectedType: "MEMORY_LIMIT",
+      },
+      {
+        name: "simple memory limit exceeded",
+        message: "memory limit exceeded",
+        expectedType: "MEMORY_LIMIT",
+      },
+      {
+        name: "OvercommitTracker decision",
+        message:
+          "OvercommitTracker decision: Query was selected to stop by OvercommitTracker: While executing AggregatingTransform",
+        expectedType: "OVERCOMMIT",
+      },
+      {
+        name: "case-insensitive overcommittracker",
+        message: "query stopped by overcommittracker",
+        expectedType: "OVERCOMMIT",
+      },
+      {
+        name: "socket timeout",
+        message: "Timeout exceeded while reading from socket",
+        expectedType: "TIMEOUT",
+      },
+      {
+        name: "timed out error",
+        message: "Request timed out after 30000ms",
+        expectedType: "TIMEOUT",
+      },
+    ];
+
+    cases.forEach(({ name, message, expectedType }) => {
+      it(`wraps ${name} as ${expectedType}`, () => {
+        const error = new Error(message);
+        const wrapped = ClickHouseResourceError.wrapIfResourceError(error);
+
+        expect(wrapped).toBeInstanceOf(ClickHouseResourceError);
+        expect(ClickHouseResourceError.is(wrapped)).toBe(true);
+        expect((wrapped as ClickHouseResourceError).errorType).toBe(
+          expectedType,
+        );
+      });
+    });
+
+    it("does not wrap regular SQL errors", () => {
+      const error = new Error("Table 'test.non_existent' doesn't exist");
+      const wrapped = ClickHouseResourceError.wrapIfResourceError(error);
+
+      expect(wrapped).toBe(error);
+      expect(wrapped).not.toBeInstanceOf(ClickHouseResourceError);
+      expect(ClickHouseResourceError.is(wrapped)).toBe(false);
+    });
+  });
+
+  describe("is", () => {
+    it("returns true for ClickHouseResourceError instances", () => {
+      const error = new ClickHouseResourceError(
+        "MEMORY_LIMIT",
+        new Error("out of memory"),
+      );
+      expect(ClickHouseResourceError.is(error)).toBe(true);
+    });
+
+    it("returns true for errors matching name ClickHouseResourceError across boundaries", () => {
+      const fakeError = new Error("resource limit");
+      fakeError.name = "ClickHouseResourceError";
+      expect(ClickHouseResourceError.is(fakeError)).toBe(true);
+    });
+
+    it("returns false for standard errors and non-errors", () => {
+      expect(ClickHouseResourceError.is(new Error("generic"))).toBe(false);
+      expect(ClickHouseResourceError.is(null)).toBe(false);
+      expect(ClickHouseResourceError.is(undefined)).toBe(false);
+      expect(ClickHouseResourceError.is("ClickHouseResourceError")).toBe(false);
+      expect(ClickHouseResourceError.is({})).toBe(false);
+    });
+  });
+});

--- a/packages/shared/src/server/repositories/clickhouseResourceError.test.ts
+++ b/packages/shared/src/server/repositories/clickhouseResourceError.test.ts
@@ -39,6 +39,14 @@ describe("ClickHouseResourceError", () => {
         expectedType: "OVERCOMMIT",
       },
       {
+        // Overcommit kills also carry a "Memory limit … exceeded" phrase; the
+        // more specific OVERCOMMIT cause must win so the outcome metric stays accurate.
+        name: "overcommit kill carrying a memory limit phrase",
+        message:
+          "Memory limit (total) exceeded: would use 9.32 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker",
+        expectedType: "OVERCOMMIT",
+      },
+      {
         name: "case-insensitive overcommittracker",
         message: "query stopped by overcommittracker",
         expectedType: "OVERCOMMIT",
@@ -68,13 +76,22 @@ describe("ClickHouseResourceError", () => {
       });
     });
 
-    it("does not wrap regular SQL errors", () => {
-      const error = new Error("Table 'test.non_existent' doesn't exist");
-      const wrapped = ClickHouseResourceError.wrapIfResourceError(error);
+    const benignCases = [
+      "Table 'test.non_existent' doesn't exist",
+      "Unknown identifier 'foo' in scope SELECT foo FROM traces",
+      "Syntax error: failed at position 42",
+      "Cannot parse input: expected ')' before end of stream",
+    ];
 
-      expect(wrapped).toBe(error);
-      expect(wrapped).not.toBeInstanceOf(ClickHouseResourceError);
-      expect(ClickHouseResourceError.is(wrapped)).toBe(false);
+    benignCases.forEach((message) => {
+      it(`does not wrap benign error: ${message.slice(0, 32)}`, () => {
+        const error = new Error(message);
+        const wrapped = ClickHouseResourceError.wrapIfResourceError(error);
+
+        expect(wrapped).toBe(error);
+        expect(wrapped).not.toBeInstanceOf(ClickHouseResourceError);
+        expect(ClickHouseResourceError.is(wrapped)).toBe(false);
+      });
     });
   });
 

--- a/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
+++ b/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
@@ -249,6 +249,33 @@ describe("ClickHouse Resource Error Handling", () => {
         errorType: "OVERCOMMIT",
       },
       {
+        name: "Memory limit for query exceeded (capitalized)",
+        errorMessage:
+          "Memory limit (for query) exceeded: would use 2.25 GiB (attempt to allocate chunk of 0.00 B), current RSS: 1.42 GiB, maximum: 2.25 GiB",
+        shouldBeResourceError: true,
+        errorType: "MEMORY_LIMIT",
+      },
+      {
+        name: "Memory limit total exceeded (capitalized)",
+        errorMessage:
+          "Memory limit (total) exceeded: would use 2.25 GiB, current RSS: 1.42 GiB, maximum: 2.25 GiB",
+        shouldBeResourceError: true,
+        errorType: "MEMORY_LIMIT",
+      },
+      {
+        name: "Memory limit for user exceeded (capitalized)",
+        errorMessage: "Memory limit (for user) exceeded: would use 2.25 GiB",
+        shouldBeResourceError: true,
+        errorType: "MEMORY_LIMIT",
+      },
+      {
+        name: "Overcommit decision with memory limit message",
+        errorMessage:
+          "(total) memory limit exceeded: would use 2.25 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker: While executing AggregatingTransform",
+        shouldBeResourceError: true,
+        errorType: "MEMORY_LIMIT",
+      },
+      {
         name: "Simple memory error",
         errorMessage: "memory limit exceeded",
         shouldBeResourceError: true,
@@ -288,6 +315,9 @@ describe("ClickHouse Resource Error Handling", () => {
           })(wrappedError);
 
           expect(isResourceError).toBe(shouldBeResourceError);
+          expect(ClickHouseResourceError.is(wrappedError)).toBe(
+            shouldBeResourceError,
+          );
 
           const resourceError = wrappedError as ClickHouseResourceError;
           if (shouldBeResourceError && errorType) {

--- a/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
+++ b/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
@@ -273,7 +273,7 @@ describe("ClickHouse Resource Error Handling", () => {
         errorMessage:
           "(total) memory limit exceeded: would use 2.25 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker: While executing AggregatingTransform",
         shouldBeResourceError: true,
-        errorType: "MEMORY_LIMIT",
+        errorType: "OVERCOMMIT",
       },
       {
         name: "Simple memory error",

--- a/worker/src/__tests__/monitorProcessor.test.ts
+++ b/worker/src/__tests__/monitorProcessor.test.ts
@@ -100,7 +100,7 @@ type ProcessCase = {
   injectError?: {
     stage: InjectErrorStage;
     message: string;
-    errorClass?: "invalid-request" | "resource";
+    errorClass?: "invalid-request" | "resource" | "resource-memory";
   };
   preempt?: { newClaimedAt: Date };
   preemptPause?: { at: Date };
@@ -736,6 +736,37 @@ const cases: ProcessCase[] = [
     },
   },
   {
+    name: "ClickHouse memory limit resource error on executeQuery: rethrows, stays ACTIVE, not ERROR_BAD_QUERY",
+    monitors: [
+      {
+        id: monitorAId,
+        severity: MonitorSeveritySchema.enum.OK,
+        severityChangedAt: tenMinutesAgo,
+        lastPublishedAt: runAt,
+      },
+    ],
+    injectError: {
+      stage: "executeQuery",
+      errorClass: "resource-memory",
+      message: "Memory limit (for query) exceeded: would use 2.25 GiB",
+    },
+    expect: {
+      throws: "Memory limit (for query) exceeded: would use 2.25 GiB",
+      publishCallCount: 0,
+      rows: [
+        {
+          id: monitorAId,
+          status: MonitorStatusSchema.enum.ACTIVE,
+          severity: MonitorSeveritySchema.enum.OK,
+          severityChangedAt: tenMinutesAgo,
+          alertedAt: null,
+          lastClaimedAt: justAfterRunAt,
+          lastCompletedAt: null,
+        },
+      ],
+    },
+  },
+  {
     name: "error on getTriggers: claim, no complete, no sev change, no emit",
     monitors: [
       {
@@ -1349,6 +1380,11 @@ describe("MonitorProcessor.process (integration)", () => {
         if (c.injectError.errorClass === "resource") {
           throw new ClickHouseResourceError(
             "TIMEOUT",
+            new Error(c.injectError.message),
+          );
+        }
+        if (c.injectError.errorClass === "resource-memory") {
+          throw ClickHouseResourceError.wrapIfResourceError(
             new Error(c.injectError.message),
           );
         }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17194 app preview](https://pr-17194.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

ClickHouse code-241 OOM errors were never classified as resource errors, so they surfaced as opaque tRPC 500s (plus Sentry noise) instead of the intended 422 "narrow your request" response.

Root cause in `ClickHouseResourceError.wrapIfResourceError`:
- The `MEMORY_LIMIT` discriminator was `"memory limit exceeded"` and matched **case-sensitively**.
- Real messages are `Code: 241. DB::Exception: Memory limit (for query) exceeded: ...` and `Memory limit (total) exceeded: ...` — the `(for query)`/`(total)` infix breaks the substring, and the casing (`Memory` vs `memory`) never matched anyway.

Fix:
- Lowercase both the error message and the discriminators before matching.
- Add discriminators for the real infix variants (`(for query)`, `(total)`, `(for user)`) plus a broad `"memory limit"` fallback.
- Add `ClickHouseResourceError.is()` for reliable identification across bundle boundaries (`instanceof` can fail across duplicate class identities) and use it in the monitor processor.
- Add unit tests (`clickhouseResourceError.test.ts`) and server-test cases asserting classification of the real code-241 strings, plus a worker monitor-processor case confirming a memory-limit error stays ACTIVE and is not misclassified as a bad query.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] `pnpm run lint` passes
- [x] Unit tests added and passing (`clickhouseResourceError.test.ts`, 13 tests)
- [x] Typecheck passes for shared, web, worker

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes ClickHouse resource-error recognition case-insensitive, recognizes common memory-limit message variants, and adds cross-bundle identification for monitor retry handling.
- Classifies per-query, total, and per-user memory-limit failures as resource errors.
- Keeps monitors active when transient memory pressure interrupts evaluation.
- Adds shared unit, web server, and worker integration coverage for the updated behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the updated classification and monitor retry behavior covered at unit and integration levels.

No concrete correctness, security, or repository-rule violation remains; the implementation consistently classifies known ClickHouse resource messages and preserves transient-failure handling.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(clickhouse): classify memory limit v..."](https://github.com/langfuse/langfuse/commit/7cfefc96494dc5bc2cca710b0c797f4f7761f990) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61600585)</sub>

**Context used:**

- Knowledge Base — [Observability data platform](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/observability-data-platform.md)
- Knowledge Base — [Dashboards, metrics, and monitors](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/dashboards-metrics-and-monitors.md)

<!-- /greptile_comment -->