### PR TITLE
refactor(web): Fix no-null-render: EvaluatorBadge.tsx

### DIFF
--- a/web/src/features/evals/v2/components/EvaluatorTestPanel/components/TestSection/components/TestResultActions/TestResultActions.tsx
+++ b/web/src/features/evals/v2/components/EvaluatorTestPanel/components/TestSection/components/TestResultActions/TestResultActions.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @repo/no-null-render */
 import { DropdownMenuTrigger } from "@/src/components/ui/dropdown-menu";
 import {
   TestResultTraceActions,
@@ -9,10 +8,10 @@ export function TestResultActions({
   executionTraceId,
   onOpenExecutionTrace,
 }: {
-  executionTraceId: string | null;
+  executionTraceId: string;
   onOpenExecutionTrace: (traceId: string) => void;
 }) {
-  return executionTraceId ? (
+  return (
     <TestResultTraceActions
       executionTraceId={executionTraceId}
       onOpenExecutionTrace={onOpenExecutionTrace}
@@ -21,5 +20,5 @@ export function TestResultActions({
         <TestResultTraceActionsTrigger />
       </DropdownMenuTrigger>
     </TestResultTraceActions>
-  ) : null;
+  );
 }

--- a/web/src/features/evals/v2/components/EvaluatorTestPanel/components/TestSection/components/TestSectionContainer/TestSectionContainer.tsx
+++ b/web/src/features/evals/v2/components/EvaluatorTestPanel/components/TestSection/components/TestSectionContainer/TestSectionContainer.tsx
@@ -64,10 +64,12 @@ export function TestSectionContainer({
             rawOpen={rawResultOpen}
             onRawOpenChange={onRawResultOpenChange}
             traceActions={
-              <TestResultActions
-                executionTraceId={executionTraceId}
-                onOpenExecutionTrace={onOpenExecutionTrace}
-              />
+              executionTraceId ? (
+                <TestResultActions
+                  executionTraceId={executionTraceId}
+                  onOpenExecutionTrace={onOpenExecutionTrace}
+                />
+              ) : undefined
             }
             rerunAction={
               <TestRerunAction

--- a/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/ObservationDetailViewHeader.tsx
@@ -739,12 +739,18 @@ export const ObservationDetailViewHeader = memo(
                 userId={observation.userId ?? null}
                 projectId={projectId}
               />
-              <EvaluatorBadge
-                evaluatorId={evaluatorId}
-                evaluatorName={evaluator.data?.name}
-                environment={observation.environment}
-                projectId={projectId}
-              />
+              {evaluatorId &&
+                (observation.environment ===
+                  LangfuseInternalTraceEnvironment.LLMJudge ||
+                  observation.environment ===
+                    LangfuseInternalTraceEnvironment.CodeEval) &&
+                !evaluatorId.startsWith("managed:") && (
+                  <EvaluatorBadge
+                    evaluatorId={evaluatorId}
+                    evaluatorName={evaluator.data?.name}
+                    projectId={projectId}
+                  />
+                )}
               <EnvironmentBadge environment={observation.environment} />
               <ReleaseBadge release={observation.release} />
               {displayedTotalCost != null && displayedCostDetails && (

--- a/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/components/EvaluatorBadge/EvaluatorBadge.stories.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/components/EvaluatorBadge/EvaluatorBadge.stories.tsx
@@ -6,7 +6,6 @@ const meta = preview.meta({
   args: {
     evaluatorId: "evaluator-id",
     evaluatorName: "Quality check",
-    environment: "langfuse-llm-as-a-judge",
     projectId: "project-id",
   },
 });

--- a/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/components/EvaluatorBadge/EvaluatorBadge.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader/components/EvaluatorBadge/EvaluatorBadge.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @repo/no-null-render */
-import { LangfuseInternalTraceEnvironment } from "@langfuse/shared";
 import { ExternalLinkIcon } from "lucide-react";
 import Link from "next/link";
 
@@ -8,20 +6,12 @@ import { Badge } from "@/src/components/design-system/Badge/Badge";
 export function EvaluatorBadge({
   evaluatorId,
   evaluatorName,
-  environment,
   projectId,
 }: {
-  evaluatorId: string | null;
+  evaluatorId: string;
   evaluatorName?: string | null;
-  environment: string;
   projectId: string;
 }) {
-  const isEvaluatorExecution =
-    environment === LangfuseInternalTraceEnvironment.LLMJudge ||
-    environment === LangfuseInternalTraceEnvironment.CodeEval;
-  const isManagedTemplate = evaluatorId?.startsWith("managed:") ?? false;
-  if (!evaluatorId || !isEvaluatorExecution || isManagedTemplate) return null;
-
   return (
     <Link
       href={`/project/${projectId}/evals/v2/${encodeURIComponent(evaluatorId)}`}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17221 app preview](https://pr-17221.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61996938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because the moved rendering predicate is equivalent and every current caller satisfies the stricter component contract.

<details><summary><h3>Summary</h3></summary>

- Moves evaluator-execution and managed-template guards into `ObservationDetailViewHeader`.
- Narrows `EvaluatorBadge.evaluatorId` from nullable to required.
- Updates the Storybook configuration for the reduced prop interface.
</details>

<!-- /greptile_comment -->