### PR TITLE
fix(blob-export): start full-history exports at the real data minimum

### DIFF
--- a/worker/src/features/blobstorage/firstExportStart.test.ts
+++ b/worker/src/features/blobstorage/firstExportStart.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { BlobStorageExportMode } from "@langfuse/shared";
+import { resolveFirstExportStart } from "./firstExportStart";
+
+const NOW = new Date("2026-08-28T12:00:00.000Z");
+
+describe("resolveFirstExportStart", () => {
+  const base = {
+    exportStartDate: null as Date | null,
+    historicalMinTimestampMs: null as number | null,
+    now: NOW,
+  };
+
+  it("uses the real ClickHouse min for FULL_HISTORY when data exists", () => {
+    const min = new Date("2025-03-01T00:00:00.000Z");
+    expect(
+      resolveFirstExportStart({
+        ...base,
+        exportMode: BlobStorageExportMode.FULL_HISTORY,
+        historicalMinTimestampMs: min.getTime(),
+      }),
+    ).toEqual(min);
+  });
+
+  it("does not floor a backfilled min that predates a much later project", () => {
+    // The reported case: data backfilled years before the project row exists.
+    // A full-history export must reach back to the real data minimum.
+    const backfilledMin = new Date("2019-01-01T00:00:00.000Z");
+    expect(
+      resolveFirstExportStart({
+        ...base,
+        exportMode: BlobStorageExportMode.FULL_HISTORY,
+        historicalMinTimestampMs: backfilledMin.getTime(),
+      }),
+    ).toEqual(backfilledMin);
+  });
+
+  it("starts a first FULL_HISTORY export at now when there are no rows", () => {
+    expect(
+      resolveFirstExportStart({
+        ...base,
+        exportMode: BlobStorageExportMode.FULL_HISTORY,
+      }),
+    ).toEqual(NOW);
+  });
+
+  it("treats a zero min timestamp as no data and starts at now", () => {
+    expect(
+      resolveFirstExportStart({
+        ...base,
+        exportMode: BlobStorageExportMode.FULL_HISTORY,
+        historicalMinTimestampMs: 0,
+      }),
+    ).toEqual(NOW);
+  });
+
+  it("uses the custom start date for FROM_CUSTOM_DATE", () => {
+    const custom = new Date("2026-01-01T00:00:00.000Z");
+    expect(
+      resolveFirstExportStart({
+        ...base,
+        exportMode: BlobStorageExportMode.FROM_CUSTOM_DATE,
+        exportStartDate: custom,
+      }),
+    ).toEqual(custom);
+  });
+
+  it("falls back to now for FROM_TODAY without a start date", () => {
+    expect(
+      resolveFirstExportStart({
+        ...base,
+        exportMode: BlobStorageExportMode.FROM_TODAY,
+      }),
+    ).toEqual(NOW);
+  });
+});

--- a/worker/src/features/blobstorage/firstExportStart.ts
+++ b/worker/src/features/blobstorage/firstExportStart.ts
@@ -1,0 +1,38 @@
+import { BlobStorageExportMode } from "@langfuse/shared";
+
+/**
+ * Resolve the inclusive lower bound for the *first* blob-export run (no
+ * `lastSyncAt` yet).
+ *
+ * The FULL_HISTORY start is the real data minimum from ClickHouse. It is used
+ * as-is and never floored at `project.createdAt`: projects legitimately
+ * backfill data that predates the project row, and a full-history export must
+ * include it.
+ *
+ * When no rows exist yet, the start resolves to `now` so the caller's
+ * empty-window check skips the run instead of advancing the cursor. Returning
+ * the Unix epoch would make the worker walk tens of thousands of empty daily
+ * windows from 1970, uploading empty files to the customer bucket.
+ */
+export function resolveFirstExportStart(params: {
+  exportMode: BlobStorageExportMode;
+  exportStartDate: Date | null;
+  historicalMinTimestampMs: number | null;
+  now?: Date;
+}): Date {
+  const now = params.now ?? new Date();
+
+  switch (params.exportMode) {
+    case BlobStorageExportMode.FULL_HISTORY: {
+      const minMs = Number(params.historicalMinTimestampMs);
+      return minMs && minMs > 0 ? new Date(minMs) : now;
+    }
+    case BlobStorageExportMode.FROM_TODAY:
+    case BlobStorageExportMode.FROM_CUSTOM_DATE:
+      return params.exportStartDate ?? now;
+    default: {
+      const _exhaustiveCheck: never = params.exportMode;
+      throw new Error(`Invalid export mode: ${_exhaustiveCheck}`);
+    }
+  }
+}

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -239,6 +239,7 @@ const getMinTimestampForExport = async (
                 SELECT min(start_time) as ts
                 FROM events_core
                 WHERE project_id = {projectId: String}
+                AND is_deleted = 0 -- match the events export query's visibility
               )
               WHERE ts > 0 -- Ignore 0 results (usually empty tables)
             `,

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -89,6 +89,7 @@ import {
   buildBlobExportDeprecationNotice,
   buildBlobExportDeprecationNoticeKey,
 } from "./deprecationNotice";
+import { resolveFirstExportStart } from "./firstExportStart";
 
 const BlobExportFormat = {
   JSON_RAW: "json-raw",
@@ -206,13 +207,15 @@ const getMinTimestampForExport = async (
     return lastSyncAt;
   }
 
-  // For first export, use the export mode to determine start date
-  switch (exportMode) {
-    case BlobStorageExportMode.FULL_HISTORY:
-      // Query ClickHouse for the actual minimum timestamp from traces, observations, and scores tables
-      try {
-        const result = await queryClickhouse<{ min_timestamp: number | null }>({
-          query: `
+  // For a first FULL_HISTORY export, probe ClickHouse for the actual minimum
+  // timestamp across every source table. This is the real data minimum, not
+  // project createdAt: projects legitimately backfill data that predates the
+  // project, and a full-history export must include it.
+  let historicalMinTimestampMs: number | null = null;
+  if (exportMode === BlobStorageExportMode.FULL_HISTORY) {
+    try {
+      const result = await queryClickhouse<{ min_timestamp: number | null }>({
+        query: `
               SELECT min(toUnixTimestamp(ts)) * 1000 as min_timestamp
               FROM (
                 SELECT min(timestamp) as ts
@@ -230,46 +233,39 @@ const getMinTimestampForExport = async (
                 SELECT min(timestamp) as ts
                 FROM scores
                 WHERE project_id = {projectId: String}
+
+                UNION ALL
+
+                SELECT min(start_time) as ts
+                FROM events_core
+                WHERE project_id = {projectId: String}
               )
               WHERE ts > 0 -- Ignore 0 results (usually empty tables)
             `,
-          params: { projectId },
-        });
+        params: { projectId },
+      });
 
-        // Extract the minimum timestamp
-        logger.info(
-          `[BLOB INTEGRATION] ClickHouse min_timestamp for project ${projectId}: ${result[0]?.min_timestamp}, type: ${typeof result[0]?.min_timestamp}`,
-        );
-        const minTimestampValue = Number(result[0]?.min_timestamp);
-
-        if (minTimestampValue && minTimestampValue > 0) {
-          const date = new Date(minTimestampValue);
-          logger.info(
-            `[BLOB INTEGRATION] Created Date from min_timestamp for project ${projectId}: ${date}, isValid: ${!isNaN(date.getTime())}, getTime: ${date.getTime()}`,
-          );
-          return date;
-        }
-
-        // If no data exists, use current time as a fallback
-        logger.info(
-          `[BLOB INTEGRATION] No historical data found for project ${projectId}, using current time`,
-        );
-        return new Date(0);
-      } catch (error) {
-        logger.error(
-          `[BLOB INTEGRATION] Error querying ClickHouse for minimum timestamp for project ${projectId}`,
-          error,
-        );
-        throw new Error(`Failed to fetch minimum timestamp: ${error}`);
+      const minTimestampValue = Number(result[0]?.min_timestamp);
+      if (minTimestampValue && minTimestampValue > 0) {
+        historicalMinTimestampMs = minTimestampValue;
       }
-    case BlobStorageExportMode.FROM_TODAY:
-    case BlobStorageExportMode.FROM_CUSTOM_DATE:
-      return exportStartDate || new Date(); // Use export start date or current time as fallback
-    default:
-      // eslint-disable-next-line no-case-declarations
-      const _exhaustiveCheck: never = exportMode;
-      throw new Error(`Invalid export mode: ${exportMode}`);
+      logger.info(
+        `[BLOB INTEGRATION] ClickHouse min_timestamp for project ${projectId}: ${historicalMinTimestampMs}`,
+      );
+    } catch (error) {
+      logger.error(
+        `[BLOB INTEGRATION] Error querying ClickHouse for minimum timestamp for project ${projectId}`,
+        error,
+      );
+      throw new Error(`Failed to fetch minimum timestamp: ${error}`);
+    }
   }
+
+  return resolveFirstExportStart({
+    exportMode,
+    exportStartDate,
+    historicalMinTimestampMs,
+  });
 };
 
 /**


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17200 app preview](https://pr-17200.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

A first `FULL_HISTORY` blob-storage export used to fall through to the Unix epoch (`new Date(0)`) when ClickHouse held no rows. The worker then walked daily 24h windows from 1970 to now and uploaded tens of thousands of empty files to the customer bucket.

This is the minimal, floor-free alternative to #16787. Instead of clamping every resolved start date at `project.createdAt`, it:

- Resolves the first-export start through a small pure helper (`resolveFirstExportStart`).
- Uses the real ClickHouse `min(timestamp)` across `traces`, `observations`, `scores`, and now `events_core` — the last so events-only projects are not treated as empty.
- Uses that minimum **as-is**: it is never floored at `project.createdAt`, so data backfilled before the project row is still exported. This matches the documented contract — *"Full history starts at the project's earliest data."*
- Defers the first run to `now` only when no rows exist, so the existing empty-window check skips the run without advancing `lastSyncAt` (instead of backfilling from 1970).

### Why no `project.createdAt` floor

Projects legitimately backfill data that predates the project row. Flooring the start at `project.createdAt` silently drops that data from a full-history export and contradicts the documented behavior. `project.createdAt` is the wrong lower bound; the real data minimum is the right one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `worker` — first-export start resolution

## Checklist

- [x] Self-reviewed
- [x] `pnpm --filter worker run test firstExportStart.test.ts` — 6 passed
- [x] `pnpm turbo run lint typecheck --filter=worker` — 5 successful, 5 total

Integration behavior (empty-window skip, `events_core` in the min probe) is exercised by the existing `blobStorageIntegrationProcessing.test.ts` suite in CI; local MinIO/ClickHouse were not running so those were not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes first-run full-history blob exports to begin at the earliest timestamp found across traces, observations, scores, and events instead of falling back to the Unix epoch when no data exists.

- Adds a pure helper for resolving first-export start times.
- Includes `events_core.start_time` in the ClickHouse minimum query.
- Preserves backfilled data predating project creation.
- Adds focused helper tests, but lacks an events-only integration case for the new query behavior.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge, with a non-blocking integration-test gap around events-only first exports.

The changed empty-project flow correctly skips without advancing the cursor, and the events timestamp matches the export predicate; only focused coverage of the newly added events minimum is missing.

**Files Needing Attention:** worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[First blob export] --> B{Export mode}
  B -->|FULL_HISTORY| C[Query minimum across four ClickHouse sources]
  C --> D{Minimum exists}
  D -->|Yes| E[Start at real data minimum]
  D -->|No| F[Start at now]
  F --> G[Empty-window check skips run]
  G --> H[lastSyncAt remains unset]
  B -->|FROM_TODAY or FROM_CUSTOM_DATE| I[Use configured start date]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts:237-241
**Events minimum lacks coverage**

The new `events_core` branch is not covered by an events-only first-export test. The helper tests only receive an already-resolved minimum, while the existing integration scenarios do not establish that an event predating all other data—or a project containing only events—sets the initial export window. A regression in this query could therefore use the no-data fallback and omit historical events without failing CI. Please add an integration case where `events_core.start_time` supplies the minimum.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(blob-export): start full-history exp..."](https://github.com/langfuse/langfuse/commit/f6f21a0cf1ace2c759ce499b5bfb13c08f8b7349) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61621820)</sub>

<!-- /greptile_comment -->