### PR TITLE
refactor(web): Fix no-null-render: ModelBadge.tsx

### DIFF
--- a/web/src/features/traces/components/ObservationDetailView/components/ModelBadge.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ModelBadge.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @repo/no-null-render */
 /**
  * Model badge for ObservationDetailView
  * Handles linked models (with external link) and unlinked models (with create form)
@@ -15,13 +14,11 @@ export function ModelBadge({
   projectId,
   usageDetails,
 }: {
-  model: string | null;
+  model: string;
   internalModelId: string | null;
   projectId: string;
   usageDetails: Record<string, number> | undefined;
 }) {
-  if (!model) return null;
-
   // Linked model - show link to model settings
   if (internalModelId) {
     return (

--- a/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx
@@ -775,12 +775,14 @@ export const ObservationDetailViewHeader = memo(
                     />
                   )}
               <VersionBadge version={observation.version} />
-              <ModelBadge
-                model={observation.model}
-                internalModelId={observation.internalModelId}
-                projectId={projectId}
-                usageDetails={observation.usageDetails}
-              />
+              {observation.model && (
+                <ModelBadge
+                  model={observation.model}
+                  internalModelId={observation.internalModelId}
+                  projectId={projectId}
+                  usageDetails={observation.usageDetails}
+                />
+              )}
               <ModelParametersBadges
                 modelParameters={observation.modelParameters}
               />


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17218 app preview](https://pr-17218.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61996543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because the moved guard preserves behavior and every known caller satisfies the narrowed prop contract.

<details><summary><h3>Summary</h3></summary>

- Conditionally renders `ModelBadge` when an observation has a model.
- Removes the obsolete null-render lint suppression and internal null guard.
- Preserves existing rendering behavior without affecting known callers.
</details>

<!-- /greptile_comment -->