### PR TITLE
fix(web): drop Kitesurf agent-browser noise from Sentry

### DIFF
--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 import {
   isDenylistedNoiseEvent,
+  isKitesurfInternalEvent,
   isNoisyHttpClientPollEvent,
   isPosthogRecorderInternalEvent,
   isReactDevtoolsInternalEvent,
@@ -54,6 +55,14 @@ Sentry.init({
     // frame is ever present in these stacks; anything touching our code is
     // kept. See isPosthogRecorderInternalEvent for the rationale.
     if (isPosthogRecorderInternalEvent(event)) {
+      return null;
+    }
+
+    // Drop Kitesurf (Cursor / Cloudflare agent-browser) internals: `[kitesurf]`
+    // console wraps with no app chunk, and stacks wholly in `__ks_*` /
+    // `dom-shim.js`. Same-origin injectors miss `denyUrls`. See
+    // isKitesurfInternalEvent.
+    if (isKitesurfInternalEvent(event)) {
       return null;
     }
 

--- a/web/src/utils/sentryFilters.clienttest.ts
+++ b/web/src/utils/sentryFilters.clienttest.ts
@@ -2,6 +2,7 @@ import { type ErrorEvent } from "@sentry/nextjs";
 
 import {
   isDenylistedNoiseEvent,
+  isKitesurfInternalEvent,
   isNoisyHttpClientPollEvent,
   isPosthogRecorderInternalEvent,
   isReactDevtoolsInternalEvent,
@@ -335,6 +336,26 @@ describe("isDenylistedNoiseEvent", () => {
           messageEvent("[PostHog.js] was already loaded elsewhere."),
         ),
       ).toBe(true);
+    });
+
+    it("drops a kitesurf: localhost CORS console error (message event)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          messageEvent(
+            "kitesurf: Access to fetch at 'http://127.0.0.1:8765/' from origin 'https://example.com' has been blocked by CORS policy: Response to preflight request doesn't pass access control check (preflight response status 403 is not ok)",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("does not treat [kitesurf] wraps as denylist prefixes (dedicated predicate)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          messageEvent(
+            "[kitesurf] event listener for load threw: TypeError: Cannot create proxy with a non-object as target or handler",
+          ),
+        ),
+      ).toBe(false);
     });
 
     it("drops the @sentry/nextjs '_error.js called with falsy error (…)' artifact", () => {
@@ -710,6 +731,24 @@ describe("isDenylistedNoiseEvent", () => {
       expect(
         isDenylistedNoiseEvent(
           exceptionEvent("Failed to fetch traces (batch 3 of 5)"),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps a CORS console error that is not namespaced by kitesurf", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          messageEvent(
+            "Access to fetch at 'https://example.com/api' from origin 'https://example.com' has been blocked by CORS policy",
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps an app error that merely mentions kitesurf mid-message", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          messageEvent("Failed to load kitesurf: connection timed out"),
         ),
       ).toBe(false);
     });
@@ -1551,6 +1590,206 @@ describe("isPosthogRecorderInternalEvent", () => {
         isPosthogRecorderInternalEvent(exceptionEvent("boom", "TypeError")),
       ).toBe(false);
       expect(isPosthogRecorderInternalEvent(messageEvent("boom"))).toBe(false);
+    });
+  });
+});
+
+describe("isKitesurfInternalEvent", () => {
+  const PROXY_TYPEERROR =
+    "Cannot create proxy with a non-object as target or handler";
+  const KS_USER = "/__ks_user_classic_regular.js";
+  const KS_SHIM = "dom-shim.js";
+  const KS_PAGE = "page.js";
+
+  describe("drops Kitesurf recorder / agent-browser internals", () => {
+    it("drops the [kitesurf] console.error message event (LANGFUSE-60W)", () => {
+      expect(
+        isKitesurfInternalEvent(
+          messageEvent(
+            `[kitesurf] event listener for load threw: TypeError: ${PROXY_TYPEERROR}`,
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops the same [kitesurf] text on event.logentry.message", () => {
+      expect(
+        isKitesurfInternalEvent(
+          logentryEvent("[kitesurf] event listener for click threw: boom"),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops ReferenceError: DOMRect is not defined from the user script (LANGFUSE-60Z)", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "ReferenceError",
+              value: "DOMRect is not defined",
+              mechanism: {
+                type: "auto.core.capture_console",
+                handled: true,
+              },
+              stacktrace: {
+                frames: [
+                  frame(KS_USER, "h"),
+                  frame(KS_USER, "o1"),
+                  frame(KS_USER, "sl"),
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isKitesurfInternalEvent(event)).toBe(true);
+    });
+
+    it("drops the proxy TypeError spanning page.js / dom-shim.js / user script (LANGFUSE-60X)", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "TypeError",
+              value: PROXY_TYPEERROR,
+              mechanism: {
+                type: "auto.browser.global_handlers.onerror",
+                handled: false,
+              },
+              stacktrace: {
+                frames: [
+                  frame(KS_PAGE, "fireIframeLoad"),
+                  frame(KS_SHIM, "invokeListeners"),
+                  frame(KS_USER, "e.recordDOM.c.win"),
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isKitesurfInternalEvent(event)).toBe(true);
+    });
+
+    it("drops the same TypeError when the injector has an origin + query", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "TypeError",
+              value: PROXY_TYPEERROR,
+              mechanism: {
+                type: "auto.browser.global_handlers.onerror",
+                handled: false,
+              },
+              stacktrace: {
+                frames: [
+                  frame(
+                    "https://us.cloud.langfuse.com/__ks_user_classic_regular.js?v=1",
+                    "e.recordDOM.c.win",
+                  ),
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isKitesurfInternalEvent(event)).toBe(true);
+    });
+  });
+
+  describe("KEEPS real errors (never masks a genuine app error)", () => {
+    it("keeps a [kitesurf] wrap that quotes a first-party /_next/ frame", () => {
+      expect(
+        isKitesurfInternalEvent(
+          messageEvent(
+            `[kitesurf] event listener for click threw: TypeError: Cannot read properties of undefined (reading 'map')\n    at handleSubmit (https://us.cloud.langfuse.com/_next/static/chunks/app.js:1:1)`,
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps the same TypeError when a first-party /_next/ frame is present", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "TypeError",
+              value: PROXY_TYPEERROR,
+              mechanism: {
+                type: "auto.browser.global_handlers.onerror",
+                handled: false,
+              },
+              stacktrace: {
+                frames: [
+                  frame(KS_USER, "e.recordDOM.c.win"),
+                  frame(
+                    "app:///_next/static/chunks/0r47ep231kqhy.js",
+                    "createStore",
+                  ),
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isKitesurfInternalEvent(event)).toBe(false);
+    });
+
+    it("keeps a first-party Proxy TypeError with no __ks_ frames", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "TypeError",
+              value: PROXY_TYPEERROR,
+              mechanism: {
+                type: "auto.browser.global_handlers.onerror",
+                handled: false,
+              },
+              stacktrace: {
+                frames: [
+                  frame(
+                    "https://us.cloud.langfuse.com/_next/static/chunks/app.js",
+                    "createStore",
+                  ),
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isKitesurfInternalEvent(event)).toBe(false);
+    });
+
+    it("keeps an all-page.js stack (too generic without a vendor script)", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "TypeError",
+              value: PROXY_TYPEERROR,
+              stacktrace: {
+                frames: [frame(KS_PAGE, "fireIframeLoad")],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isKitesurfInternalEvent(event)).toBe(false);
+    });
+
+    it("keeps a message that quotes Proxy wording without the [kitesurf] prefix", () => {
+      expect(
+        isKitesurfInternalEvent(
+          messageEvent(`Proxy setup failed: ${PROXY_TYPEERROR}`),
+        ),
+      ).toBe(false);
+    });
+
+    it("does not let the generic denylist swallow this TypeError on its own", () => {
+      expect(
+        isDenylistedNoiseEvent(exceptionEvent(PROXY_TYPEERROR, "TypeError")),
+      ).toBe(false);
     });
   });
 });

--- a/web/src/utils/sentryFilters.ts
+++ b/web/src/utils/sentryFilters.ts
@@ -136,6 +136,10 @@ const NOISE_MESSAGE_PREFIXES: readonly string[] = [
   "[next-auth][error][CLIENT_FETCH_ERROR]",
   // PostHog analytics SDK notices / client-side rate-limit logs. Third-party.
   "[PostHog.js]",
+  // Cloudflare / Cursor Kitesurf console-errors its own localhost CORS probe
+  // with this unbracketed prefix (LANGFUSE-610). Distinct from bracketed
+  // `[kitesurf]` listener wraps — those go through {@link isKitesurfInternalEvent}.
+  "kitesurf:",
   // `Response.json()` on a non-JSON body (a 5xx / HTML proxy page returned where
   // JSON was expected). This is the response not being ours-as-JSON, i.e. a
   // transport/infra artifact, not app logic.
@@ -613,4 +617,70 @@ export function isPosthogRecorderInternalEvent(event: ErrorEvent): boolean {
     return false;
   }
   return sawRecorderFrame;
+}
+
+/**
+ * Kitesurf's injected page-world scripts. Served as root-relative paths on our
+ * origin (`/__ks_user_classic_regular.js`), so `denyUrls` never matches them.
+ */
+const KITESURF_USER_SCRIPT_RE = /(?:^|\/)__ks_user[^/]*\.js$/i;
+const KITESURF_DOM_SHIM_RE = /(?:^|\/)dom-shim\.js$/i;
+
+/**
+ * Bare `page.js` as Sentry reports Kitesurf's page controller. Must NOT match
+ * a Next.js `/_next/.../page.js` — basename-only matching is intentional.
+ */
+function isKitesurfPageControllerFilename(path: string): boolean {
+  return path === "page.js" || path === "/page.js";
+}
+
+function isKitesurfVendorFilename(path: string): boolean {
+  return KITESURF_USER_SCRIPT_RE.test(path) || KITESURF_DOM_SHIM_RE.test(path);
+}
+
+/**
+ * True for Kitesurf (Cursor / Cloudflare agent-browser) internals that mint
+ * production Sentry noise without involving Langfuse app code:
+ *
+ *  1. Console: `[kitesurf] …` via `captureConsoleIntegration` (LANGFUSE-60W).
+ *     Dropped only when the text has no `/_next/` chunk — a wrap of a real
+ *     app listener throw usually quotes our chunk and is KEPT.
+ *  2. Stack: every attributable frame in `__ks_user_*.js` / `dom-shim.js`
+ *     (plus opaque / bare `page.js` controller frames). Covers
+ *     `ReferenceError: DOMRect is not defined` (LANGFUSE-60Z) and the
+ *     iframe-load `Proxy` TypeError (LANGFUSE-60X).
+ *
+ * Unbracketed `kitesurf:` CORS probes are handled by
+ * {@link NOISE_MESSAGE_PREFIXES} (LANGFUSE-610).
+ *
+ * Same posture as {@link isPosthogRecorderInternalEvent}.
+ */
+export function isKitesurfInternalEvent(event: ErrorEvent): boolean {
+  const text = eventText(event);
+  if (text.length > 0) {
+    const core = coreMessage(text);
+    if (core.startsWith("[kitesurf]") && !text.includes("/_next/")) {
+      return true;
+    }
+  }
+
+  const frames = event.exception?.values?.[0]?.stacktrace?.frames;
+  if (!frames || frames.length === 0) return false;
+
+  let sawKitesurfVendorFrame = false;
+  for (const stackFrame of frames) {
+    const filename = stackFrame?.filename;
+    if (typeof filename !== "string" || filename.length === 0) continue;
+    const path = filename.split(/[?#]/)[0];
+    if (isKitesurfVendorFilename(path)) {
+      sawKitesurfVendorFrame = true;
+      continue;
+    }
+    if (isOpaqueOrSdkFrame(filename)) continue;
+    // Bare `page.js` is Kitesurf's controller only when a vendor script is
+    // also on the stack. An all-`page.js` stack is kept.
+    if (isKitesurfPageControllerFilename(path)) continue;
+    return false;
+  }
+  return sawKitesurfVendorFrame;
 }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17216 app preview](https://pr-17216.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Consolidates four overlapping Cursor/Cloudflare Kitesurf Sentry-noise PRs into one filter:

- `kitesurf:` CORS / localhost probe console noise (LANGFUSE-610)
- `[kitesurf] …` console wraps with **no** `/_next/` chunk in the text (LANGFUSE-60W) — wraps that quote an app chunk stay
- Exception stacks wholly in `__ks_user_*.js` / `dom-shim.js` (+ opaque / bare `page.js` controller frames) (LANGFUSE-60Z, LANGFUSE-60X)

Same-origin `/__ks_*` injectors miss `denyUrls`. Same posture as the PostHog recorder stack filter.

**Supersedes (closing):** #17111, #17112, #17113, #17114

Impacted packages: `web`

Verification:
- `pnpm --filter web run test-client src/utils/sentryFilters.clienttest.ts` — Tests 114 passed (114)
- `pnpm exec turbo run lint` — Tasks: 7 successful, 7 total; Cached: 0 cached, 7 total

Skipped typecheck (filter-only). Skipped knip (export is used from `instrumentation-client.ts`). Skipped browser review (filter-only, no UI).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have commented the predicate rationale and added keep/drop client tests for each production shape

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a082b1-15b6-785e-b7c2-3bbca26b3eb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a082b1-15b6-785e-b7c2-3bbca26b3eb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61982992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no concrete correctness, security, or repository-rule violations identified.

<details><summary><h3>Summary</h3></summary>

- Drops unbracketed `kitesurf:` probe messages through the existing denylist.
- Drops bracketed Kitesurf console wrappers unless they quote a Next.js application chunk.
- Drops stacks attributable entirely to Kitesurf user scripts, its DOM shim, and associated controller frames.
- Adds keep/drop coverage for the observed event shapes and wires the predicate into `beforeSend`.
</details>

<!-- /greptile_comment -->