### PR TITLE
refactor(web): Fix no-null-render: SectionToolDefinitions.tsx

### DIFF
--- a/web/src/features/traces/components/IOPreview/IOPreviewPretty.tsx
+++ b/web/src/features/traces/components/IOPreview/IOPreviewPretty.tsx
@@ -287,7 +287,7 @@ export function IOPreviewPretty({
         <StatusMessageSection status={status} currentView="pretty" />
       ) : null}
 
-      {showData ? (
+      {showData && allTools.length > 0 ? (
         <SectionToolDefinitions
           tools={allTools}
           toolCallCounts={toolCallCounts}

--- a/web/src/features/traces/components/IOPreview/components/SectionToolDefinitions.tsx
+++ b/web/src/features/traces/components/IOPreview/components/SectionToolDefinitions.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @repo/no-null-render */
 import {
   ToolCallDefinitionCard,
   type ToolDefinition,
@@ -24,10 +23,6 @@ export function SectionToolDefinitions({
   toolCallsByName,
   toolNameToDefinitionNumber,
 }: SectionToolDefinitionsProps) {
-  if (tools.length === 0) {
-    return null;
-  }
-
   return (
     <div className="[&_.io-message-content]:px-2 [&_.io-message-header]:px-2">
       <div className="border-border mb-4 border-b pb-4">


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17223 app preview](https://pr-17223.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61997229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because the sole caller preserves the removed empty-list behavior.

<details><summary><h3>Summary</h3></summary>

- Prevents the tool definitions section from being mounted when no tools exist.
- Removes the component-level `null` return and its associated lint suppression.
</details>

<!-- /greptile_comment -->