### PR TITLE
fix(observations): make start-time lookup inputs a best-effort performance hint

### DIFF
--- a/fern/apis/server/definition/comments.yml
+++ b/fern/apis/server/definition/comments.yml
@@ -64,7 +64,7 @@ types:
         docs: The id of the user who created the comment. Must be a member of the organization that owns the project, otherwise an error will be thrown.
       objectStartTime:
         type: optional<datetime>
-        docs: The start time of the referenced object (for observations, the observation's start time). Acts as a filter that speeds up reference validation by narrowing the lookup. Matched at minute resolution (the value is floored to the minute), so it must fall in the same minute (UTC) as the object's start time; a value in a different minute causes the reference to be treated as not found. Omit it to validate the reference without a time bound.
+        docs: The start time of the referenced object (for observations, the observation's start time). Optional performance hint - when provided, Langfuse narrows the lookup to validate the reference faster. It only affects speed - an incorrect or omitted value never changes the result.
   CreateCommentResponse:
     properties:
       id:

--- a/fern/apis/server/definition/comments.yml
+++ b/fern/apis/server/definition/comments.yml
@@ -64,7 +64,7 @@ types:
         docs: The id of the user who created the comment. Must be a member of the organization that owns the project, otherwise an error will be thrown.
       objectStartTime:
         type: optional<datetime>
-        docs: The start time of the referenced object (for observations, the observation's start time). When provided, Langfuse validates the reference more efficiently by narrowing the lookup to that time range.
+        docs: The start time of the referenced object (for observations, the observation's start time). Acts as a filter that speeds up reference validation by narrowing the lookup to that time range. Must match the object's start time; a value that does not will cause the reference to be treated as not found. Omit it to validate the reference without a time bound.
   CreateCommentResponse:
     properties:
       id:

--- a/fern/apis/server/definition/comments.yml
+++ b/fern/apis/server/definition/comments.yml
@@ -64,7 +64,7 @@ types:
         docs: The id of the user who created the comment. Must be a member of the organization that owns the project, otherwise an error will be thrown.
       objectStartTime:
         type: optional<datetime>
-        docs: The start time of the referenced object (for observations, the observation's start time). Acts as a filter that speeds up reference validation by narrowing the lookup to that time range. Must match the object's start time; a value that does not will cause the reference to be treated as not found. Omit it to validate the reference without a time bound.
+        docs: The start time of the referenced object (for observations, the observation's start time). Acts as a filter that speeds up reference validation by narrowing the lookup. Matched at minute resolution (the value is floored to the minute), so it must fall in the same minute (UTC) as the object's start time; a value in a different minute causes the reference to be treated as not found. Omit it to validate the reference without a time bound.
   CreateCommentResponse:
     properties:
       id:

--- a/fern/apis/server/definition/legacy/observations-v1.yml
+++ b/fern/apis/server/definition/legacy/observations-v1.yml
@@ -22,7 +22,7 @@ service:
         query-parameters:
           startTime:
             type: optional<datetime>
-            docs: The start time of the observation (ISO 8601 with offset, e.g. 2024-01-01T00:00:00Z). When provided, the lookup is restricted to the observation's start day, which makes the request substantially faster. Omit it to look up the observation without a time bound.
+            docs: The start time of the observation (ISO 8601 with offset, e.g. 2024-01-01T00:00:00Z). Acts as a filter that restricts the lookup to the observation's start day, which makes the request substantially faster. Must match the observation's start time; a value that does not will return not found. Omit it to look up the observation without a time bound.
       response: commons.ObservationsViewSingle
     getMany:
       availability:

--- a/fern/apis/server/definition/legacy/observations-v1.yml
+++ b/fern/apis/server/definition/legacy/observations-v1.yml
@@ -22,7 +22,7 @@ service:
         query-parameters:
           startTime:
             type: optional<datetime>
-            docs: The start time of the observation (ISO 8601 with offset, e.g. 2024-01-01T00:00:00Z). Acts as a filter that restricts the lookup, which makes the request substantially faster. Matched at minute resolution (the value is floored to the minute), so it must fall in the same minute (UTC) as the observation's start time; a value in a different minute returns not found. Omit it to look up the observation without a time bound.
+            docs: The start time of the observation (ISO 8601 with offset, e.g. 2024-01-01T00:00:00Z). Optional performance hint - when provided, Langfuse narrows the lookup to make the request substantially faster. It only affects speed - an incorrect or omitted value never changes the result.
       response: commons.ObservationsViewSingle
     getMany:
       availability:

--- a/fern/apis/server/definition/legacy/observations-v1.yml
+++ b/fern/apis/server/definition/legacy/observations-v1.yml
@@ -22,7 +22,7 @@ service:
         query-parameters:
           startTime:
             type: optional<datetime>
-            docs: The start time of the observation (ISO 8601 with offset, e.g. 2024-01-01T00:00:00Z). Acts as a filter that restricts the lookup to the observation's start day, which makes the request substantially faster. Must match the observation's start time; a value that does not will return not found. Omit it to look up the observation without a time bound.
+            docs: The start time of the observation (ISO 8601 with offset, e.g. 2024-01-01T00:00:00Z). Acts as a filter that restricts the lookup, which makes the request substantially faster. Matched at minute resolution (the value is floored to the minute), so it must fall in the same minute (UTC) as the observation's start time; a value in a different minute returns not found. Omit it to look up the observation without a time bound.
       response: commons.ObservationsViewSingle
     getMany:
       availability:

--- a/packages/shared/src/features/comments/types.ts
+++ b/packages/shared/src/features/comments/types.ts
@@ -27,10 +27,10 @@ export const CreateCommentData = z
     content: z.string().trim().min(1).max(MAX_COMMENT_LENGTH),
     objectId: z.string(),
     objectType: z.enum(COMMENT_OBJECT_TYPES),
-    // Optional start time of the referenced object (e.g. an observation's
-    // start_time). When present it filters the reference-existence lookup to the
-    // minute of this value so ClickHouse can prune partitions/parts. A value
-    // whose minute differs from the object's start_time excludes it.
+    // Optional performance hint: the referenced object's start time (e.g. an
+    // observation's start_time). When present it bounds the reference-existence
+    // lookup to its minute so ClickHouse can prune parts/partitions; on a miss
+    // the lookup retries unbounded, so the hint never changes the result.
     objectStartTime: z.coerce.date().nullish(),
     // Optional inline positioning (parallel arrays)
     dataField: z.enum(COMMENT_DATA_FIELDS).nullish(),

--- a/packages/shared/src/features/comments/types.ts
+++ b/packages/shared/src/features/comments/types.ts
@@ -28,8 +28,9 @@ export const CreateCommentData = z
     objectId: z.string(),
     objectType: z.enum(COMMENT_OBJECT_TYPES),
     // Optional start time of the referenced object (e.g. an observation's
-    // start_time). When present it bounds the reference-existence lookup to a
-    // narrow time range so ClickHouse can prune partitions/parts.
+    // start_time). When present it filters the reference-existence lookup to a
+    // narrow time range so ClickHouse can prune partitions/parts. A value that
+    // does not match the object's start_time excludes it from the lookup.
     objectStartTime: z.coerce.date().nullish(),
     // Optional inline positioning (parallel arrays)
     dataField: z.enum(COMMENT_DATA_FIELDS).nullish(),

--- a/packages/shared/src/features/comments/types.ts
+++ b/packages/shared/src/features/comments/types.ts
@@ -28,9 +28,9 @@ export const CreateCommentData = z
     objectId: z.string(),
     objectType: z.enum(COMMENT_OBJECT_TYPES),
     // Optional start time of the referenced object (e.g. an observation's
-    // start_time). When present it filters the reference-existence lookup to a
-    // narrow time range so ClickHouse can prune partitions/parts. A value that
-    // does not match the object's start_time excludes it from the lookup.
+    // start_time). When present it filters the reference-existence lookup to the
+    // minute of this value so ClickHouse can prune partitions/parts. A value
+    // whose minute differs from the object's start_time excludes it.
     objectStartTime: z.coerce.date().nullish(),
     // Optional inline positioning (parallel arrays)
     dataField: z.enum(COMMENT_DATA_FIELDS).nullish(),

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -1017,10 +1017,17 @@ async function getObservationByIdFromEventsTableInternal({
       ),
     )
     .whereRaw("span_id = {id: String}", { id })
+    // Matched at minute resolution: minute is the finest the events_full primary
+    // key (project_id, toStartOfMinute(start_time), ...) can prune on, and
+    // flooring absorbs sub-minute precision differences in the caller-supplied
+    // start time.
     .when(Boolean(startTime), (b) =>
-      b.whereRaw("toDate(start_time) = toDate({startTime: DateTime64(3)})", {
-        startTime: convertDateToClickhouseDateTime(startTime!),
-      }),
+      b.whereRaw(
+        "toStartOfMinute(start_time) = toStartOfMinute({startTime: DateTime64(3)})",
+        {
+          startTime: convertDateToClickhouseDateTime(startTime!),
+        },
+      ),
     )
     // Lower-bound start_time on an anchor (e.g. the parent trace's timestamp) so
     // the lookup can prune events_full parts/partitions. Subtract the skew

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -500,7 +500,8 @@ const getObservationByIdInternal = async ({
   FROM observations
   WHERE id = {id: String}
   AND project_id = {projectId: String}
-  ${startTime ? `AND toDate(start_time) = toDate({startTime: DateTime64(3)})` : ""}
+  ${/* Matched at minute resolution: minute is the finest the primary key can prune on, and flooring absorbs sub-minute precision differences in the caller-supplied start time. */ ""}
+  ${startTime ? `AND toStartOfMinute(start_time) = toStartOfMinute({startTime: DateTime64(3)})` : ""}
   ${startTimeLowerBound ? `AND start_time >= {startTimeLowerBound: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}` : ""}
   ${type ? `AND type = {type: String}` : ""}
   ${traceId ? `AND trace_id = {traceId: String}` : ""}

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3017,11 +3017,12 @@ paths:
           in: query
           description: >-
             The start time of the observation (ISO 8601 with offset, e.g.
-            2024-01-01T00:00:00Z). Acts as a filter that restricts the lookup to
-            the observation's start day, which makes the request substantially
-            faster. Must match the observation's start time; a value that does
-            not will return not found. Omit it to look up the observation
-            without a time bound.
+            2024-01-01T00:00:00Z). Acts as a filter that restricts the lookup,
+            which makes the request substantially faster. Matched at minute
+            resolution (the value is floored to the minute), so it must fall in
+            the same minute (UTC) as the observation's start time; a value in a
+            different minute returns not found. Omit it to look up the
+            observation without a time bound.
           required: false
           schema:
             type: string
@@ -9213,10 +9214,11 @@ components:
           description: >-
             The start time of the referenced object (for observations, the
             observation's start time). Acts as a filter that speeds up reference
-            validation by narrowing the lookup to that time range. Must match
-            the object's start time; a value that does not will cause the
-            reference to be treated as not found. Omit it to validate the
-            reference without a time bound.
+            validation by narrowing the lookup. Matched at minute resolution
+            (the value is floored to the minute), so it must fall in the same
+            minute (UTC) as the object's start time; a value in a different
+            minute causes the reference to be treated as not found. Omit it to
+            validate the reference without a time bound.
       required:
         - projectId
         - objectType

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3017,12 +3017,10 @@ paths:
           in: query
           description: >-
             The start time of the observation (ISO 8601 with offset, e.g.
-            2024-01-01T00:00:00Z). Acts as a filter that restricts the lookup,
-            which makes the request substantially faster. Matched at minute
-            resolution (the value is floored to the minute), so it must fall in
-            the same minute (UTC) as the observation's start time; a value in a
-            different minute returns not found. Omit it to look up the
-            observation without a time bound.
+            2024-01-01T00:00:00Z). Optional performance hint - when provided,
+            Langfuse narrows the lookup to make the request substantially
+            faster. It only affects speed - an incorrect or omitted value never
+            changes the result.
           required: false
           schema:
             type: string
@@ -9213,12 +9211,10 @@ components:
           nullable: true
           description: >-
             The start time of the referenced object (for observations, the
-            observation's start time). Acts as a filter that speeds up reference
-            validation by narrowing the lookup. Matched at minute resolution
-            (the value is floored to the minute), so it must fall in the same
-            minute (UTC) as the object's start time; a value in a different
-            minute causes the reference to be treated as not found. Omit it to
-            validate the reference without a time bound.
+            observation's start time). Optional performance hint - when
+            provided, Langfuse narrows the lookup to validate the reference
+            faster. It only affects speed - an incorrect or omitted value never
+            changes the result.
       required:
         - projectId
         - objectType

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3017,9 +3017,11 @@ paths:
           in: query
           description: >-
             The start time of the observation (ISO 8601 with offset, e.g.
-            2024-01-01T00:00:00Z). When provided, the lookup is restricted to
+            2024-01-01T00:00:00Z). Acts as a filter that restricts the lookup to
             the observation's start day, which makes the request substantially
-            faster. Omit it to look up the observation without a time bound.
+            faster. Must match the observation's start time; a value that does
+            not will return not found. Omit it to look up the observation
+            without a time bound.
           required: false
           schema:
             type: string
@@ -9210,9 +9212,11 @@ components:
           nullable: true
           description: >-
             The start time of the referenced object (for observations, the
-            observation's start time). When provided, Langfuse validates the
-            reference more efficiently by narrowing the lookup to that time
-            range.
+            observation's start time). Acts as a filter that speeds up reference
+            validation by narrowing the lookup to that time range. Must match
+            the object's start time; a value that does not will cause the
+            reference to be treated as not found. Omit it to validate the
+            reference without a time bound.
       required:
         - projectId
         - objectType

--- a/web/src/__tests__/server/comments-api.servertest.ts
+++ b/web/src/__tests__/server/comments-api.servertest.ts
@@ -100,8 +100,11 @@ describe("Create and get comments", () => {
     });
   });
 
-  it("should create an observation comment when objectStartTime bounds the lookup", async () => {
+  it("should create an observation comment when objectStartTime is in the observation's minute", async () => {
     const startTime = new Date("2024-05-15T12:00:00.000Z");
+    // Same minute, different second: the lookup floors to the minute, so this
+    // still resolves the observation.
+    const sameMinuteStartTime = new Date("2024-05-15T12:00:45.000Z");
     const observationId = randomUUID();
     // Seed both tables so the lookup resolves regardless of the v4 write-mode
     // routing the test environment happens to use.
@@ -134,7 +137,7 @@ describe("Create and get comments", () => {
         objectId: observationId,
         objectType: "OBSERVATION",
         projectId: seedProjectId,
-        objectStartTime: startTime.toISOString(),
+        objectStartTime: sameMinuteStartTime.toISOString(),
         authorUserId: orgMemberUserId,
       },
     );
@@ -157,12 +160,12 @@ describe("Create and get comments", () => {
     });
   });
 
-  it("should fail to create an observation comment when objectStartTime does not match", async () => {
+  it("should fail to create an observation comment when objectStartTime is in a different minute", async () => {
     const actualStartTime = new Date("2024-05-15T12:00:00.000Z");
-    // A day the observation does NOT live on: objectStartTime is a hard filter,
-    // so a value that misses the observation's start_time excludes it and the
-    // reference is treated as not found.
-    const wrongStartTime = new Date("2024-05-20T12:00:00.000Z");
+    // A different minute: objectStartTime is a hard filter at minute resolution,
+    // so a value outside the observation's minute excludes it and the reference
+    // is treated as not found.
+    const wrongStartTime = new Date("2024-05-15T12:02:00.000Z");
     const observationId = randomUUID();
     // Seed both tables so the lookup resolves regardless of the v4 write-mode
     // routing the test environment happens to use.

--- a/web/src/__tests__/server/comments-api.servertest.ts
+++ b/web/src/__tests__/server/comments-api.servertest.ts
@@ -157,12 +157,15 @@ describe("Create and get comments", () => {
     });
   });
 
-  it("should still create an observation comment when objectStartTime is a wrong/stale hint", async () => {
+  it("should fail to create an observation comment when objectStartTime does not match", async () => {
     const actualStartTime = new Date("2024-05-15T12:00:00.000Z");
-    // A day the observation does NOT live on: the bounded lookup misses and
-    // must fall back to an unbounded lookup instead of surfacing a false 404.
+    // A day the observation does NOT live on: objectStartTime is a hard filter,
+    // so a value that misses the observation's start_time excludes it and the
+    // reference is treated as not found.
     const wrongStartTime = new Date("2024-05-20T12:00:00.000Z");
     const observationId = randomUUID();
+    // Seed both tables so the lookup resolves regardless of the v4 write-mode
+    // routing the test environment happens to use.
     await Promise.all([
       createEventsCh([
         createEvent({
@@ -183,36 +186,32 @@ describe("Create and get comments", () => {
       ]),
     ]);
 
-    const commentResponse = await makeZodVerifiedAPICall(
-      PostCommentsV1Response,
-      "POST",
-      "/api/public/comments",
-      {
-        content: "wrong-hint observation comment",
-        objectId: observationId,
-        objectType: "OBSERVATION",
-        projectId: seedProjectId,
-        objectStartTime: wrongStartTime.toISOString(),
-        authorUserId: orgMemberUserId,
-      },
-    );
-
-    const { id: commentId } = commentResponse.body;
-
-    const response = await makeZodVerifiedAPICall(
-      GetCommentV1Response,
-      "GET",
-      `/api/public/comments/${commentId}`,
-    );
-
-    expect(response.status).toBe(200);
-    expect(response.body).toMatchObject({
-      id: commentId,
-      projectId: seedProjectId,
-      objectId: observationId,
-      objectType: "OBSERVATION",
-      content: "wrong-hint observation comment",
-    });
+    expect.assertions(2);
+    try {
+      await makeZodVerifiedAPICall(
+        z.object({
+          message: z.string(),
+          error: z.array(z.object({})),
+        }),
+        "POST",
+        "/api/public/comments",
+        {
+          content: "mismatched start-time observation comment",
+          objectId: observationId,
+          objectType: "OBSERVATION",
+          projectId: seedProjectId,
+          objectStartTime: wrongStartTime.toISOString(),
+          authorUserId: orgMemberUserId,
+        },
+      );
+    } catch (error) {
+      expect((error as Error).message).toContain(
+        `API call did not return 200, returned status 404`,
+      );
+      expect((error as Error).message).toContain(
+        `Observation with id ${observationId} not found`,
+      );
+    }
   });
 
   it("should fail to create comment if reference object does not exist", async () => {

--- a/web/src/__tests__/server/comments-api.servertest.ts
+++ b/web/src/__tests__/server/comments-api.servertest.ts
@@ -160,11 +160,10 @@ describe("Create and get comments", () => {
     });
   });
 
-  it("should fail to create an observation comment when objectStartTime is in a different minute", async () => {
+  it("should still create an observation comment when objectStartTime is a wrong/stale hint", async () => {
     const actualStartTime = new Date("2024-05-15T12:00:00.000Z");
-    // A different minute: objectStartTime is a hard filter at minute resolution,
-    // so a value outside the observation's minute excludes it and the reference
-    // is treated as not found.
+    // A different minute than the observation: the bounded lookup misses, but the
+    // hint falls back to an unbounded lookup, so the comment is still created.
     const wrongStartTime = new Date("2024-05-15T12:02:00.000Z");
     const observationId = randomUUID();
     // Seed both tables so the lookup resolves regardless of the v4 write-mode
@@ -189,32 +188,36 @@ describe("Create and get comments", () => {
       ]),
     ]);
 
-    expect.assertions(2);
-    try {
-      await makeZodVerifiedAPICall(
-        z.object({
-          message: z.string(),
-          error: z.array(z.object({})),
-        }),
-        "POST",
-        "/api/public/comments",
-        {
-          content: "mismatched start-time observation comment",
-          objectId: observationId,
-          objectType: "OBSERVATION",
-          projectId: seedProjectId,
-          objectStartTime: wrongStartTime.toISOString(),
-          authorUserId: orgMemberUserId,
-        },
-      );
-    } catch (error) {
-      expect((error as Error).message).toContain(
-        `API call did not return 200, returned status 404`,
-      );
-      expect((error as Error).message).toContain(
-        `Observation with id ${observationId} not found`,
-      );
-    }
+    const commentResponse = await makeZodVerifiedAPICall(
+      PostCommentsV1Response,
+      "POST",
+      "/api/public/comments",
+      {
+        content: "wrong-hint observation comment",
+        objectId: observationId,
+        objectType: "OBSERVATION",
+        projectId: seedProjectId,
+        objectStartTime: wrongStartTime.toISOString(),
+        authorUserId: orgMemberUserId,
+      },
+    );
+
+    const { id: commentId } = commentResponse.body;
+
+    const response = await makeZodVerifiedAPICall(
+      GetCommentV1Response,
+      "GET",
+      `/api/public/comments/${commentId}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      id: commentId,
+      projectId: seedProjectId,
+      objectId: observationId,
+      objectType: "OBSERVATION",
+      content: "wrong-hint observation comment",
+    });
   });
 
   it("should fail to create comment if reference object does not exist", async () => {

--- a/web/src/__tests__/server/observation-api.servertest.ts
+++ b/web/src/__tests__/server/observation-api.servertest.ts
@@ -170,7 +170,7 @@ describe("/api/public/observations API Endpoint", () => {
           });
         });
 
-        it("should GET an observation when startTime matches its UTC day", async () => {
+        it("should GET an observation when the startTime hint matches", async () => {
           const observationId = uuidv4();
           const traceId = uuidv4();
           const startTime = new Date("2024-03-15T08:30:00.000Z").getTime();
@@ -190,7 +190,7 @@ describe("/api/public/observations API Endpoint", () => {
           const getEventRes = await makeZodVerifiedAPICall(
             GetObservationV1Response,
             "GET",
-            `/api/public/observations/${observationId}?startTime=2024-03-15T23:59:59.000Z&useEventsTable=${useEventsTable}`,
+            `/api/public/observations/${observationId}?startTime=2024-03-15T08:30:00.000Z&useEventsTable=${useEventsTable}`,
           );
 
           expect(getEventRes.body).toMatchObject({
@@ -200,7 +200,7 @@ describe("/api/public/observations API Endpoint", () => {
           });
         });
 
-        it("should 404 when startTime is on a different UTC day", async () => {
+        it("should still GET an observation when the startTime hint is wrong", async () => {
           const observationId = uuidv4();
           const traceId = uuidv4();
           const startTime = new Date("2024-03-15T08:30:00.000Z").getTime();
@@ -217,12 +217,20 @@ describe("/api/public/observations API Endpoint", () => {
 
           await insertObservations(useEventsTable, [observation]);
 
-          const res = await makeAPICall(
+          // A different day than the observation: the bounded lookup misses, but
+          // the hint falls back to an unbounded lookup, so the observation is
+          // still returned.
+          const getEventRes = await makeZodVerifiedAPICall(
+            GetObservationV1Response,
             "GET",
             `/api/public/observations/${observationId}?startTime=2024-03-16T00:00:00.000Z&useEventsTable=${useEventsTable}`,
           );
 
-          expect(res.status).toBe(404);
+          expect(getEventRes.body).toMatchObject({
+            id: observationId,
+            traceId,
+            type: "GENERATION",
+          });
         });
 
         it("should 400 when startTime lacks a timezone offset", async () => {

--- a/web/src/features/comments/validateCommentReferenceObject.ts
+++ b/web/src/features/comments/validateCommentReferenceObject.ts
@@ -22,9 +22,10 @@ export const validateCommentReferenceObject = async ({
       commentTarget = await getObservationById({
         id: objectId,
         projectId,
-        // Filters the events_full lookup to the observation's day so ClickHouse
-        // can prune partitions/parts; absent, the lookup scans without a time
-        // bound. A start_time that does not match the observation excludes it.
+        // Filters the lookup to the minute of objectStartTime so ClickHouse can
+        // prune partitions/parts; absent, the lookup scans without a time bound.
+        // An objectStartTime whose minute differs from the observation's start
+        // time excludes it, so the reference is reported not found.
         startTime: objectStartTime ?? undefined,
       });
       break;

--- a/web/src/features/comments/validateCommentReferenceObject.ts
+++ b/web/src/features/comments/validateCommentReferenceObject.ts
@@ -1,4 +1,8 @@
-import { CommentObjectType, type CreateCommentData } from "@langfuse/shared";
+import {
+  CommentObjectType,
+  type CreateCommentData,
+  LangfuseNotFoundError,
+} from "@langfuse/shared";
 import { type z } from "zod";
 import {
   getObservationById,
@@ -18,16 +22,22 @@ export const validateCommentReferenceObject = async ({
   let commentTarget;
   switch (objectType) {
     case CommentObjectType.OBSERVATION: {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      commentTarget = await getObservationById({
-        id: objectId,
-        projectId,
-        // Filters the lookup to the minute of objectStartTime so ClickHouse can
-        // prune partitions/parts; absent, the lookup scans without a time bound.
-        // An objectStartTime whose minute differs from the observation's start
-        // time excludes it, so the reference is reported not found.
-        startTime: objectStartTime ?? undefined,
-      });
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        commentTarget = await getObservationById({
+          id: objectId,
+          projectId,
+          // objectStartTime is a performance hint: it bounds the lookup to its
+          // minute so ClickHouse can prune parts/partitions. On a miss we retry
+          // unbounded below, so a wrong or stale hint only ever costs speed,
+          // never correctness.
+          startTime: objectStartTime ?? undefined,
+        });
+      } catch (e) {
+        if (!(e instanceof LangfuseNotFoundError) || !objectStartTime) throw e;
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        commentTarget = await getObservationById({ id: objectId, projectId });
+      }
       break;
     }
     case CommentObjectType.TRACE: {

--- a/web/src/features/comments/validateCommentReferenceObject.ts
+++ b/web/src/features/comments/validateCommentReferenceObject.ts
@@ -1,8 +1,4 @@
-import {
-  CommentObjectType,
-  type CreateCommentData,
-  LangfuseNotFoundError,
-} from "@langfuse/shared";
+import { CommentObjectType, type CreateCommentData } from "@langfuse/shared";
 import { type z } from "zod";
 import {
   getObservationById,
@@ -22,25 +18,15 @@ export const validateCommentReferenceObject = async ({
   let commentTarget;
   switch (objectType) {
     case CommentObjectType.OBSERVATION: {
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        commentTarget = await getObservationById({
-          id: objectId,
-          projectId,
-          // Bounds the events_full lookup to the observation's day so ClickHouse
-          // can prune partitions/parts; absent, the lookup falls back to a scan.
-          startTime: objectStartTime ?? undefined,
-        });
-      } catch (e) {
-        // objectStartTime is a client-supplied hint on the public API; a wrong
-        // or stale value bounds the lookup to the wrong day, so getObservationById
-        // throws NotFound for an observation that does exist. Retry once
-        // unbounded so the hint can only ever speed up a hit, never turn into a
-        // false "not found". A genuine miss re-throws from the unbounded lookup.
-        if (!(e instanceof LangfuseNotFoundError) || !objectStartTime) throw e;
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        commentTarget = await getObservationById({ id: objectId, projectId });
-      }
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      commentTarget = await getObservationById({
+        id: objectId,
+        projectId,
+        // Filters the events_full lookup to the observation's day so ClickHouse
+        // can prune partitions/parts; absent, the lookup scans without a time
+        // bound. A start_time that does not match the observation excludes it.
+        startTime: objectStartTime ?? undefined,
+      });
       break;
     }
     case CommentObjectType.TRACE: {

--- a/web/src/pages/api/public/observations/[observationId].ts
+++ b/web/src/pages/api/public/observations/[observationId].ts
@@ -35,21 +35,33 @@ export default withMiddlewares(
           ? new Date(query.startTime)
           : undefined;
 
-        const clickhouseObservation = query.useEventsTable
-          ? await getObservationByIdFromEventsTable({
-              id: query.observationId,
-              projectId: auth.scope.projectId,
-              fetchWithInputOutput: true,
-              startTime,
-            })
-          : // eslint-disable-next-line @typescript-eslint/no-deprecated
-            await getObservationById({
-              id: query.observationId,
-              projectId: auth.scope.projectId,
-              fetchWithInputOutput: true,
-              startTime,
-              preferredClickhouseService: "ReadOnly",
-            });
+        const lookupObservation = (withStartTime: boolean) =>
+          query.useEventsTable
+            ? getObservationByIdFromEventsTable({
+                id: query.observationId,
+                projectId: auth.scope.projectId,
+                fetchWithInputOutput: true,
+                startTime: withStartTime ? startTime : undefined,
+              })
+            : // eslint-disable-next-line @typescript-eslint/no-deprecated
+              getObservationById({
+                id: query.observationId,
+                projectId: auth.scope.projectId,
+                fetchWithInputOutput: true,
+                startTime: withStartTime ? startTime : undefined,
+                preferredClickhouseService: "ReadOnly",
+              });
+
+        // startTime is a performance hint: it bounds the lookup to its minute so
+        // ClickHouse can prune parts/partitions. On a miss we retry unbounded,
+        // so a wrong or stale hint only ever costs speed, never correctness.
+        let clickhouseObservation;
+        try {
+          clickhouseObservation = await lookupObservation(true);
+        } catch (e) {
+          if (!(e instanceof LangfuseNotFoundError) || !startTime) throw e;
+          clickhouseObservation = await lookupObservation(false);
+        }
 
         if (!clickhouseObservation) {
           throw new LangfuseNotFoundError(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17202 app preview](https://pr-17202.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Makes the two public start-time inputs on observation lookups — `objectStartTime` on `POST /comments` and `startTime` on `GET /observations/{id}` — **best-effort performance hints** rather than filters.

Both fed a start-time equality into the by-id ClickHouse lookup. As a filter this was a footgun: a wrong or stale value returned not-found for an object that actually exists. These are the only two public endpoints that thread a start time into a single-object/reference lookup (list-endpoint range filters are unaffected).

Behavior now:
- The shared repository predicate matches at **minute resolution** (`toStartOfMinute`), which is the finest the `events_full` primary key can prune on — this is what makes the lookup fast.
- Both public call sites wrap the lookup with an **unbounded retry on miss**, so a correct value speeds the query up via partition/part pruning, and an incorrect or omitted value falls back and never changes the result.

Docs on both endpoints and the shared zod comment now describe the hint semantics. Internal callers (eval by-id, web-callouts) are unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] `pnpm run lint` / `pnpm run typecheck` — Tasks: 7 successful, 7 total (forced)
- [x] Fern sources updated + `pnpm run openapi:export` regenerated; `openapi:check` exit 0
- [x] Tests updated: wrong-value cases succeed via fallback; matching value exercises the fast path
- [ ] Server tests (comments + observations) not run locally (no ClickHouse container / `.env.test` in this environment) — they run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)