### PR TITLE
docs(web): fix treeNodeToFlatRow's stale @param index doc

### DIFF
--- a/web/src/features/traces/components/AdvancedJsonViewer/utils/treeNavigation.ts
+++ b/web/src/features/traces/components/AdvancedJsonViewer/utils/treeNavigation.ts
@@ -119,7 +119,7 @@ export function getVisibleRowCount(rootNode: TreeNode): number {
  * Eventually we can update components to work directly with TreeNode.
  *
  * @param node - TreeNode to convert
- * @param index - Index in visible rows (for rowIndex)
+ * @param _index - Unused; kept for compatibility with row-mapping callers.
  * @returns FlatJSONRow
  */
 export function treeNodeToFlatRow(node: TreeNode, _index: number): FlatJSONRow {


### PR DESCRIPTION
`treeNodeToFlatRow(node, _index)`'s JSDoc documents `@param index - Index in visible rows (for rowIndex)` — the parameter is the unused `_index`, and `FlatJSONRow` has no `rowIndex` field (`rowIndex` exists only on `SearchMatch`). The doc now describes the parameter as it is. Docs-only.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61682258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because it only corrects an accurate JSDoc description.

<details><summary><h3>Summary</h3></summary>

- Corrects stale JSDoc for `treeNodeToFlatRow` by documenting `_index` as an unused compatibility parameter. The change affects documentation only and introduces no runtime behavior changes.
</details>

<!-- /greptile_comment -->