### PR TITLE
test(web): avoid broad imports during resource cleanup

### DIFF
--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -57,6 +57,10 @@
   AI SDK-native LLM execution helpers (`generateLLMText` and
   `streamLLMText`), Bedrock default-credential provider auth
   (`createDefaultBedrockProviderAuth`), and server test utilities.
+- `@langfuse/shared/src/server/clickhouse` via `src/server/clickhouse/index.ts`:
+  ClickHouse clients and helpers without loading the full server barrel. Use this
+  entry point for test cleanup so built and source-aliased clients retain the same
+  module identity.
 - `@langfuse/shared/src/db` via `src/db.ts`: Prisma client singleton plus
   Prisma namespace/types for direct database access. Never route this into
   frontend-safe code.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -31,6 +31,10 @@
       "import": "./dist/src/server/index.js",
       "require": "./dist/src/server/index.js"
     },
+    "./src/server/clickhouse": {
+      "import": "./dist/src/server/clickhouse/index.js",
+      "require": "./dist/src/server/clickhouse/index.js"
+    },
     "./src/server/clickhouse/clickhouseIdentifiers": {
       "import": "./dist/src/server/clickhouse/clickhouseIdentifiers.js",
       "require": "./dist/src/server/clickhouse/clickhouseIdentifiers.js"

--- a/packages/shared/src/server/clickhouse/index.ts
+++ b/packages/shared/src/server/clickhouse/index.ts
@@ -1,0 +1,1 @@
+export { ClickHouseClientManager, clickhouseClient } from "./client";

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -199,6 +199,10 @@ Sentry instrumentation skill first and decide whether it should capture at all
   `JobConfiguration` naming into the public contract.
 - Keep tests independent; in `src/__tests__/server/**`, prefer scoped cleanup or
   unique test data over global reset helpers.
+- Test teardown closes existing `globalThis.redis` and imports ClickHouse through
+  `@langfuse/shared/src/server/clickhouse`, not the full server barrel or relative
+  shared source paths. Suites own their private Redis clients; shared-context
+  workers skip per-file teardown.
 - Put pure server unit tests that do not need Postgres bootstrap under
   `src/__tests__/server/unit/**` so they skip the shared DB setup hook.
 - Server tests that drive the public REST API over HTTP need a web server on

--- a/web/src/__tests__/after-teardown.ts
+++ b/web/src/__tests__/after-teardown.ts
@@ -11,7 +11,4 @@ afterAll(async () => {
   }
 
   await teardown();
-  // The teardown dynamically imports the heavy @langfuse/shared server module
-  // graph; under a fully loaded CI runner that alone can exceed the default
-  // 10s hook timeout.
 }, 30_000);

--- a/web/src/__tests__/server/unit/teardown-shared-source.servertest.ts
+++ b/web/src/__tests__/server/unit/teardown-shared-source.servertest.ts
@@ -1,0 +1,17 @@
+import { expect, it, vi } from "vitest";
+import { env } from "@langfuse/shared/src/env";
+import { clickhouseClient } from "@langfuse/shared/src/server";
+import teardown from "../../teardown";
+
+it("closes clients through the same source-module identity", async () => {
+  const client = clickhouseClient({ url: env.CLICKHOUSE_URL });
+  const close = vi.spyOn(client, "close");
+
+  try {
+    await teardown();
+
+    expect(close).toHaveBeenCalledOnce();
+  } finally {
+    close.mockRestore();
+  }
+});

--- a/web/src/__tests__/server/unit/teardown.servertest.ts
+++ b/web/src/__tests__/server/unit/teardown.servertest.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as SharedServer from "@langfuse/shared/src/server";
+import teardown from "../../teardown";
+
+vi.mock("@langfuse/shared/src/server", () => {
+  throw new Error("Test cleanup must not load the shared server barrel");
+});
+
+describe("server test resource cleanup", () => {
+  beforeEach(() => {
+    vi.stubGlobal("redis", undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("does not initialize Redis when no test opened it", async () => {
+    await teardown();
+
+    expect(globalThis.redis).toBeUndefined();
+  });
+
+  it.each(["ready", "end", "close"])(
+    "disconnects only an active Redis connection (%s)",
+    async (status) => {
+      const disconnect = vi.fn();
+      vi.stubGlobal("redis", { status, disconnect });
+
+      await teardown();
+
+      expect(disconnect).toHaveBeenCalledTimes(status === "ready" ? 1 : 0);
+    },
+  );
+
+  it("waits for existing ClickHouse clients to close", async () => {
+    const { clickhouseClient } =
+      await import("@langfuse/shared/src/server/clickhouse");
+    const client = clickhouseClient();
+    let finishClose!: () => void;
+    const closed = new Promise<void>((resolve) => {
+      finishClose = resolve;
+    });
+    const close = vi.spyOn(client, "close").mockReturnValue(closed);
+    const finished = vi.fn();
+    const cleanup = teardown().then(finished);
+
+    try {
+      await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+      expect(finished).not.toHaveBeenCalled();
+    } finally {
+      finishClose();
+      await cleanup;
+    }
+
+    expect(finished).toHaveBeenCalledOnce();
+  });
+
+  it("closes clients created through the built shared server export", async () => {
+    const actual = await vi.importActual<typeof SharedServer>(
+      "@langfuse/shared/src/server",
+    );
+    try {
+      const client = actual.clickhouseClient();
+      const close = vi.spyOn(client, "close");
+
+      await teardown();
+
+      expect(close).toHaveBeenCalledOnce();
+    } finally {
+      actual.redis?.disconnect();
+    }
+  });
+
+  it("leaves shared-context resources open for later test files", async () => {
+    const { clickhouseClient } =
+      await import("@langfuse/shared/src/server/clickhouse");
+    const disconnect = vi.fn();
+    const close = vi.spyOn(clickhouseClient(), "close");
+    vi.stubGlobal("redis", { status: "ready", disconnect });
+    vi.stubEnv("VITEST_SHARED_CONTEXT", "1");
+    let afterAllHook!: () => Promise<void>;
+    vi.stubGlobal("afterAll", (hook: () => Promise<void>) => {
+      afterAllHook = hook;
+    });
+    vi.resetModules();
+    await import("../../after-teardown");
+
+    try {
+      await afterAllHook();
+
+      expect(disconnect).not.toHaveBeenCalled();
+      expect(close).not.toHaveBeenCalled();
+    } finally {
+      await teardown();
+    }
+  });
+});

--- a/web/src/__tests__/teardown.ts
+++ b/web/src/__tests__/teardown.ts
@@ -1,13 +1,12 @@
 export default async function teardown() {
-  const { redis, logger, ClickHouseClientManager } =
-    await import("@langfuse/shared/src/server");
-
-  logger.debug(`Redis status ${redis?.status}`);
+  // Redis records the existing non-production singleton on globalThis.
+  // Importing its module here would create a connection for otherwise pure tests.
+  const redis = globalThis.redis;
   if (redis && redis.status !== "end" && redis.status !== "close") {
     redis.disconnect();
   }
 
+  const { ClickHouseClientManager } =
+    await import("@langfuse/shared/src/server/clickhouse");
   await ClickHouseClientManager.getInstance().closeAllConnections();
-
-  logger.debug("Teardown complete");
 }


### PR DESCRIPTION
## What does this PR do?

Avoid loading the entire shared server module during web test cleanup.

- Close the existing Redis singleton without importing code that creates a connection.
- Expose a narrow ClickHouse entry point and use it to close clients from the same built/source module instance.
- Keep shared-context workers and private test-client ownership unchanged.
- Cover cold cleanup, Redis statuses, awaited ClickHouse shutdown, built/source identity and shared-context skipping.

This isolates the cleanup approach from Nimar's [#17103](https://github.com/langfuse/langfuse/pull/17103) for measurement. Runner sizes, concurrency, caches and test scheduling are unchanged. Separate from the merged Redis/webhook work in [#17232](https://github.com/langfuse/langfuse/pull/17232).

Reasoning: cleanup should not load unrelated services merely to close resources. This remains a small import change, not a new resource registry. ClickHouse instrumentation still initializes; it does not eliminate every import-time cost.

Impacted packages: `web`, `@langfuse/shared` (one narrow re-export). No production client implementation changes.

## Verification

- Cold-cleanup regression before the change: `Tests 1 failed (1)`.
- Cleanup plus existing admin/auth tests: `Tests 34 passed (34)`.
- Worker regression: `Tests 22 passed (22)`.
- `pnpm exec turbo run lint --force`: `Tasks: 7 successful, 7 total`; `Cached: 0 cached, 7 total`.
- `pnpm exec turbo run typecheck --force`: `Tasks: 8 successful, 8 total`; `Cached: 0 cached, 8 total`.
- `pnpm exec knip`, agent sync/check and `git diff --check`: exit 0.
- Shared Prisma generation and build passed before testing, so checks use the current built package.
- No browser check: test cleanup and package-export changes, no rendered UI change.

## Measurement

Five interleaved local pairs after warm-up, identical existing tests and worker settings:

| Sample | Baseline median | PR median |
| --- | ---: | ---: |
| 966 unit tests, Vitest duration | 23.47s | 17.77s |
| Same unit command, process wall time | 26.32s | 20.77s |
| Six-test pure unit file, Vitest duration | 2.62s | 0.385s |

The 966-test sample is **24.3% faster locally**. New regression files were excluded equally from both timed versions. These are not whole-pipeline CI savings.

### CI: two matched pairs

Baseline `934179050e`; PR `2f97c51313`. All four runs used `workflow_dispatch` and unchanged 16-vCPU / 12-worker web jobs. The first pair had `0 cached, 6 total` in each web build; the second pair had `5 cached, 6 total` on both sides. Tests always executed.

| Full web suite (Vitest median) | Baseline | PR | Change |
| --- | ---: | ---: | ---: |
| Default | 66.50s | 61.52s | -7.5% |
| Azure | 65.49s | 62.55s | -4.5% |
| Redis Cluster | 64.66s | 61.98s | -4.1% |

The web suites improved in **all six mode/run comparisons**, despite eight additional cleanup regression tests. Whole web-job medians, including build and cleanup, improved by 2–4 seconds. No web/worker test retries occurred in these samples.

**There is no demonstrated end-to-end CI speedup.** Creation-to-gate times were baseline **177 / 137s**, candidate **177 / 171s**. The second candidate run waited for the web Docker build (finished 37 seconds after its last web-test job). These four runs do not establish whether any whole-pipeline change is repeatable. The supported result is faster test cleanup and a modest full-web-suite improvement, not a 24% whole-CI gain.

| Pair | Baseline | PR |
| --- | --- | --- |
| First | [177s, success](https://github.com/langfuse/langfuse/actions/runs/34336287861) | [177s, success](https://github.com/langfuse/langfuse/actions/runs/34336419408) |
| Second | [137s, success](https://github.com/langfuse/langfuse/actions/runs/34336607014) | [171s, success](https://github.com/langfuse/langfuse/actions/runs/34336727986) |

Final PR checks: **42 passed, 9 skipped, none failed/pending**, including Docker and preview builds. All four manual runs passed all test/deployment-mode matrices. The PR run also passed.

## Type of change

- [x] Test performance and regression coverage
- [x] Self-reviewed
