### PR TITLE
refactor(web): thin project settings page into ProjectSettingsPage

### DIFF
--- a/web/src/features/command-k-menu/CommandMenu.tsx
+++ b/web/src/features/command-k-menu/CommandMenu.tsx
@@ -15,7 +15,7 @@ import { env } from "@/src/env.mjs";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics";
 import { useDebounce } from "@/src/hooks/useDebounce";
 import { useCommandMenu } from "@/src/features/command-k-menu/CommandMenuProvider";
-import { useProjectSettingsPages } from "@/src/pages/project/[projectId]/settings";
+import { useProjectSettingsPages } from "@/src/features/projects/ProjectSettingsPage";
 import { useOrganizationSettingsPages } from "@/src/pages/organization/[organizationId]/settings";
 import { useAccountSettingsPages } from "@/src/pages/account/settings";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";

--- a/web/src/features/command-k-menu/CommandMenu.tsx
+++ b/web/src/features/command-k-menu/CommandMenu.tsx
@@ -15,7 +15,7 @@ import { env } from "@/src/env.mjs";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics";
 import { useDebounce } from "@/src/hooks/useDebounce";
 import { useCommandMenu } from "@/src/features/command-k-menu/CommandMenuProvider";
-import { useProjectSettingsPages } from "@/src/features/projects/ProjectSettingsPage";
+import { useProjectSettingsPages } from "@/src/features/projects";
 import { useOrganizationSettingsPages } from "@/src/pages/organization/[organizationId]/settings";
 import { useAccountSettingsPages } from "@/src/pages/account/settings";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";

--- a/web/src/features/projects/ProjectSettingsPage.tsx
+++ b/web/src/features/projects/ProjectSettingsPage.tsx
@@ -78,7 +78,7 @@ export function useProjectSettingsPages(): ProjectSettingsPageEntry[] {
   });
 }
 
-export const getProjectSettingsPages = ({
+const getProjectSettingsPages = ({
   project,
   organization,
   showBillingSettings,
@@ -325,7 +325,15 @@ export default function ProjectSettingsPage() {
   const pages = useProjectSettingsPages();
 
   if (!project || !organization) {
-    return <NoDataOrLoading isLoading />;
+    return (
+      <ContainerPage
+        headerProps={{
+          title: "Project Settings",
+        }}
+      >
+        <NoDataOrLoading isLoading />
+      </ContainerPage>
+    );
   }
 
   return (

--- a/web/src/features/projects/ProjectSettingsPage.tsx
+++ b/web/src/features/projects/ProjectSettingsPage.tsx
@@ -26,6 +26,7 @@ import { AuditLogsSettingsPage } from "@/src/ee/features/audit-log-viewer/AuditL
 import { ModelsSettings } from "@/src/features/models/components/ModelSettings";
 import ConfigureRetention from "@/src/features/projects/components/ConfigureRetention";
 import ContainerPage from "@/src/components/layouts/container-page";
+import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import ProtectedLabelsSettings from "@/src/features/prompts/components/ProtectedLabelsSettings";
 import { SiSlack } from "react-icons/si";
 import { ScoreConfigSettings } from "@/src/features/score-configs/components/ScoreConfigSettings";
@@ -323,7 +324,9 @@ export default function SettingsPage() {
   const router = useRouter();
   const pages = useProjectSettingsPages();
 
-  if (!project || !organization) return null;
+  if (!project || !organization) {
+    return <NoDataOrLoading isLoading />;
+  }
 
   return (
     <ContainerPage

--- a/web/src/features/projects/ProjectSettingsPage.tsx
+++ b/web/src/features/projects/ProjectSettingsPage.tsx
@@ -37,14 +37,14 @@ import { WebCalloutIntegrationCard } from "@/src/features/web-callouts/component
 import { DeveloperToolsSettings } from "@/src/features/developer-tools/components/DeveloperToolsSettings";
 import { useV4UpgradeUiFlag } from "@/src/features/v4-migration/useV4UpgradeUiEnabled";
 
-type ProjectSettingsPage = {
+type ProjectSettingsPageEntry = {
   title: string;
   slug: string;
   show?: boolean | (() => boolean);
   cmdKKeywords?: string[];
 } & ({ content: React.ReactNode } | { href: string });
 
-export function useProjectSettingsPages(): ProjectSettingsPage[] {
+export function useProjectSettingsPages(): ProjectSettingsPageEntry[] {
   const router = useRouter();
   const { project, organization } = useQueryProject();
   const showBillingSettings = useHasEntitlement("cloud-billing");
@@ -98,7 +98,7 @@ export const getProjectSettingsPages = ({
   showProjectNotificationChannels: boolean;
   showScoreConfigSettings: boolean;
   showV4Migration: boolean;
-}): ProjectSettingsPage[] => [
+}): ProjectSettingsPageEntry[] => [
   {
     title: "General",
     slug: "index",
@@ -319,7 +319,7 @@ export const getProjectSettingsPages = ({
   },
 ];
 
-export default function SettingsPage() {
+export default function ProjectSettingsPage() {
   const { project, organization } = useQueryProject();
   const router = useRouter();
   const pages = useProjectSettingsPages();

--- a/web/src/features/projects/index.ts
+++ b/web/src/features/projects/index.ts
@@ -1,1 +1,2 @@
 export { useProject } from "@/src/features/projects/hooks";
+export { useProjectSettingsPages } from "@/src/features/projects/ProjectSettingsPage";

--- a/web/src/pages/project/[projectId]/settings/[page].tsx
+++ b/web/src/pages/project/[projectId]/settings/[page].tsx
@@ -1,3 +1,1 @@
-import SettingsPage from "@/src/features/projects/ProjectSettingsPage";
-
-export default SettingsPage;
+export { default } from "@/src/features/projects/ProjectSettingsPage";

--- a/web/src/pages/project/[projectId]/settings/[page].tsx
+++ b/web/src/pages/project/[projectId]/settings/[page].tsx
@@ -1,3 +1,3 @@
-import SettingsPage from "@/src/pages/project/[projectId]/settings";
+import SettingsPage from "@/src/features/projects/ProjectSettingsPage";
 
 export default SettingsPage;

--- a/web/src/pages/project/[projectId]/settings/index.tsx
+++ b/web/src/pages/project/[projectId]/settings/index.tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  useProjectSettingsPages,
+} from "@/src/features/projects/ProjectSettingsPage";


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17215 app preview](https://pr-17215.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Thin `src/pages/project/[projectId]/settings/index.tsx` into `src/features/projects/ProjectSettingsPage.tsx` and leave a small Next.js route shim. Same mechanical pattern as the dashboard detail page thin.

- `pnpm structure:move` preserves history
- Route files re-export the feature Page
- `useProjectSettingsPages` is re-exported from the projects feature surface for Command Menu
- Pages-only `return null` gate becomes `NoDataOrLoading` inside `ContainerPage` so `@repo/no-null-render` stays happy under `features/`
- `getProjectSettingsPages` is file-local (knip: unused once moved out of `pages/`)

No intentional settings behavior change.

## Type of change

- [x] Refactor (restructures existing code without changing behavior)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Self-reviewed
- Husky lint + Prettier on commit
- `pnpm --filter web run structure:stats`: rule 12 **596 → 562** (−34); thin pages **43 → 44** of 97
- Claude review: fixed knip unused export + ContainerPage loading wrap; skipped distinguishing permanent missing-project from loading (optional; needs `useQueryProject` API changes)

## Test plan

1. Open Project Settings (`/project/<id>/settings`) — general tab renders
2. Navigate a couple of sub-pages via the settings nav / `/settings/[page]`
3. Cmd-K → project settings entries still appear (uses `useProjectSettingsPages`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08066-8784-7bc3-beaa-d9970a3f2507?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08066-8784-7bc3-beaa-d9970a3f2507&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61981686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The refactor appears functionally safe to merge, with a non-blocking structural concern around newly introduced cross-feature internal imports.

<details><summary><h3>Summary</h3></summary>

- Preserves the existing settings-page definitions and navigation behavior.
- Replaces the prior null render during unresolved project data with a loading placeholder.
- Introduces direct sibling-feature internal imports from the newly relocated feature module.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  IndexRoute["settings/index.tsx"] --> Page["features/projects/ProjectSettingsPage"]
  DynamicRoute["settings/[page].tsx"] --> Page
  CommandMenu["CommandMenu"] --> Barrel["features/projects/index.ts"]
  Barrel --> Hook["useProjectSettingsPages"]
  Hook --> Page
```
</details>

<!-- /greptile_comment -->