### PR TITLE
feat(preview): link health alerts to the pull requests

### DIFF
--- a/.github/workflows/preview-health-check.yml
+++ b/.github/workflows/preview-health-check.yml
@@ -133,6 +133,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_PREVIEW_ALERTS_WEBHOOK_URL }}
           UNHEALTHY: ${{ steps.probe.outputs.unhealthy }}
           TOTAL: ${{ steps.probe.outputs.total }}
+          REPOSITORY: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -147,7 +148,18 @@ jobs:
           # the fleet. Only the list itself grows, so cap it: a broken ALB would
           # otherwise paste 50 hostnames into the channel.
           count="$(printf '%s' "$UNHEALTHY" | wc -w | tr -d ' ')"
-          shown="$(printf '%s' "$UNHEALTHY" | tr ' ' '\n' | head -10 | paste -sd' ' -)"
+
+          # Link each entry to its pull request, which is where the fix lives —
+          # a broken preview is almost always a failed image build or an unmerged
+          # seeder fix, neither of which you act on from the preview URL. Slack's
+          # <url|label> form keeps the token space-free, so the count and the
+          # truncation below still split this list on whitespace correctly.
+          shown=""
+          for token in $(printf '%s' "$UNHEALTHY" | tr ' ' '\n' | head -10); do
+            number="${token#pr-}"
+            number="${number%%(*}"
+            shown="${shown:+$shown }<https://github.com/${REPOSITORY}/pull/${number}|${token}>"
+          done
           if [ "$count" -gt 10 ]; then
             shown="$shown (+$((count - 10)) more)"
           fi


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17201 app preview](https://pr-17201.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Why

The alert names previews as bare text:

> Preview health: 5 of 34 labeled previews not serving — pr-17189(503) pr-17125(503) pr-17046(503) pr-16715(503) pr-16711(503).

Nothing to click, and the useful destination isn't the preview anyway. Every broken preview investigated so far was one of two things — an image build that failed for the PR's head SHA, or a seeder fix not yet merged into that branch. Both are acted on from the **pull request**, so link there.

## What

Each entry becomes a Slack link to its PR:

```
Preview health: 5 of 34 labeled previews not serving — <https://github.com/langfuse/langfuse/pull/17189|pr-17189(503)> … . Run: …
```

Slack's `<url|label>` form matters beyond looks: it keeps every entry space-free, which the counter and the ten-entry truncation both depend on, since they split that list on whitespace. An earlier version of this message used `pr-17189(HTTP 503)` and consequently reported `4 of 18` as `8 of 18`.

The plain `pr-N(code)` tokens are still what the step summary and the count use; only the Slack text gets rewritten, so the two can't drift.

## Verification

Ran the message builder against today's real alert and against a 12-entry list to exercise truncation:

```
Preview health: 5 of 34 labeled previews not serving — <…/pull/17189|pr-17189(503)> <…/pull/17125|pr-17125(503)> <…/pull/17046|pr-17046(503)> <…/pull/16715|pr-16715(503)> <…/pull/16711|pr-16711(503)>. Run: …
Preview health: 12 of 34 labeled previews not serving — <…10 links…> (+2 more). Run: …
```

Counts stay correct, `+N more` still fires, and the payload is valid JSON in both cases. `bash -n` clean on the step; workflow parses as YAML.

Tests added: 0 — no unit-test seam for a workflow in this repo, and the assertion that matters is the rendered message, which is the output above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates preview-health Slack alerts so each unhealthy-preview token links directly to its pull request.
- Adds the repository identifier to the notification step.
- Preserves the existing space-free token format, count, and ten-entry truncation behavior.
- Rewrites only the displayed Slack entries; the underlying probe output remains unchanged.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or repository-rule issues identified.

The producer guarantees the token format expected by the new loop, and the generated links preserve the alert’s existing counting and truncation contracts.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(preview): link health alerts to the..."](https://github.com/langfuse/langfuse/commit/c7cfb3ec2b107f4e5c5b16b3ef52a976ecfc458a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61649259)</sub>

<!-- /greptile_comment -->