### PR TITLE
docs(shared): fix DatabaseReadStream's stale constructor JSDoc

### DIFF
--- a/packages/shared/src/server/utils/DatabaseReadStream.ts
+++ b/packages/shared/src/server/utils/DatabaseReadStream.ts
@@ -10,9 +10,9 @@ import { Readable } from "stream";
  * rather than true database streaming. It fetches data in paginated batches determined by the pageSize.
  * GitHub issue: https://github.com/prisma/prisma/issues/5055
  *
- * @param prisma - The PrismaClient instance for database queries.
- * @param rawSqlQuery - A Prisma.Sql object representing the base SQL query, excluding OFFSET and LIMIT.
+ * @param queryDelegate - Executes one page of the query, excluding OFFSET and LIMIT.
  * @param pageSize - Number of records per batch, defining the chunk size.
+ * @param maxRecords - Maximum number of records to stream before closing.
  *
  * The class extends Node.js's Readable stream, using async iteration and Prisma's pagination for scalable
  * data processing. It's suitable for applications requiring large dataset processing with a low memory footprint.


### PR DESCRIPTION
`DatabaseReadStream`'s JSDoc documents `@param prisma` and `@param rawSqlQuery` — the constructor takes `queryDelegate`, `pageSize`, and `maxRecords` (all call sites pass a delegate function). The @param lines now match the signature. Docs-only.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61682569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The documentation-only change is non-blocking, but the query delegate description should be corrected to explain its pagination arguments accurately.

<details><summary><h3>Summary</h3></summary>

- Replaces the obsolete `prisma` and `rawSqlQuery` entries with `queryDelegate` and `maxRecords`.
- The new `queryDelegate` description remains inconsistent with the callback’s pagination contract.
</details>

<!-- /greptile_comment -->