### PR TITLE
refactor(web): Fix no-null-render: SectionMedia.tsx

### DIFF
--- a/web/src/features/traces/components/IOPreview/components/SectionMedia.tsx
+++ b/web/src/features/traces/components/IOPreview/components/SectionMedia.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @repo/no-null-render */
 import { LangfuseMediaView } from "@/src/components/ui/LangfuseMediaView";
 import { type MediaReturnType } from "@/src/features/media/validation";
 
@@ -11,10 +10,6 @@ export interface SectionMediaProps {
  * SectionMedia renders media attachments at the bottom of the message list.
  */
 export function SectionMedia({ media }: SectionMediaProps) {
-  if (media.length === 0) {
-    return null;
-  }
-
   return (
     <>
       <div className="text-muted-foreground my-1 px-2 py-1 text-xs">Media</div>


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17222 app preview](https://pr-17222.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61997129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because the existing caller suppresses `SectionMedia` when no media remains.

<details><summary><h3>Summary</h3></summary>

- Removes the `@repo/no-null-render` suppression.
- Makes `SectionMedia` consistently render when invoked.
- Preserves existing empty-media behavior through the parent’s length check.
</details>

<!-- /greptile_comment -->