### PR TITLE
refactor(web): Fix no-null-render: PreviewDeploymentBanner.tsx

### DIFF
--- a/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
+++ b/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
@@ -262,7 +262,11 @@ export function AuthenticatedLayout({
           <SidebarProvider>
             <div className="flex h-dvh w-full flex-col">
               <PaymentBanner />
-              <PreviewDeploymentBanner />
+              {env.NEXT_PUBLIC_PREVIEW_PR_URL && (
+                <PreviewDeploymentBanner
+                  prUrl={env.NEXT_PUBLIC_PREVIEW_PR_URL}
+                />
+              )}
               {versionUpdatePrompt.isVisible && (
                 <VersionUpdateBanner
                   onReload={versionUpdatePrompt.reload}

--- a/web/src/features/preview-deployment-banner/PreviewDeploymentBanner.clienttest.tsx
+++ b/web/src/features/preview-deployment-banner/PreviewDeploymentBanner.clienttest.tsx
@@ -20,11 +20,6 @@ describe("PreviewDeploymentBanner", () => {
     for (const key of Object.keys(h.env)) delete h.env[key];
   });
 
-  it("renders nothing when the preview env vars are unset", () => {
-    const { container } = render(<PreviewDeploymentBanner />);
-    expect(container).toBeEmptyDOMElement();
-  });
-
   it("links the PR and the author and shows the update time", () => {
     h.env.NEXT_PUBLIC_PREVIEW_PR_URL =
       "https://github.com/langfuse/langfuse/pull/15580";
@@ -33,7 +28,11 @@ describe("PreviewDeploymentBanner", () => {
       Date.now() - 2 * 60 * 60 * 1000,
     ).toISOString();
 
-    render(<PreviewDeploymentBanner />);
+    render(
+      <PreviewDeploymentBanner
+        prUrl={h.env.NEXT_PUBLIC_PREVIEW_PR_URL as string}
+      />,
+    );
 
     expect(screen.getByRole("link", { name: "PR #15580" })).toHaveAttribute(
       "href",
@@ -51,7 +50,11 @@ describe("PreviewDeploymentBanner", () => {
       "https://github.com/langfuse/langfuse/pull/1";
     h.env.NEXT_PUBLIC_PREVIEW_LAST_UPDATED = "not-a-date";
 
-    render(<PreviewDeploymentBanner />);
+    render(
+      <PreviewDeploymentBanner
+        prUrl={h.env.NEXT_PUBLIC_PREVIEW_PR_URL as string}
+      />,
+    );
 
     expect(screen.getByRole("link", { name: "PR #1" })).toBeInTheDocument();
     expect(screen.queryByText(/updated/)).not.toBeInTheDocument();
@@ -60,7 +63,11 @@ describe("PreviewDeploymentBanner", () => {
   it("falls back to a generic link label when the URL has no PR number", () => {
     h.env.NEXT_PUBLIC_PREVIEW_PR_URL = "https://github.com/langfuse/langfuse";
 
-    render(<PreviewDeploymentBanner />);
+    render(
+      <PreviewDeploymentBanner
+        prUrl={h.env.NEXT_PUBLIC_PREVIEW_PR_URL as string}
+      />,
+    );
 
     expect(
       screen.getByRole("link", { name: "a pull request" }),

--- a/web/src/features/preview-deployment-banner/PreviewDeploymentBanner.tsx
+++ b/web/src/features/preview-deployment-banner/PreviewDeploymentBanner.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @repo/no-null-render */
 import { useRef } from "react";
 import { formatDistanceToNow } from "date-fns";
 import {
@@ -16,22 +15,16 @@ const PREVIEW_BANNER_ORDER = 20;
  * baked into preview web images by .github/workflows/preview-build.yml; they
  * are unset everywhere else, so the banner never renders outside previews.
  */
-export function PreviewDeploymentBanner() {
+export function PreviewDeploymentBanner({ prUrl }: { prUrl: string }) {
   const bannerRef = useRef<HTMLDivElement>(null);
   const { getTopBannerOffset } = useTopBanner();
-
-  const prUrl = env.NEXT_PUBLIC_PREVIEW_PR_URL;
 
   useTopBannerRegistration({
     bannerId: PREVIEW_BANNER_ID,
     order: PREVIEW_BANNER_ORDER,
-    isVisible: Boolean(prUrl),
+    isVisible: true,
     elementRef: bannerRef,
   });
-
-  if (!prUrl) {
-    return null;
-  }
 
   const parsed = env.NEXT_PUBLIC_PREVIEW_LAST_UPDATED
     ? new Date(env.NEXT_PUBLIC_PREVIEW_LAST_UPDATED)


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17225 app preview](https://pr-17225.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61997514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The refactor appears safe to merge, with a non-blocking request to restore coverage at the new environment-gating boundary.

<details><summary><h3>Summary</h3></summary>

- Conditionally mounts the banner only when a preview PR URL is configured.
- Simplifies banner registration to an always-visible mounted state.
- Updates component tests for the required URL prop, but removes coverage of the relocated conditional behavior.
</details>

<!-- /greptile_comment -->