### PR TITLE
refactor(web): Fix no-null-render: code-eval-test-run-card.tsx

### DIFF
--- a/web/src/features/evals/components/code-eval-test-run-card.tsx
+++ b/web/src/features/evals/components/code-eval-test-run-card.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @repo/no-null-render */
 import { CodeMirrorEditor } from "@/src/components/editor";
 import { TablePeekViewTraceDetail } from "@/src/components/table/peek/peek-trace-detail";
 import { usePeekNavigation } from "@/src/components/table/peek/hooks/usePeekNavigation";
@@ -27,10 +26,6 @@ import { useMemo } from "react";
 import { toast } from "sonner";
 
 import { type EvalFormType } from "@/src/features/evals/utils/evaluator-form-utils";
-import {
-  isEventTarget,
-  isExperimentTarget,
-} from "@/src/features/evals/utils/typeHelpers";
 
 type CodeEvalTestRunResult =
   | RouterOutputs["evals"]["testRunCodeEval"]
@@ -44,32 +39,20 @@ type CodeEvalInputPreviewData = Extract<
   { type: typeof EvalTargetObject.EVENT }
 >;
 
-function isCodeEvalTestTarget(
-  target: EvalFormType["target"],
-): target is
-  | typeof EvalTargetObject.EVENT
-  | typeof EvalTargetObject.EXPERIMENT {
-  return isEventTarget(target) || isExperimentTarget(target);
-}
-
 export function CodeEvalTestRunCard({
   projectId,
   evalTemplate,
   target,
   scoreName,
-  disabled = false,
   enableExecutionTracePeek = true,
 }: {
   projectId: string;
   evalTemplate: EvalTemplate;
-  target: EvalFormType["target"];
+  target: typeof EvalTargetObject.EVENT | typeof EvalTargetObject.EXPERIMENT;
   scoreName: EvalFormType["scoreName"];
-  disabled?: boolean;
   enableExecutionTracePeek?: boolean;
 }) {
   const { isV4 } = useReadPath();
-  const isSupportedTarget = isCodeEvalTestTarget(target);
-  const canPreview = isSupportedTarget && !disabled;
   const previewPointer = useFirstEvalPreviewPointer({
     target,
     useEventsTable: isV4,
@@ -96,7 +79,7 @@ export function CodeEvalTestRunCard({
 
   const { previewData, isLoading } = usePreviewData({
     projectId,
-    enabled: canPreview && Boolean(previewPointer),
+    enabled: Boolean(previewPointer),
     target,
     traceId: previewPointer?.traceId,
     observationId: previewPointer?.observationId,
@@ -116,8 +99,6 @@ export function CodeEvalTestRunCard({
       toast.error(result.error.message);
     },
   });
-
-  if (!isSupportedTarget || !canPreview) return null;
 
   return (
     <>

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -1363,9 +1363,12 @@ export const InnerEvaluatorForm = (props: {
         <CodeEvalTestRunCard
           projectId={props.projectId}
           evalTemplate={props.evalTemplate}
-          target={watchedTarget}
+          target={
+            isEventTarget(watchedTarget)
+              ? EvalTargetObject.EVENT
+              : EvalTargetObject.EXPERIMENT
+          }
           scoreName={watchedScoreName}
-          disabled={props.disabled}
           enableExecutionTracePeek={!props.existingEvaluator}
         />
       ) : isCodeEvalConfig ? null : (


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17224 app preview](https://pr-17224.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61997371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because the removed checks are already enforced by the card’s sole caller.

<details><summary><h3>Summary</h3></summary>

- Narrows the card’s target contract to event and experiment targets.
- Removes redundant internal target and disabled-state checks.
- Stops forwarding the now-unnecessary `disabled` property from the evaluator form.
</details>

<!-- /greptile_comment -->