### PR TITLE
docs(agents): record which observability store holds which signal

### DIFF
--- a/.agents/skills/datadog-query-recipes/SKILL.md
+++ b/.agents/skills/datadog-query-recipes/SKILL.md
@@ -41,6 +41,9 @@ data domain you need: traces, logs, metrics, and visualizations.
      [`references/public-api-tenant-usage.md`](references/public-api-tenant-usage.md)
    - Queue inventory, queue consumers, and queue metrics:
      [`references/queue-consumers.md`](references/queue-consumers.md)
+   - Which store holds a signal, what each drops on purpose, and the
+     release/tenant correlation fields:
+     [`../debug-issue-with-datadog/references/signal-boundaries.md`](../debug-issue-with-datadog/references/signal-boundaries.md)
    - Scheduled-export freshness lag (blob / PostHog / Mixpanel):
      [`references/export-freshness-lag.md`](references/export-freshness-lag.md)
 3. Start with aggregate queries, grouped by environment, service, route,

--- a/.agents/skills/datadog-query-recipes/references/environments.md
+++ b/.agents/skills/datadog-query-recipes/references/environments.md
@@ -42,4 +42,8 @@ When a query returns zero:
 1. Check the time window and spelling of `env`, `service`, and route/resource.
 2. Query facets on the same site for `env` and `service`.
 3. Repeat a small count query on the other Datadog site.
-4. Only then report "No measurements found".
+4. Confirm the signal would have been recorded at all — trace sampling,
+   uninstrumented health-check routes, and Sentry's browser-only scope each
+   manufacture empty results. See
+   [`../../debug-issue-with-datadog/references/signal-boundaries.md`](../../debug-issue-with-datadog/references/signal-boundaries.md).
+5. Only then report "No measurements found".

--- a/.agents/skills/debug-issue-with-datadog/SKILL.md
+++ b/.agents/skills/debug-issue-with-datadog/SKILL.md
@@ -48,6 +48,11 @@ supports them.
    window. Use [`references/repo-debug-map.md`](references/repo-debug-map.md)
    to translate "PostHog integration", "ingestion failures", "evals stuck",
    etc. into the Datadog filters and source files you should be looking at.
+   Settle **which store would even hold the signal** before querying, using
+   [`references/signal-boundaries.md`](references/signal-boundaries.md): server
+   and worker failures land in Datadog and never in Sentry, browser failures
+   the other way round. Querying the wrong half produces a confident "no
+   errors" for a subsystem that is on fire.
 
 3. **Run the broad Datadog sweep.** Default to the full sweep in
    [`references/datadog-playbook.md`](references/datadog-playbook.md): APM
@@ -122,6 +127,9 @@ do not invent root causes.
 - Production telemetry query recipes, tenant/public API usage, and queue
   consumer measurements:
   [`datadog-query-recipes`](../datadog-query-recipes/SKILL.md)
+- Which store holds which signal, what each one drops on purpose, and the
+  build-id join between Datadog and Sentry:
+  [`references/signal-boundaries.md`](references/signal-boundaries.md)
 - Backend layout, queue contracts, instrumentation patterns:
   [`backend-dev-guidelines`](../backend-dev-guidelines/SKILL.md)
 - ClickHouse-related findings (memory ceilings, JOIN spills, slow queries):

--- a/.agents/skills/debug-issue-with-datadog/references/signal-boundaries.md
+++ b/.agents/skills/debug-issue-with-datadog/references/signal-boundaries.md
@@ -11,8 +11,13 @@ would have recorded the event.
 | --- | --- | --- |
 | `web` server (API routes, tRPC, SSR), `web-ingestion`, `web-iso` | Datadog APM spans + logs | Sentry |
 | `worker`, `worker-cpu` (BullMQ consumers) | Datadog APM spans + logs | Sentry |
-| The user's **browser** | Sentry (`@sentry/nextjs`), Datadog RUM | Datadog APM/logs |
+| The user's **browser** | Sentry (`@sentry/nextjs`) | Datadog APM/logs |
 | A deliberate product action | PostHog | Datadog, Sentry |
+
+**There is no browser-side Datadog.** No RUM package, no client token, no init
+call — a browser symptom has exactly one error store, Sentry. Do not reach for
+RUM to fill the gap; querying a store that was never wired up returns the same
+manufactured zero this page exists to prevent.
 
 **Sentry is browser-only.** The one `Sentry.init` lives in
 [`web/instrumentation-client.ts`](../../../../web/instrumentation-client.ts),
@@ -23,8 +28,8 @@ and `@sentry/nextjs` is a dependency of `web` alone — not `worker`, not
   Sentry issues for a worker symptom is the expected shape, never a sign the
   handler is healthy.
 - Conversely, a "page is broken for one customer" report with nothing in
-  Datadog APM may be entirely client-side. Check Sentry and RUM before
-  concluding nothing happened.
+  Datadog APM may be entirely client-side. Check Sentry before concluding
+  nothing happened.
 
 ## Absence is manufactured, not neutral
 
@@ -42,8 +47,11 @@ name which of these could explain it:
   muted deliberately. A missing span is not a missing request.
 - **Health-check routes are never instrumented.** `ignoreIncomingRequestHook`
   drops `/api/public/health`, `/api/public/ready`, and `/api/health`.
-- **PostHog captures shape, never raw values**, so it cannot answer "what did
-  this user type" — only that a step happened.
+- **PostHog events are meant to carry shape, not user content** — a convention
+  the `capture` wrapper does not enforce, since it accepts any property object.
+  So do not assume an event holds the value you need, and equally do not rule
+  PostHog out: check the event's actual properties in the typed registry
+  (`usePostHogClientCapture.ts`) before concluding either way.
 
 ## Release correlation — the deploy question
 
@@ -66,12 +74,23 @@ build" from "pre-existing". Deploys themselves are driven by
 
 `addUserToSpan` in
 [`packages/shared/src/server/instrumentation/index.ts`](../../../../packages/shared/src/server/instrumentation/index.ts)
-sets these as **both** span attributes and OTel **baggage**, so they propagate
-to child spans rather than sitting only on the span that authenticated:
+sets these as attributes on the **active span only**:
 
 - `langfuse.project.id`
 - `langfuse.org.id`
 - `user.id`
+
+**They do not reach child spans.** The function also builds baggage and returns
+`propagation.setBaggage(ctx, baggage)`, but every production caller
+(`apiAuth.ts`, `trpc.ts`, `run-mcp-tool.ts`, `watchHandler.ts`) discards that
+returned context, and an OTel context is immutable — unless someone activates
+it with `context.with(...)`, the baggage is never live, so nothing propagates.
+
+The practical consequence is the rule already stated in
+`datadog-playbook.md`: **correlate by trace, not by a single span filter.**
+Tenant tags sit on the span that authenticated (often `api-auth-verify`) while
+the route lives on the request root, so a query demanding both on one span
+matches nothing. Join on `traceid` instead.
 
 Error attributes from the same file — `error.type`, `error.message`,
 `error.stack` — are what Datadog Error Tracking groups on. Note the log-side

--- a/.agents/skills/debug-issue-with-datadog/references/signal-boundaries.md
+++ b/.agents/skills/debug-issue-with-datadog/references/signal-boundaries.md
@@ -1,0 +1,88 @@
+# Signal Boundaries — Which System Holds Which Half of the Truth
+
+Read this before concluding that a signal is absent. Our telemetry is split by
+**where the code ran**, not by severity, and each store drops data on purpose.
+An empty result is only evidence when the store you queried is the one that
+would have recorded the event.
+
+## The split
+
+| Where the code ran | Recorded in | Not recorded in |
+| --- | --- | --- |
+| `web` server (API routes, tRPC, SSR), `web-ingestion`, `web-iso` | Datadog APM spans + logs | Sentry |
+| `worker`, `worker-cpu` (BullMQ consumers) | Datadog APM spans + logs | Sentry |
+| The user's **browser** | Sentry (`@sentry/nextjs`), Datadog RUM | Datadog APM/logs |
+| A deliberate product action | PostHog | Datadog, Sentry |
+
+**Sentry is browser-only.** The one `Sentry.init` lives in
+[`web/instrumentation-client.ts`](../../../../web/instrumentation-client.ts),
+and `@sentry/nextjs` is a dependency of `web` alone — not `worker`, not
+`packages/shared`. So:
+
+- An ingestion, queue, or worker failure **cannot** appear in Sentry. Zero
+  Sentry issues for a worker symptom is the expected shape, never a sign the
+  handler is healthy.
+- Conversely, a "page is broken for one customer" report with nothing in
+  Datadog APM may be entirely client-side. Check Sentry and RUM before
+  concluding nothing happened.
+
+## Absence is manufactured, not neutral
+
+Each store discards data by design. Before writing "No measurements found",
+name which of these could explain it:
+
+- **Sentry `beforeSend` drops whole classes of event.** React DevTools probes,
+  poll 5xx from `httpClientIntegration` (the NextAuth session poll dominates
+  it), known-benign transport/offline/CORS failures, and PostHog recorder
+  internals are filtered; stale-chunk parse errors are collapsed onto a single
+  fingerprint. See `web/src/utils/sentryFilters.ts` and the
+  [`sentry-instrumentation`](../../sentry-instrumentation/SKILL.md) skill.
+- **APM traces are sampled.** `web` applies a `TraceIdRatioBasedSampler`
+  driven by `OTEL_TRACE_SAMPLING_RATIO`, and the `next.js` tracer scope is
+  muted deliberately. A missing span is not a missing request.
+- **Health-check routes are never instrumented.** `ignoreIncomingRequestHook`
+  drops `/api/public/health`, `/api/public/ready`, and `/api/health`.
+- **PostHog captures shape, never raw values**, so it cannot answer "what did
+  this user type" — only that a step happened.
+
+## Release correlation — the deploy question
+
+"Did this start with a deploy?" is answered by the **build id**, which is the
+one identifier both stores share:
+
+| Store | Field | Source |
+| --- | --- | --- |
+| Datadog | `service.version` (the `version` tag) | `BUILD_ID`, set as the OTel resource `service.version` in [`web/src/observability.config.ts`](../../../../web/src/observability.config.ts) and [`worker/src/instrumentation.ts`](../../../../worker/src/instrumentation.ts) |
+| Sentry | `release` | `NEXT_PUBLIC_BUILD_ID` |
+
+Because both derive from the same build, a `version` in Datadog and a `release`
+in Sentry name the same deploy — group errors by it to separate "new in this
+build" from "pre-existing". Deploys themselves are driven by
+`.github/workflows/deploy.yml`, whose environment inputs are the same
+`prod-us` / `prod-eu` / `prod-hipaa` / `prod-jp` (plus `staging`) values as the
+`env` tag.
+
+## Tenant correlation
+
+`addUserToSpan` in
+[`packages/shared/src/server/instrumentation/index.ts`](../../../../packages/shared/src/server/instrumentation/index.ts)
+sets these as **both** span attributes and OTel **baggage**, so they propagate
+to child spans rather than sitting only on the span that authenticated:
+
+- `langfuse.project.id`
+- `langfuse.org.id`
+- `user.id`
+
+Error attributes from the same file — `error.type`, `error.message`,
+`error.stack` — are what Datadog Error Tracking groups on. Note the log-side
+facet is `@projectId` **or** `@langfuse.project.id` depending on the
+instrumentation site; see `datadog-playbook.md` before assuming one.
+
+Treat `user.id` as customer-identifying: correlate with it, but do not paste it
+into an analysis, a ticket, or a PR description.
+
+## `prod-hipaa`
+
+Regulated data. Do not quote or copy payloads out of it, and do not assume its
+access, retention, or instrumentation matches `prod-us` — confirm before
+promising a measurement.


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17235 app preview](https://pr-17235.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

The investigation skills never said where client-side error reporting stops and
server-side telemetry starts — and never mentioned the error tracker at all.
That makes one mistake easy and invisible: querying it for a worker symptom
returns nothing, which reads like a healthy handler. Adds one reference that
draws the boundary, lists what each store discards on purpose, and records the
build-id join that answers "did this start with a deploy?".

## Why

Three gaps, each verified against `main` rather than assumed:

1. **Zero mentions of the error tracker** across any of the three
   investigation skills. `Sentry.init` is called only in
   `web/instrumentation-client.ts`, and `@sentry/nextjs` is a dependency of
   `web` alone — not `worker`, not `packages/shared`. So a worker or ingestion
   failure **cannot** appear there. Nothing said so.
2. **No release-correlation field documented**, so "did a deploy cause this?"
   had no mechanical answer — despite both stores already carrying it.
3. **The zero-result rule was incomplete.** `references/environments.md`
   required checking the other regional site before writing "No measurements
   found", but not whether the signal would have been recorded at all.

## What

`references/signal-boundaries.md`, plus wiring so it is read at the moment it
matters:

- **Where code ran → where it is recorded.** Server and worker land in APM and
  logs; the browser lands in the error tracker and RUM; product actions land
  in analytics. An empty result is only evidence when the store queried is the
  one that would have recorded the event.
- **Absence is manufactured, not neutral.** `beforeSend` drops DevTools probes,
  poll 5xx, benign transport failures, and recorder internals, and collapses
  stale-chunk errors onto one fingerprint; traces are sampled via
  `OTEL_TRACE_SAMPLING_RATIO`; the `next.js` tracer scope is muted; health
  routes are uninstrumented.
- **Release correlation.** `BUILD_ID` → the APM `service.version`, and
  `NEXT_PUBLIC_BUILD_ID` → the error tracker's `release`. Same build, so the
  two identify one deploy — group by it to separate "new in this build" from
  pre-existing.
- **Tenant correlation.** `langfuse.project.id`, `langfuse.org.id`, `user.id`
  set by `addUserToSpan` as span attributes **and** baggage, so they propagate
  to child spans. Notes that the log facet is `@projectId` *or*
  `@langfuse.project.id` depending on instrumentation site, and that `user.id`
  is customer-identifying: correlate with it, don't paste it into a ticket.

Wired into the sweep-scoping step of the issue-debugging skill (decide which
store holds the signal *before* querying), both telemetry skills' reference
lists, and the cross-site rule in `references/environments.md` — so "No
measurements found" now requires ruling out a manufactured absence first.

Also flags that `prod-hipaa` carries regulated data and should not be assumed
to match `prod-us`.

## Result

An agent triaging a queue failure no longer reports "no errors" from the half
of the stack that structurally cannot contain them, and can answer the deploy
question from a field that already exists.

Docs only — no runtime code, no dependencies, no behavior change. Every
relative link and cited path verified to resolve after rebase onto current
`main`.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62026706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 3/5</h2>

The PR is not yet safe to merge because its investigation guide directs browser triage toward an unconfigured RUM store and promises tenant propagation that current callers do not establish.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Datadog RUM Is Unconfigured** <a href="https://github.com/langfuse/langfuse/pull/17235#discussion_r3966681144">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Baggage Does Not Propagate** <a href="https://github.com/langfuse/langfuse/pull/17235#discussion_r3966681170">▶</a>
3. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**PostHog Claim Is Overbroad** <a href="https://github.com/langfuse/langfuse/pull/17235#discussion_r3966681162">▶</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.agents/skills/debug-issue-with-datadog/references/signal-boundaries.md:12
The store map sends browser investigations to Datadog RUM, but this repository has no Datadog browser-RUM dependency, initialization, or client configuration. Browser errors are initialized through Sentry in `web/instrumentation-client.ts`. Following this guidance would send investigators to a store that cannot contain the signal and could produce the same false “no errors” conclusion this document is meant to prevent.

### Issue 2
.agents/skills/debug-issue-with-datadog/references/signal-boundaries.md:71-76
Although `addUserToSpan` constructs baggage, `setBaggage` returns a new immutable context, and the production callers shown here ignore the returned context. The identifiers are attached to the current span but do not become active baggage for subsequently created child spans. Tenant queries that rely on the documented propagation can therefore miss those descendant spans.

### Issue 3
.agents/skills/debug-issue-with-datadog/references/signal-boundaries.md:47
The statement that PostHog captures “shape, never raw values” is too broad. The capture wrapper accepts unrestricted property objects, and existing events record concrete values such as `dashboardId`. This could make investigators incorrectly rule out PostHog even when the relevant action event contains the value they need; the guidance should instead describe the narrower privacy convention and available event properties.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Adds a signal-boundary reference covering Datadog, Sentry, PostHog, filtering, and correlation fields.
- Extends zero-result procedures to account for intentionally absent telemetry.
- Contains inaccurate guidance about Datadog RUM and tenant baggage propagation, plus an overbroad PostHog assertion.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Browser[Browser execution] --> Sentry[Sentry]
  Server[Web server execution] --> APM[Datadog APM and logs]
  Worker[Worker execution] --> APM
  Action[Product action] --> PostHog[PostHog]
  Build[Build ID] --> APMVersion[Datadog service.version]
  Build --> SentryRelease[Sentry release]
```
</details>

<!-- /greptile_comment -->