### PR TITLE
docs(fern): update scores get-many description to match its filters

### DIFF
--- a/fern/apis/server/definition/scores.yml
+++ b/fern/apis/server/definition/scores.yml
@@ -16,7 +16,7 @@ service:
       availability:
         status: deprecated
         message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. Use `GET /api/public/v3/scores` instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
-      docs: Get a list of scores (supports both trace and session scores)
+      docs: Get a list of scores (supports trace, observation, session, and dataset run scores)
       method: GET
       path: /v2/scores
       request:


### PR DESCRIPTION
`scores.get-many`'s description said "supports both trace and session scores" — but the endpoint exposes `observationId` and `datasetRunId` filters, and `scores.create`'s description already lists all four contexts. The phrase is updated to match. User-visible via the generated API docs.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61696712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation-only change appears safe to merge.

<details><summary><h3>Summary</h3></summary>

- Adds observation and dataset-run scores alongside trace and session scores.
- Aligns the wording with the create-score endpoint and implemented filters.
</details>

<!-- /greptile_comment -->