### PR TITLE
refactor(web): Fix no-null-render: TestResultActions.tsx

### DIFF
--- a/web/src/features/evals/v2/components/EvaluatorTestPanel/components/TestSection/components/TestResultActions/TestResultActions.tsx
+++ b/web/src/features/evals/v2/components/EvaluatorTestPanel/components/TestSection/components/TestResultActions/TestResultActions.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @repo/no-null-render */
 import { DropdownMenuTrigger } from "@/src/components/ui/dropdown-menu";
 import {
   TestResultTraceActions,
@@ -9,10 +8,10 @@ export function TestResultActions({
   executionTraceId,
   onOpenExecutionTrace,
 }: {
-  executionTraceId: string | null;
+  executionTraceId: string;
   onOpenExecutionTrace: (traceId: string) => void;
 }) {
-  return executionTraceId ? (
+  return (
     <TestResultTraceActions
       executionTraceId={executionTraceId}
       onOpenExecutionTrace={onOpenExecutionTrace}
@@ -21,5 +20,5 @@ export function TestResultActions({
         <TestResultTraceActionsTrigger />
       </DropdownMenuTrigger>
     </TestResultTraceActions>
-  ) : null;
+  );
 }

--- a/web/src/features/evals/v2/components/EvaluatorTestPanel/components/TestSection/components/TestSectionContainer/TestSectionContainer.tsx
+++ b/web/src/features/evals/v2/components/EvaluatorTestPanel/components/TestSection/components/TestSectionContainer/TestSectionContainer.tsx
@@ -64,10 +64,12 @@ export function TestSectionContainer({
             rawOpen={rawResultOpen}
             onRawOpenChange={onRawResultOpenChange}
             traceActions={
-              <TestResultActions
-                executionTraceId={executionTraceId}
-                onOpenExecutionTrace={onOpenExecutionTrace}
-              />
+              executionTraceId ? (
+                <TestResultActions
+                  executionTraceId={executionTraceId}
+                  onOpenExecutionTrace={onOpenExecutionTrace}
+                />
+              ) : undefined
             }
             rerunAction={
               <TestRerunAction


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17219 app preview](https://pr-17219.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61996678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because the relocated guard preserves existing behavior and all affected callers remain type-consistent.

<details><summary><h3>Summary</h3></summary>

- Makes `TestResultActions.executionTraceId` non-nullable.
- Supplies trace actions only when an execution trace ID exists.
- Preserves the existing rendered behavior for missing trace IDs.
</details>

<!-- /greptile_comment -->