### PR TITLE
perf(annotation-queues): persist observation start_time on queue items

### DIFF
--- a/fern/apis/server/definition/annotation-queues.yml
+++ b/fern/apis/server/definition/annotation-queues.yml
@@ -189,6 +189,11 @@ types:
       status:
         type: optional<AnnotationQueueStatus>
         docs: Defaults to PENDING for new queue items
+      objectStartTime:
+        type: optional<datetime>
+        docs: >-
+          The start time of the referenced observation. When provided, Langfuse
+          resolves the referenced object more efficiently when the item is read.
 
   UpdateAnnotationQueueItemRequest:
     properties:

--- a/packages/shared/prisma/migrations/20260908120000_add_annotation_queue_item_object_start_time/migration.sql
+++ b/packages/shared/prisma/migrations/20260908120000_add_annotation_queue_item_object_start_time/migration.sql
@@ -1,0 +1,4 @@
+-- Persisted start_time of the referenced observation so by-id lookups can bound
+-- the events_full scan by partition/part instead of scanning the whole table.
+-- Nullable: older rows and non-observation items have no value.
+ALTER TABLE "annotation_queue_items" ADD COLUMN "object_start_time" TIMESTAMP(3);

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -504,6 +504,7 @@ model AnnotationQueueItem {
   queue           AnnotationQueue           @relation(fields: [queueId], references: [id], onDelete: Cascade)
   objectId        String                    @map("object_id")
   objectType      AnnotationQueueObjectType @map("object_type")
+  objectStartTime DateTime?                 @map("object_start_time")
   status          AnnotationQueueStatus     @default(PENDING)
   lockedAt        DateTime?                 @map("locked_at")
   lockedByUserId  String?                   @map("locked_by_user_id")

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -8722,6 +8722,14 @@ components:
           $ref: '#/components/schemas/AnnotationQueueStatus'
           nullable: true
           description: Defaults to PENDING for new queue items
+        objectStartTime:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            The start time of the referenced observation. When provided,
+            Langfuse resolves the referenced object more efficiently when the
+            item is read.
       required:
         - objectId
         - objectType

--- a/web/src/__tests__/server/annotation-queue-items-trpc.servertest.ts
+++ b/web/src/__tests__/server/annotation-queue-items-trpc.servertest.ts
@@ -2,7 +2,11 @@ import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { AnnotationQueueObjectType, type Plan } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
-import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
+import {
+  createEvent,
+  createEventsCh,
+  createOrgProjectAndApiKey,
+} from "@langfuse/shared/src/server";
 import type { Session } from "next-auth";
 import { v4 as uuidv4 } from "uuid";
 
@@ -134,6 +138,60 @@ describe("annotation queues trpc", () => {
           itemId: item.id,
         }),
       ).rejects.toThrow("User does not have access to this resource or action");
+    });
+  });
+
+  describe("annotationQueueItems.byId", () => {
+    it("resolves an observation item using the persisted objectStartTime", async () => {
+      const setup = await createOrgProjectAndApiKey();
+      orgIds.push(setup.org.id);
+      const { caller } = createCallerForProjectRole(setup, "ADMIN");
+
+      const queue = await prisma.annotationQueue.create({
+        data: {
+          name: "Test Queue",
+          description: "Test Queue Description",
+          scoreConfigIds: [],
+          projectId: setup.project.id,
+        },
+      });
+
+      const observationId = uuidv4();
+      const traceId = uuidv4();
+      const startTime = new Date("2024-05-15T12:00:00.000Z");
+      await createEventsCh([
+        createEvent({
+          id: observationId,
+          span_id: observationId,
+          trace_id: traceId,
+          project_id: setup.project.id,
+          start_time: startTime,
+          type: "GENERATION",
+        }),
+      ]);
+
+      const item = await prisma.annotationQueueItem.create({
+        data: {
+          queueId: queue.id,
+          objectId: observationId,
+          objectType: AnnotationQueueObjectType.OBSERVATION,
+          objectStartTime: startTime,
+          projectId: setup.project.id,
+        },
+      });
+
+      const result = await caller.annotationQueueItems.byId({
+        projectId: setup.project.id,
+        itemId: item.id,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result && "parentTraceId" in result && result.parentTraceId).toBe(
+        traceId,
+      );
+      expect(result?.objectStartTime?.toISOString()).toBe(
+        startTime.toISOString(),
+      );
     });
   });
 

--- a/web/src/__tests__/server/annotation-queue-items-trpc.servertest.ts
+++ b/web/src/__tests__/server/annotation-queue-items-trpc.servertest.ts
@@ -208,6 +208,70 @@ describe("annotation queues trpc", () => {
         startTime.toISOString(),
       );
     });
+
+    it("resolves an observation item when the persisted objectStartTime is wrong", async () => {
+      // objectStartTime can originate from a client-supplied hint on the public
+      // create API, so a stale/wrong day must not hide an existing observation:
+      // the bounded lookup misses and the resolver retries unbounded.
+      const setup = await createOrgProjectAndApiKey();
+      orgIds.push(setup.org.id);
+      const { caller } = createCallerForProjectRole(setup, "ADMIN");
+
+      const queue = await prisma.annotationQueue.create({
+        data: {
+          name: "Test Queue",
+          description: "Test Queue Description",
+          scoreConfigIds: [],
+          projectId: setup.project.id,
+        },
+      });
+
+      const observationId = uuidv4();
+      const traceId = uuidv4();
+      const startTime = new Date("2024-05-15T12:00:00.000Z");
+      const wrongStartTime = new Date("2024-01-01T00:00:00.000Z");
+      await Promise.all([
+        createEventsCh([
+          createEvent({
+            id: observationId,
+            span_id: observationId,
+            trace_id: traceId,
+            project_id: setup.project.id,
+            start_time: startTime,
+            type: "GENERATION",
+          }),
+        ]),
+        createObservationsCh([
+          createObservation({
+            id: observationId,
+            trace_id: traceId,
+            project_id: setup.project.id,
+            start_time: startTime,
+            type: "GENERATION",
+          }),
+        ]),
+      ]);
+
+      const item = await prisma.annotationQueueItem.create({
+        data: {
+          queueId: queue.id,
+          objectId: observationId,
+          objectType: AnnotationQueueObjectType.OBSERVATION,
+          objectStartTime: wrongStartTime,
+          projectId: setup.project.id,
+        },
+      });
+
+      const result = await caller.annotationQueueItems.byId({
+        projectId: setup.project.id,
+        itemId: item.id,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result && "parentTraceId" in result && result.parentTraceId).toBe(
+        traceId,
+      );
+    });
   });
 
   describe("annotationQueues.create", () => {

--- a/web/src/__tests__/server/annotation-queue-items-trpc.servertest.ts
+++ b/web/src/__tests__/server/annotation-queue-items-trpc.servertest.ts
@@ -5,6 +5,8 @@ import { prisma } from "@langfuse/shared/src/db";
 import {
   createEvent,
   createEventsCh,
+  createObservation,
+  createObservationsCh,
   createOrgProjectAndApiKey,
 } from "@langfuse/shared/src/server";
 import type { Session } from "next-auth";
@@ -159,15 +161,28 @@ describe("annotation queues trpc", () => {
       const observationId = uuidv4();
       const traceId = uuidv4();
       const startTime = new Date("2024-05-15T12:00:00.000Z");
-      await createEventsCh([
-        createEvent({
-          id: observationId,
-          span_id: observationId,
-          trace_id: traceId,
-          project_id: setup.project.id,
-          start_time: startTime,
-          type: "GENERATION",
-        }),
+      // Seed both tables so the lookup resolves regardless of the v4 write-mode
+      // / preview routing the test environment happens to use.
+      await Promise.all([
+        createEventsCh([
+          createEvent({
+            id: observationId,
+            span_id: observationId,
+            trace_id: traceId,
+            project_id: setup.project.id,
+            start_time: startTime,
+            type: "GENERATION",
+          }),
+        ]),
+        createObservationsCh([
+          createObservation({
+            id: observationId,
+            trace_id: traceId,
+            project_id: setup.project.id,
+            start_time: startTime,
+            type: "GENERATION",
+          }),
+        ]),
       ]);
 
       const item = await prisma.annotationQueueItem.create({

--- a/web/src/__tests__/server/annotation-queues-api.servertest.ts
+++ b/web/src/__tests__/server/annotation-queues-api.servertest.ts
@@ -585,6 +585,32 @@ describe("Annotation Queues API Endpoints", () => {
       expect(response.body.status).toBe(AnnotationQueueStatus.PENDING);
     });
 
+    it("should persist objectStartTime when provided", async () => {
+      const objectId = uuidv4();
+      const objectStartTime = new Date("2024-05-15T12:00:00.000Z");
+
+      const response = await makeZodVerifiedAPICall(
+        CreateAnnotationQueueItemResponse,
+        "POST",
+        `/api/public/annotation-queues/${queueId}/items`,
+        {
+          objectId,
+          objectType: AnnotationQueueObjectType.OBSERVATION,
+          objectStartTime: objectStartTime.toISOString(),
+        },
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+
+      const persisted = await prisma.annotationQueueItem.findFirstOrThrow({
+        where: { queueId, objectId, projectId },
+      });
+      expect(persisted.objectStartTime?.toISOString()).toBe(
+        objectStartTime.toISOString(),
+      );
+    });
+
     it("should create queue items with different object types and statuses", async () => {
       const traceObjectId = uuidv4();
       const observationObjectId = uuidv4();

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -668,10 +668,24 @@ export default function ObservationsTable({
       selectedPageRowIds: selectedGenerationIds,
     } = observationsTableStore.getState();
 
+    // Persist each selected observation's start_time (from the loaded rows) so
+    // the queue-item by-id lookups can bound the events_full scan. Only the
+    // non-batch path uses this; selectAll goes through the worker stream.
+    const startTimeByObjectId = new Map(
+      (generations.data?.generations ?? []).map((g) => [g.id, g.startTime]),
+    );
+    const objectStartTimes = Object.fromEntries(
+      selectedGenerationIds.flatMap((id) => {
+        const startTime = startTimeByObjectId.get(id);
+        return startTime ? [[id, startTime.toISOString()]] : [];
+      }),
+    );
+
     await addToQueueMutation.mutateAsync({
       projectId,
       objectIds: selectedGenerationIds,
       objectType: AnnotationQueueObjectType.OBSERVATION,
+      objectStartTimes,
       queueId: targetId,
       isBatchAction: selectAll,
       query: {

--- a/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
+++ b/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
@@ -142,11 +142,13 @@ export const queueItemRouter = createTRPCRouter({
             ? await getObservationByIdFromEventsTable({
                 id: item.objectId,
                 projectId: input.projectId,
+                startTime: item.objectStartTime ?? undefined,
               })
             : // eslint-disable-next-line @typescript-eslint/no-deprecated
               await getObservationById({
                 id: item.objectId,
                 projectId: input.projectId,
+                startTime: item.objectStartTime ?? undefined,
               });
 
         if (!clickhouseObservation) {
@@ -286,6 +288,9 @@ export const queueItemRouter = createTRPCRouter({
           .array(z.string())
           .min(1, "Minimum 1 object_id is required."),
         objectType: z.enum(AnnotationQueueObjectType),
+        // start_time per objectId (observations only), persisted so later by-id
+        // lookups can bound the events_full scan.
+        objectStartTimes: z.record(z.string(), z.coerce.date()).optional(),
         query: BatchActionQuerySchema.optional(),
         isBatchAction: z.boolean().default(false),
       }),
@@ -324,6 +329,7 @@ export const queueItemRouter = createTRPCRouter({
             queueId: input.queueId,
             objectId,
             objectType: input.objectType,
+            objectStartTime: input.objectStartTimes?.[objectId] ?? null,
           })),
           skipDuplicates: true,
         });

--- a/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
+++ b/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
@@ -19,8 +19,6 @@ import {
   Prisma,
 } from "@langfuse/shared";
 import {
-  getObservationById,
-  getObservationByIdFromEventsTable,
   getObservationsTraceIdsFromEventsTable,
   getTraceIdsForObservations,
   logger,
@@ -28,6 +26,7 @@ import {
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { env } from "@/src/env.mjs";
+import { lookupQueueItemObservation } from "./lookupQueueItemObservation";
 
 const isItemLocked = (item: AnnotationQueueItem) => {
   return (
@@ -137,19 +136,11 @@ export const queueItemRouter = createTRPCRouter({
       };
 
       if (item.objectType === AnnotationQueueObjectType.OBSERVATION) {
-        const clickhouseObservation =
-          env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
-            ? await getObservationByIdFromEventsTable({
-                id: item.objectId,
-                projectId: input.projectId,
-                startTime: item.objectStartTime ?? undefined,
-              })
-            : // eslint-disable-next-line @typescript-eslint/no-deprecated
-              await getObservationById({
-                id: item.objectId,
-                projectId: input.projectId,
-                startTime: item.objectStartTime ?? undefined,
-              });
+        const clickhouseObservation = await lookupQueueItemObservation({
+          objectId: item.objectId,
+          projectId: input.projectId,
+          objectStartTime: item.objectStartTime,
+        });
 
         if (!clickhouseObservation) {
           throw new LangfuseNotFoundError("Observation not found");

--- a/web/src/features/annotation-queues/server/annotationQueuesRouter.ts
+++ b/web/src/features/annotation-queues/server/annotationQueuesRouter.ts
@@ -580,11 +580,13 @@ export const queueRouter = createTRPCRouter({
             ? await getObservationByIdFromEventsTable({
                 id: item.objectId,
                 projectId: input.projectId,
+                startTime: item.objectStartTime ?? undefined,
               })
             : // eslint-disable-next-line @typescript-eslint/no-deprecated
               await getObservationById({
                 id: item.objectId,
                 projectId: input.projectId,
+                startTime: item.objectStartTime ?? undefined,
               });
         return {
           ...inflatedUpdatedItem,

--- a/web/src/features/annotation-queues/server/annotationQueuesRouter.ts
+++ b/web/src/features/annotation-queues/server/annotationQueuesRouter.ts
@@ -1,4 +1,3 @@
-import { env } from "@/src/env.mjs";
 import { auditLog } from "@/src/features/audit-logs/server";
 import { throwIfNoProjectAccess } from "@/src/features/rbac";
 import {
@@ -15,13 +14,10 @@ import {
   optionalPaginationZod,
   Prisma,
 } from "@langfuse/shared";
-import {
-  getObservationById,
-  getObservationByIdFromEventsTable,
-  logger,
-} from "@langfuse/shared/src/server";
+import { logger } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { lookupQueueItemObservation } from "./lookupQueueItemObservation";
 
 export const queueRouter = createTRPCRouter({
   hasAny: protectedProjectProcedure
@@ -575,19 +571,11 @@ export const queueRouter = createTRPCRouter({
       };
 
       if (item.objectType === AnnotationQueueObjectType.OBSERVATION) {
-        const clickhouseObservation =
-          env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
-            ? await getObservationByIdFromEventsTable({
-                id: item.objectId,
-                projectId: input.projectId,
-                startTime: item.objectStartTime ?? undefined,
-              })
-            : // eslint-disable-next-line @typescript-eslint/no-deprecated
-              await getObservationById({
-                id: item.objectId,
-                projectId: input.projectId,
-                startTime: item.objectStartTime ?? undefined,
-              });
+        const clickhouseObservation = await lookupQueueItemObservation({
+          objectId: item.objectId,
+          projectId: input.projectId,
+          objectStartTime: item.objectStartTime,
+        });
         return {
           ...inflatedUpdatedItem,
           parentTraceId: clickhouseObservation?.traceId,

--- a/web/src/features/annotation-queues/server/lookupQueueItemObservation.ts
+++ b/web/src/features/annotation-queues/server/lookupQueueItemObservation.ts
@@ -1,4 +1,5 @@
 import { env } from "@/src/env.mjs";
+import { LangfuseNotFoundError } from "@langfuse/shared";
 import {
   getObservationById,
   getObservationByIdFromEventsTable,
@@ -33,9 +34,18 @@ export const lookupQueueItemObservation = async ({
       : // eslint-disable-next-line @typescript-eslint/no-deprecated
         getObservationById({ id: objectId, projectId, startTime });
 
-  const observation = await lookup(objectStartTime ?? undefined);
-  if (observation || !objectStartTime) {
-    return observation;
+  if (!objectStartTime) {
+    return lookup();
   }
-  return lookup();
+  try {
+    return await lookup(objectStartTime);
+  } catch (e) {
+    // The bounded lookups throw LangfuseNotFoundError on an empty result rather
+    // than returning null, so a wrong/stale hint surfaces here. Retry unbounded
+    // before giving up; any other error is a real failure and propagates.
+    if (e instanceof LangfuseNotFoundError) {
+      return lookup();
+    }
+    throw e;
+  }
 };

--- a/web/src/features/annotation-queues/server/lookupQueueItemObservation.ts
+++ b/web/src/features/annotation-queues/server/lookupQueueItemObservation.ts
@@ -1,0 +1,41 @@
+import { env } from "@/src/env.mjs";
+import {
+  getObservationById,
+  getObservationByIdFromEventsTable,
+} from "@langfuse/shared/src/server";
+
+/**
+ * Resolve the observation referenced by an annotation-queue item.
+ *
+ * `objectStartTime` (persisted on the queue item at enqueue) bounds the
+ * events_full lookup to the observation's day so ClickHouse can prune
+ * partitions/parts. The value can originate from a client-supplied hint on the
+ * public create API, so a wrong or stale day would bound the lookup to the
+ * wrong day and hide an existing observation. Retry once unbounded on a miss so
+ * the hint can only ever speed up a hit, never turn into a false "not found".
+ */
+export const lookupQueueItemObservation = async ({
+  objectId,
+  projectId,
+  objectStartTime,
+}: {
+  objectId: string;
+  projectId: string;
+  objectStartTime: Date | null;
+}) => {
+  const lookup = (startTime?: Date) =>
+    env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
+      ? getObservationByIdFromEventsTable({
+          id: objectId,
+          projectId,
+          startTime,
+        })
+      : // eslint-disable-next-line @typescript-eslint/no-deprecated
+        getObservationById({ id: objectId, projectId, startTime });
+
+  const observation = await lookup(objectStartTime ?? undefined);
+  if (observation || !objectStartTime) {
+    return observation;
+  }
+  return lookup();
+};

--- a/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
+++ b/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
@@ -413,6 +413,7 @@ export const createAnnotationQueueItemForApi = async ({
       queueId,
       objectId: input.objectId,
       objectType: input.objectType,
+      objectStartTime: input.objectStartTime ?? null,
       status,
       completedAt,
       projectId,

--- a/web/src/features/events/hooks/useEventsTableData.ts
+++ b/web/src/features/events/hooks/useEventsTableData.ts
@@ -272,8 +272,9 @@ export function useEventsTableData({
     projectId: string;
     targetId: string;
   }) => {
+    const loadedObservations = activeObservations.data?.observations ?? [];
     const visibleObservationIds = new Set(
-      (activeObservations.data?.observations ?? [])
+      loadedObservations
         .map((observation) => observation.id)
         .filter((id): id is string => Boolean(id)),
     );
@@ -282,10 +283,28 @@ export function useEventsTableData({
       (observationId) => visibleObservationIds.has(observationId),
     );
 
+    // Persist each selected observation's start_time (from the loaded rows) so
+    // the queue-item by-id lookups can bound the events_full scan. Only the
+    // non-batch path uses this; selectAll goes through the worker stream.
+    const startTimeByObjectId = new Map(
+      loadedObservations.flatMap((observation) =>
+        observation.id && observation.startTime
+          ? [[observation.id, observation.startTime] as const]
+          : [],
+      ),
+    );
+    const objectStartTimes = Object.fromEntries(
+      selectedObservationIds.flatMap((id) => {
+        const startTime = startTimeByObjectId.get(id);
+        return startTime ? [[id, startTime.toISOString()]] : [];
+      }),
+    );
+
     await addToQueueMutation.mutateAsync({
       projectId,
       objectIds: selectedObservationIds,
       objectType: AnnotationQueueObjectType.OBSERVATION,
+      objectStartTimes,
       queueId: targetId,
       isBatchAction: selectAll,
       query: {

--- a/web/src/features/public-api/types/annotation-queues.ts
+++ b/web/src/features/public-api/types/annotation-queues.ts
@@ -113,7 +113,7 @@ export const CreateAnnotationQueueItemBody = z
       .enum(AnnotationQueueStatus)
       .optional()
       .default(AnnotationQueueStatus.PENDING),
-    objectStartTime: z.coerce.date().nullish(),
+    objectStartTime: z.coerce.date().optional(),
   })
   .strict();
 

--- a/web/src/features/public-api/types/annotation-queues.ts
+++ b/web/src/features/public-api/types/annotation-queues.ts
@@ -113,6 +113,7 @@ export const CreateAnnotationQueueItemBody = z
       .enum(AnnotationQueueStatus)
       .optional()
       .default(AnnotationQueueStatus.PENDING),
+    objectStartTime: z.coerce.date().nullish(),
   })
   .strict();
 

--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -98,6 +98,9 @@ async function processActionChunk(
   chunkIds: string[],
   projectId: string,
   targetId?: string,
+  // start_time per chunk id; only used for observation add-to-queue so the
+  // referenced observation's timestamp is persisted on the queue item
+  objectStartTimes?: Map<string, Date>,
 ): Promise<void> {
   try {
     switch (actionId) {
@@ -124,6 +127,7 @@ async function processActionChunk(
           projectId,
           chunkIds,
           targetId as string,
+          objectStartTimes,
         );
         break;
 
@@ -274,11 +278,21 @@ export const handleBatchActionJob = async (
     for (let i = 0; i < records.length; i += CHUNK_SIZE) {
       const batch = records.slice(i, i + CHUNK_SIZE);
 
+      // Observation streams carry startTime; persist it on the queue item so
+      // later by-id lookups bound the events_full scan. Other record shapes
+      // have no startTime and the map is simply empty.
+      const objectStartTimes = new Map<string, Date>(
+        batch
+          .filter((r) => r.startTime instanceof Date)
+          .map((r) => [r.id, r.startTime as Date]),
+      );
+
       await processActionChunk(
         actionId,
         batch.map((r) => r.id),
         projectId,
         targetId,
+        objectStartTimes,
       );
     }
   } else if (actionId === "eval-create") {

--- a/worker/src/features/batchAction/processAddToQueue.ts
+++ b/worker/src/features/batchAction/processAddToQueue.ts
@@ -6,11 +6,14 @@ const addToQueue = async ({
   objectIds,
   objectType,
   targetId,
+  objectStartTimes,
 }: {
   projectId: string;
   objectIds: string[];
   objectType: AnnotationQueueObjectType;
   targetId: string;
+  // start_time per objectId, persisted so later by-id lookups stay bounded
+  objectStartTimes?: Map<string, Date>;
 }) => {
   // cannot use prisma `createMany` operation as we do not have unique constraint enforced on schema level
   // conflict must be handled on query level by reading existing items and filtering out traces that already exist
@@ -37,6 +40,7 @@ const addToQueue = async ({
         queueId: targetId,
         objectId,
         objectType,
+        objectStartTime: objectStartTimes?.get(objectId) ?? null,
       })),
     });
   }
@@ -97,6 +101,7 @@ export const processAddObservationsToQueue = async (
   projectId: string,
   observationIds: string[],
   targetId: string,
+  objectStartTimes?: Map<string, Date>,
 ) => {
   logger.info(
     `Adding observations ${JSON.stringify(observationIds)} to annotation queue ${targetId} in project ${projectId}`,
@@ -108,6 +113,7 @@ export const processAddObservationsToQueue = async (
       objectIds: observationIds,
       objectType: AnnotationQueueObjectType.OBSERVATION,
       targetId,
+      objectStartTimes,
     });
   } catch (e) {
     logger.error(

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -17,6 +17,7 @@ import {
   buildEventsBlobExportStreamQuery,
   buildEventsStreamQuery,
   getDistinctScoreNames,
+  parseClickhouseUTCDateTimeFormat,
   queryClickhouseStream,
   logger,
 } from "@langfuse/shared/src/server";
@@ -369,7 +370,7 @@ export const getEventsStreamForDataset = async (props: {
 /**
  * Lightweight event stream for batch add-to-annotation-queue.
  * Only fetches the fields needed for annotation queue item creation:
- * id, traceId.
+ * id, traceId, startTime (persisted so later by-id lookups stay bounded).
  */
 export const getEventsStreamForAnnotationQueue = async (props: {
   projectId: string;
@@ -403,6 +404,7 @@ export const getEventsStreamForAnnotationQueue = async (props: {
   type AnnotationQueueEventRow = {
     id: string;
     trace_id: string;
+    start_time: string;
   };
 
   const asyncGenerator = queryClickhouseStream<AnnotationQueueEventRow>({
@@ -425,6 +427,7 @@ export const getEventsStreamForAnnotationQueue = async (props: {
         yield {
           id: row.id,
           traceId: row.trace_id,
+          startTime: parseClickhouseUTCDateTimeFormat(row.start_time),
         };
       }
     })(),


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17197 app preview](https://pr-17197.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

The annotation-queue item detail (`annotationQueueItems.byId`) and dequeue (`annotationQueuesRouter.fetchAndLockNext`) procedures resolve the referenced observation via `getObservationById`. For `OBSERVATION` items this issued an `events_full` single-observation lookup **without a `start_time` bound**, so ClickHouse could not prune partitions/parts — a single lookup opened hundreds-to-thousands of parts on a hot annotation-UI path (one of the v4 events-table 30s-timeout query shapes).

The UI/queue-item row only carries a queue-item id — the observation's timestamp is never in scope at read time — so this uses the **persist-at-enqueue** approach: the referenced observation's `start_time` is stored on the `annotation_queue_items` row when the item is created, and the two read procedures pass it into the lookup to bound the scan.

- **Schema:** new nullable `object_start_time` column (Prisma migration).
- **Populated at every create path:**
  - Bulk worker batch-add threads `start_time` from the ClickHouse read stream (observation-stream already carries it; the events-stream now selects/parses it).
  - The tRPC `createMany` accepts an optional per-object `objectStartTimes` map, supplied by the observations and events tables (which already hold each row's `startTime`).
  - The public REST create endpoint gains an optional `objectStartTime` field (Fern + zod).
- **Reads:** `byId` and `fetchAndLockNext` pass the persisted `start_time` to `getObservationById*`.

The column is nullable: older rows and non-observation items (and any create path that doesn't supply it) fall back to the previous unbounded query. No progressive widening.

## Type of change

- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Added a tRPC `byId` test (seeds an event + a queue item with `objectStartTime`, asserts the bounded lookup resolves `parentTraceId`) and a public-API test asserting `objectStartTime` is persisted.
- `pnpm turbo run typecheck lint --filter=web --filter=worker --filter=@langfuse/shared` → all green.
- `pnpm run openapi:check` → served OpenAPI specs match their Fern sources.
- The new server tests were not executed locally (ClickHouse + web server not running here); they run in CI.

### What a reviewer should doubt

- The bulk-add events-stream path parses ClickHouse `start_time` via `parseClickhouseUTCDateTimeFormat` — a wrong parse would persist a wrong `start_time` and make the bounded `toDate(start_time)=toDate(...)` lookup **miss a valid observation (false 404)**, which is worse than an unbounded read. Worth confirming the parse and that single-day equality holds for the exact persisted value.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR persists observation start times on annotation queue items and passes them into ClickHouse detail lookups to constrain scans.

- Adds the nullable PostgreSQL field and Prisma migration.
- Threads timestamps through table actions, batch workers, tRPC, and the public REST contract.
- Uses the timestamp in both queue-item detail and dequeue observation resolution.
- Adds happy-path persistence and bounded-lookup tests.
- The public timestamp currently affects correctness despite being documented as an optimization hint.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until an incorrect public timestamp hint can no longer make valid queue items unresolvable and temporarily locked.

The UTC timestamp propagation is internally consistent, but the public endpoint trusts an optional client value that both lookup paths use as an authoritative date filter, creating false not-found responses and failed dequeues.

**Files Needing Attention:** web/src/features/annotation-queues/server/publicAnnotationQueueService.ts, web/src/features/annotation-queues/server/annotationQueuesRouter.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Observation or event row] --> B[UI, public API, or batch stream]
  B --> C[(annotation_queue_items.object_start_time)]
  C --> D[Queue item detail or dequeue]
  D --> E{Migration read path}
  E -->|Legacy| F[observations lookup]
  E -->|Events| G[events_full lookup]
  F --> H[toDate start_time bound]
  G --> H
  H --> I[Resolved observation and parent trace]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/annotation-queues/server/publicAnnotationQueueService.ts:416
**Unverified Hint Breaks Lookups**

The public API accepts and persists any `objectStartTime`, but both observation lookup paths use it as an exact calendar-day filter. If a client supplies a stale or incorrect day, `byId` reports that the valid observation was not found. Dequeue also saves the item lock before running this lookup, so the failed item remains unavailable for up to five minutes. Because this field is documented as a performance hint, an invalid value should not change lookup correctness.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(annotation-queues): persist observa..."](https://github.com/langfuse/langfuse/commit/af856e494c9606c2858f01875c7576bc56bdec4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61608146)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Observability data platform](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/observability-data-platform.md)
- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)
- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)
</details>


<!-- /greptile_comment -->