### PR TITLE
fix(web): remove per-chip hide controls from session header

### DIFF
--- a/web/src/features/annotation-queues/components/session/ModernSessionHeader.clienttest.tsx
+++ b/web/src/features/annotation-queues/components/session/ModernSessionHeader.clienttest.tsx
@@ -3,7 +3,6 @@ import { type ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ModernSessionHeader } from "@/src/features/annotation-queues/components/session/ModernSessionHeader";
-import { sessionHeaderVisibilityStorageKey } from "@/src/features/annotation-queues/components/session/sessionHeaderVisibility";
 
 const capture = vi.hoisted(() => vi.fn());
 
@@ -71,128 +70,32 @@ const defaultProps = {
 describe("ModernSessionHeader", () => {
   afterEach(() => {
     capture.mockClear();
-    localStorage.clear();
   });
 
-  it("hides and reveals a detail while persisting the preference", () => {
-    render(<ModernSessionHeader {...defaultProps} />);
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Hide trace and span counts in session header",
-      }),
-    );
+  it("renders every session detail chip without a hide control", () => {
+    const { container } = render(<ModernSessionHeader {...defaultProps} />);
 
     expect(
-      screen.queryByRole("button", {
-        name: "Hide trace and span counts in session header",
-      }),
+      container.querySelectorAll('[data-session-header-pill="true"]').length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.queryByRole("button", { name: /^Hide /i }),
     ).not.toBeInTheDocument();
     expect(
-      localStorage.getItem(sessionHeaderVisibilityStorageKey("project-1")),
-    ).toBe(JSON.stringify(["traces"]));
-    expect(capture).toHaveBeenCalledWith(
-      "session_detail:header_detail_visibility_changed",
-      {
-        action: "hide",
-        detailType: "traces",
-        storedHiddenDetailCount: 1,
-        isV4: true,
-      },
-    );
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Show 1 hidden session details",
-      }),
-    );
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Show trace and span counts in session header",
-      }),
-    );
-
-    expect(
-      screen.getByRole("button", {
-        name: "Hide trace and span counts in session header",
-      }),
-    ).toBeInTheDocument();
-    expect(
-      localStorage.getItem(sessionHeaderVisibilityStorageKey("project-1")),
-    ).toBe(JSON.stringify([]));
-    expect(capture).toHaveBeenCalledTimes(2);
-    expect(capture).toHaveBeenLastCalledWith(
-      "session_detail:header_detail_visibility_changed",
-      {
-        action: "show",
-        detailType: "traces",
-        storedHiddenDetailCount: 0,
-        isV4: true,
-      },
-    );
+      screen.queryByRole("button", { name: /^Show .+ in session header$/i }),
+    ).not.toBeInTheDocument();
   });
 
-  it("restores hidden details from project-scoped local storage", () => {
-    localStorage.setItem(
-      sessionHeaderVisibilityStorageKey("project-1"),
-      JSON.stringify(["traces"]),
-    );
+  it("does not capture a header detail visibility event", () => {
     render(<ModernSessionHeader {...defaultProps} />);
 
-    expect(
-      screen.queryByRole("button", {
-        name: "Hide trace and span counts in session header",
-      }),
-    ).not.toBeInTheDocument();
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Show 1 hidden session details",
-      }),
+    expect(capture).not.toHaveBeenCalledWith(
+      "session_detail:header_detail_visibility_changed",
+      expect.anything(),
     );
-    expect(
-      screen.getByRole("button", {
-        name: "Show trace and span counts in session header",
-      }),
-    ).toBeInTheDocument();
   });
 
-  it("does not persist customer identifiers in dynamic detail keys", () => {
-    const userId = "customer@example.com";
-    render(<ModernSessionHeader {...defaultProps} users={[userId]} />);
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Hide user 1 in session header",
-      }),
-    );
-
-    const storedValue = localStorage.getItem(
-      sessionHeaderVisibilityStorageKey("project-1"),
-    );
-    expect(storedValue).not.toContain(userId);
-    expect(JSON.parse(storedValue ?? "[]")).toHaveLength(1);
-  });
-
-  it("preserves preferences for details that are temporarily unavailable", () => {
-    const storageKey = sessionHeaderVisibilityStorageKey("project-1");
-    localStorage.setItem(storageKey, JSON.stringify(["latency"]));
-    render(
-      <ModernSessionHeader {...defaultProps} traces={{ state: "loading" }} />,
-    );
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Hide trace and span counts in session header",
-      }),
-    );
-
-    expect(JSON.parse(localStorage.getItem(storageKey) ?? "[]")).toEqual([
-      "latency",
-      "traces",
-    ]);
-  });
-
-  it("lets overflow-only users participate in visibility preferences", () => {
+  it("keeps overflow users reachable through the overflow popover", () => {
     const users = [
       "user-1@example.com",
       "user-2@example.com",
@@ -203,22 +106,12 @@ describe("ModernSessionHeader", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Show 1 hidden session details",
+        name: "Show 1 more session details",
       }),
     );
-    const hideOverflowUser = screen.getByRole("button", {
-      name: "Hide user 4 in session header",
-    });
-    hideOverflowUser.focus();
-    fireEvent.click(hideOverflowUser);
 
-    const showOverflowUser = screen.getByRole("button", {
-      name: "Show user 4 in session header",
-    });
-    expect(showOverflowUser).toBeInTheDocument();
-    expect(showOverflowUser).toHaveFocus();
     expect(
-      localStorage.getItem(sessionHeaderVisibilityStorageKey("project-1")),
-    ).not.toContain(users[3]);
+      screen.getByRole("link", { name: "user user-4@example.com" }),
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/features/annotation-queues/components/session/ModernSessionHeader.stories.tsx
+++ b/web/src/features/annotation-queues/components/session/ModernSessionHeader.stories.tsx
@@ -3,7 +3,6 @@ import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 
 import preview from "@/.storybook/preview";
 import { ModernSessionHeader } from "@/src/features/annotation-queues/components/session/ModernSessionHeader";
-import { sessionHeaderVisibilityStorageKey } from "@/src/features/annotation-queues/components/session/sessionHeaderVisibility";
 
 const scores = [
   {
@@ -105,8 +104,8 @@ export const ConfiguredMetadata = meta.story({
   },
 });
 
-export const TestSearchesHiddenPills = meta.story({
-  name: "(Test) Searches hidden pills",
+export const TestSearchesOverflowPills = meta.story({
+  name: "(Test) Searches overflow pills",
   args: {
     ...defaultArgs,
     scores: overflowScores,
@@ -125,12 +124,12 @@ export const TestSearchesHiddenPills = meta.story({
     await waitFor(() =>
       expect(
         canvas.getByRole("button", {
-          name: /show \d+ hidden session details/i,
+          name: /show \d+ more session details/i,
         }),
       ).toBeInTheDocument(),
     );
     const overflowButton = canvas.getByRole("button", {
-      name: /show \d+ hidden session details/i,
+      name: /show \d+ more session details/i,
     });
     const visiblePills = canvasElement.querySelectorAll<HTMLElement>(
       "[data-overflow-visible-item='true'] [data-session-header-pill='true']",
@@ -191,7 +190,7 @@ export const TestBoundsManyUsers = meta.story({
 
     await userEvent.click(
       canvas.getByRole("button", {
-        name: /show \d+ hidden session details/i,
+        name: /show \d+ more session details/i,
       }),
     );
     const body = within(canvasElement.ownerDocument.body);
@@ -328,83 +327,6 @@ export const TestCompactsTokenCounts = meta.story({
     await expect(tokenPill).toHaveAttribute(
       "title",
       "tokens 648,714 → 6,697 (Σ 655,411)",
-    );
-  },
-});
-
-export const TestHidesAndRevealsDetails = meta.story({
-  name: "(Test) Hides and reveals details",
-  args: {
-    ...defaultArgs,
-    projectId: "project-header-visibility-story",
-  },
-  play: async ({ canvasElement }) => {
-    const storageKey = sessionHeaderVisibilityStorageKey(
-      "project-header-visibility-story",
-    );
-    const storedValue = JSON.stringify([]);
-    localStorage.setItem(storageKey, storedValue);
-    window.dispatchEvent(
-      new CustomEvent("localStorageChange", {
-        detail: { key: storageKey, newValue: storedValue },
-      }),
-    );
-
-    const canvas = within(canvasElement);
-    const hideTraceDetail = await canvas.findByRole("button", {
-      name: "Hide trace and span counts in session header",
-    });
-    const visibleTraceDetail = hideTraceDetail.closest(
-      "[data-overflow-visible-item='true']",
-    );
-    await expect(visibleTraceDetail).toBeInTheDocument();
-    hideTraceDetail.focus();
-    await waitFor(() => expect(hideTraceDetail).toBeVisible());
-    await expect(
-      hideTraceDetail.getBoundingClientRect().width,
-    ).toBeGreaterThanOrEqual(24);
-    await expect(
-      hideTraceDetail.getBoundingClientRect().height,
-    ).toBeGreaterThanOrEqual(24);
-    await userEvent.click(hideTraceDetail);
-    await expect(
-      canvas.queryByRole("button", {
-        name: "Hide trace and span counts in session header",
-      }),
-    ).not.toBeInTheDocument();
-    await expect(
-      JSON.parse(localStorage.getItem(storageKey) ?? "[]"),
-    ).toContain("traces");
-
-    const overflowButton = canvas.getByRole("button", {
-      name: /show \d+ hidden session details/i,
-    });
-    await waitFor(() => expect(overflowButton).toHaveFocus());
-    await userEvent.click(overflowButton);
-    const body = within(canvasElement.ownerDocument.body);
-    const overflowSearchInput = await body.findByRole("textbox", {
-      name: "Search session details",
-    });
-    const showTraceDetail = await body.findByRole("button", {
-      name: "Show trace and span counts in session header",
-    });
-    showTraceDetail.focus();
-    await waitFor(() => expect(showTraceDetail).toBeVisible());
-    await userEvent.click(showTraceDetail);
-
-    await expect(
-      canvas.getByRole("button", {
-        name: "Hide trace and span counts in session header",
-      }),
-    ).toBeInTheDocument();
-    await expect(localStorage.getItem(storageKey)).toBe(JSON.stringify([]));
-    const metadataEditorButton = canvas.getByRole("button", {
-      name: "Add metadata JSONPath",
-    });
-    await waitFor(() =>
-      expect([overflowSearchInput, metadataEditorButton]).toContain(
-        canvasElement.ownerDocument.activeElement,
-      ),
     );
   },
 });

--- a/web/src/features/annotation-queues/components/session/ModernSessionHeader.tsx
+++ b/web/src/features/annotation-queues/components/session/ModernSessionHeader.tsx
@@ -1,15 +1,10 @@
 import { percentile, type ScoreDomain } from "@langfuse/shared";
-import { ArrowUpRight, Eye, EyeOff, Plus, Search, X } from "lucide-react";
-import { type ReactNode, type SyntheticEvent, useRef, useState } from "react";
+import { ArrowUpRight, Plus, Search, X } from "lucide-react";
+import { type ReactNode, type SyntheticEvent, useState } from "react";
 
 import { SingleLineOverflowList } from "@/src/components/SingleLineOverflowList";
 import { ModernSessionHeaderPill } from "@/src/features/annotation-queues/components/session/ModernSessionHeaderPill";
-import {
-  MAX_STORED_HIDDEN_SESSION_HEADER_DETAILS,
-  parseStoredHiddenSessionHeaderDetails,
-  sessionHeaderDynamicDetailKey,
-  sessionHeaderVisibilityStorageKey,
-} from "@/src/features/annotation-queues/components/session/sessionHeaderVisibility";
+import { sessionHeaderDynamicDetailKey } from "@/src/features/annotation-queues/components/session/sessionHeaderVisibility";
 import {
   getMetadataJsonPathLabel,
   resolveMetadataJsonPath,
@@ -28,7 +23,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/src/components/ui/popover";
-import useLocalStorage from "@/src/components/useLocalStorage";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
 import {
@@ -36,7 +30,6 @@ import {
   numberFormatter,
   usdFormatter,
 } from "@/src/utils/numbers";
-import { cn } from "@/src/utils/tailwind";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 type ModernSessionHeaderProps = {
@@ -79,14 +72,9 @@ type SessionHeaderDetailType =
 type SessionHeaderDetail = {
   key: string;
   searchText: string;
-  visibilityLabel: string;
   type: SessionHeaderDetailType;
   content: ReactNode;
 };
-
-type SessionHeaderDetailControlLocation = "header" | "overflow";
-
-const EMPTY_HIDDEN_SESSION_HEADER_DETAILS: readonly string[] = [];
 
 const ChipValue = ({ children }: { children: React.ReactNode }) => (
   <span className="text-foreground">{children}</span>
@@ -122,50 +110,6 @@ const UserChip = ({ projectId, user }: { projectId: string; user: string }) => (
     <ArrowUpRight className="text-link h-3 w-3 shrink-0" />
   </ModernSessionHeaderPill>
 );
-
-const SessionHeaderDetailWithVisibilityControl = ({
-  detail,
-  isHidden,
-  location,
-  onVisibilityChange,
-}: {
-  detail: SessionHeaderDetail;
-  isHidden: boolean;
-  location: SessionHeaderDetailControlLocation;
-  onVisibilityChange: (
-    detail: SessionHeaderDetail,
-    isHidden: boolean,
-    location: SessionHeaderDetailControlLocation,
-    control: HTMLButtonElement,
-  ) => void;
-}) => {
-  const action = isHidden ? "Show" : "Hide";
-  return (
-    <span
-      className={cn(
-        "group relative flex items-center",
-        detail.type === "metadata" ? "pr-6" : "[@media(hover:none)]:pr-6",
-      )}
-    >
-      {detail.content}
-      <button
-        type="button"
-        aria-label={`${action} ${detail.visibilityLabel} in session header`}
-        title={`${action} in session header`}
-        className="bg-header hover:bg-muted focus-visible:ring-ring absolute right-0 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-sm border opacity-0 shadow-sm transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:ring-1 focus-visible:outline-none [@media(hover:none)]:opacity-100"
-        onClick={(event) =>
-          onVisibilityChange(detail, !isHidden, location, event.currentTarget)
-        }
-      >
-        {isHidden ? (
-          <Eye aria-hidden="true" className="h-3 w-3" />
-        ) : (
-          <EyeOff aria-hidden="true" className="h-3 w-3" />
-        )}
-      </button>
-    </span>
-  );
-};
 
 const resolveAgainstSource = (
   source: FirstVisibleObservationMetadataState,
@@ -345,17 +289,6 @@ export function ModernSessionHeader({
   scores,
 }: ModernSessionHeaderProps) {
   const capture = usePostHogClientCapture();
-  const [rawHiddenDetailKeys, setRawHiddenDetailKeys] =
-    useLocalStorage<unknown>(
-      sessionHeaderVisibilityStorageKey(projectId),
-      EMPTY_HIDDEN_SESSION_HEADER_DETAILS,
-    );
-  const hiddenDetailKeys =
-    parseStoredHiddenSessionHeaderDetails(rawHiddenDetailKeys);
-  const hiddenDetailKeySet = new Set(hiddenDetailKeys);
-  const overflowButtonRef = useRef<HTMLButtonElement>(null);
-  const metadataEditorButtonRef = useRef<HTMLButtonElement>(null);
-  const overflowSearchInputRef = useRef<HTMLInputElement>(null);
   const [search, setSearch] = useState("");
   const [visibleUserCount, setVisibleUserCount] = useState(
     SESSION_USERS_PER_PAGE,
@@ -400,7 +333,6 @@ export function ModernSessionHeader({
     {
       key: "traces",
       searchText: `traces ${countTraces} spans ${spanCount ?? ""}`,
-      visibilityLabel: "trace and span counts",
       type: "traces",
       content: (
         <ModernSessionHeaderPill variant="display">
@@ -424,7 +356,6 @@ export function ModernSessionHeader({
     pills.push({
       key: "latency",
       searchText: `latency p50 ${p50LatencyMs} p95 ${p95LatencyMs ?? ""}`,
-      visibilityLabel: "latency percentiles",
       type: "latency",
       content: (
         <ModernSessionHeaderPill variant="display">
@@ -453,7 +384,6 @@ export function ModernSessionHeader({
     pills.push({
       key: "tokens",
       searchText: `tokens ${tokensIn} ${tokensOut} ${totalTokens}`,
-      visibilityLabel: "token usage",
       type: "tokens",
       content: (
         <ModernSessionHeaderPill
@@ -476,7 +406,6 @@ export function ModernSessionHeader({
   pills.push({
     key: "cost",
     searchText: `cost ${totalCost}`,
-    visibilityLabel: "cost",
     type: "cost",
     content: (
       <ModernSessionHeaderPill
@@ -490,7 +419,7 @@ export function ModernSessionHeader({
     ),
   });
 
-  scores.forEach((score, index) => {
+  scores.forEach((score) => {
     const value = scoreChipValue(score);
     const isFraction =
       score.dataType === "NUMERIC" &&
@@ -501,7 +430,6 @@ export function ModernSessionHeader({
     pills.push({
       key: sessionHeaderDynamicDetailKey("score", score.id),
       searchText: `score ${score.name} ${value}`,
-      visibilityLabel: `score ${index + 1}`,
       type: "score",
       content: (
         <ModernSessionHeaderPill variant="display" title={score.name}>
@@ -521,7 +449,6 @@ export function ModernSessionHeader({
     pills.push({
       key: "environment",
       searchText: `environment env ${environment}`,
-      visibilityLabel: "environment",
       type: "environment",
       content: (
         <ModernSessionHeaderPill variant="display">
@@ -534,17 +461,17 @@ export function ModernSessionHeader({
   }
 
   const userDetails = users.map(
-    (user, index): SessionHeaderDetail => ({
+    (user): SessionHeaderDetail => ({
       key: sessionHeaderDynamicDetailKey("user", user),
       searchText: `user ${user}`,
-      visibilityLabel: `user ${index + 1}`,
       type: "user",
       content: <UserChip projectId={projectId} user={user} />,
     }),
   );
-  const visibleUserDetails = userDetails
-    .filter((detail) => !hiddenDetailKeySet.has(detail.key))
-    .slice(0, INITIAL_SESSION_USERS_DISPLAY_COUNT);
+  const visibleUserDetails = userDetails.slice(
+    0,
+    INITIAL_SESSION_USERS_DISPLAY_COUNT,
+  );
   visibleUserDetails.forEach((detail) => pills.push(detail));
   const visibleUserDetailKeySet = new Set(
     visibleUserDetails.map((detail) => detail.key),
@@ -553,7 +480,7 @@ export function ModernSessionHeader({
     (detail) => !visibleUserDetailKeySet.has(detail.key),
   );
 
-  metadataJsonPaths.paths.forEach((path, index) => {
+  metadataJsonPaths.paths.forEach((path) => {
     const display = getConfiguredMetadataDisplay(
       path,
       metadataJsonPaths.source,
@@ -561,7 +488,6 @@ export function ModernSessionHeader({
     pills.push({
       key: sessionHeaderDynamicDetailKey("metadata", path),
       searchText: `metadata ${display.path} ${display.label} ${display.displayValue}`,
-      visibilityLabel: `metadata ${index + 1}`,
       type: "metadata",
       content: (
         <MetadataJsonPathPill
@@ -571,68 +497,13 @@ export function ModernSessionHeader({
       ),
     });
   });
-  const visiblePills = pills.filter(
-    (pill) => !hiddenDetailKeySet.has(pill.key),
-  );
-  const manuallyHiddenPills = pills.filter((pill) =>
-    hiddenDetailKeySet.has(pill.key),
-  );
-  const changeDetailVisibility = (
-    detail: SessionHeaderDetail,
-    isHidden: boolean,
-    location: SessionHeaderDetailControlLocation,
-    control: HTMLButtonElement,
-  ) => {
-    if (hiddenDetailKeySet.has(detail.key) === isHidden) return;
-
-    setRawHiddenDetailKeys((current: unknown) => {
-      const currentKeys = parseStoredHiddenSessionHeaderDetails(current);
-      return isHidden
-        ? currentKeys
-            .concat(detail.key)
-            .slice(-MAX_STORED_HIDDEN_SESSION_HEADER_DETAILS)
-        : currentKeys.filter((key) => key !== detail.key);
-    });
-    capture("session_detail:header_detail_visibility_changed", {
-      action: isHidden ? "hide" : "show",
-      detailType: detail.type,
-      storedHiddenDetailCount: Math.min(
-        Math.max(hiddenDetailKeys.length + (isHidden ? 1 : -1), 0),
-        MAX_STORED_HIDDEN_SESSION_HEADER_DETAILS,
-      ),
-      isV4: true,
-    });
-    window.requestAnimationFrame(() => {
-      if (control.isConnected) return;
-
-      const preferredTarget =
-        location === "overflow"
-          ? overflowSearchInputRef.current
-          : overflowButtonRef.current;
-      (
-        preferredTarget ??
-        overflowButtonRef.current ??
-        metadataEditorButtonRef.current
-      )?.focus();
-    });
-  };
-
   return (
     <div className="bg-header border-b px-4 py-2">
       <SingleLineOverflowList
-        items={visiblePills}
-        additionalOverflowCount={
-          overflowUserDetails.length + manuallyHiddenPills.length
-        }
+        items={pills}
+        additionalOverflowCount={overflowUserDetails.length}
         getKey={(pill) => pill.key}
-        renderItem={(pill) => (
-          <SessionHeaderDetailWithVisibilityControl
-            detail={pill}
-            isHidden={false}
-            location="header"
-            onVisibilityChange={changeDetailVisibility}
-          />
-        )}
+        renderItem={(pill) => pill.content}
         trailingContent={
           <Popover
             open={isMetadataEditorOpen}
@@ -642,7 +513,6 @@ export function ModernSessionHeader({
               <ModernSessionHeaderPill
                 variant="button"
                 ariaLabel="Add metadata JSONPath"
-                ref={metadataEditorButtonRef}
               >
                 <Plus className="h-3 w-3" />
               </ModernSessionHeaderPill>
@@ -656,16 +526,8 @@ export function ModernSessionHeader({
             ) : null}
           </Popover>
         }
-        renderOverflow={({ hiddenItems: hiddenPills, overflowItemCount }) => {
+        renderOverflow={({ hiddenItems: overflowPills, overflowItemCount }) => {
           const normalizedSearch = search.trim().toLocaleLowerCase();
-          const overflowPillKeys = new Set(
-            hiddenPills
-              .map((pill) => pill.key)
-              .concat(manuallyHiddenPills.map((pill) => pill.key)),
-          );
-          const overflowPills = pills.filter((pill) =>
-            overflowPillKeys.has(pill.key),
-          );
           const filteredPills = normalizedSearch
             ? overflowPills.filter((pill) =>
                 pill.searchText.toLocaleLowerCase().includes(normalizedSearch),
@@ -693,8 +555,7 @@ export function ModernSessionHeader({
               <PopoverTrigger asChild>
                 <ModernSessionHeaderPill
                   variant="button"
-                  ariaLabel={`Show ${overflowItemCount} hidden session details`}
-                  ref={overflowButtonRef}
+                  ariaLabel={`Show ${overflowItemCount} more session details`}
                 >
                   +{overflowItemCount}
                 </ModernSessionHeaderPill>
@@ -707,7 +568,6 @@ export function ModernSessionHeader({
                 <div className="relative border-b p-2">
                   <Search className="text-muted-foreground absolute top-1/2 left-4 h-3.5 w-3.5 -translate-y-1/2" />
                   <Input
-                    ref={overflowSearchInputRef}
                     value={search}
                     onChange={(event) => {
                       setSearch(event.target.value);
@@ -741,22 +601,14 @@ export function ModernSessionHeader({
                   {hasResults ? (
                     <>
                       {filteredPills.map((pill) => (
-                        <SessionHeaderDetailWithVisibilityControl
-                          key={pill.key}
-                          detail={pill}
-                          isHidden={hiddenDetailKeySet.has(pill.key)}
-                          location="overflow"
-                          onVisibilityChange={changeDetailVisibility}
-                        />
+                        <span key={pill.key} className="flex items-center">
+                          {pill.content}
+                        </span>
                       ))}
                       {visibleUsers.map((detail) => (
-                        <SessionHeaderDetailWithVisibilityControl
-                          key={detail.key}
-                          detail={detail}
-                          isHidden={hiddenDetailKeySet.has(detail.key)}
-                          location="overflow"
-                          onVisibilityChange={changeDetailVisibility}
-                        />
+                        <span key={detail.key} className="flex items-center">
+                          {detail.content}
+                        </span>
                       ))}
                     </>
                   ) : (

--- a/web/src/features/annotation-queues/components/session/sessionHeaderVisibility.ts
+++ b/web/src/features/annotation-queues/components/session/sessionHeaderVisibility.ts
@@ -1,19 +1,3 @@
-import { z } from "zod";
-
-export const MAX_STORED_HIDDEN_SESSION_HEADER_DETAILS = 1_000;
-
-const storedHiddenSessionHeaderDetailsSchema = z
-  .array(z.string().min(1).max(2_000))
-  .max(MAX_STORED_HIDDEN_SESSION_HEADER_DETAILS)
-  .transform((keys) => Array.from(new Set(keys)));
-
-export type StoredHiddenSessionHeaderDetails = z.infer<
-  typeof storedHiddenSessionHeaderDetailsSchema
->;
-
-export const sessionHeaderVisibilityStorageKey = (projectId: string) =>
-  `modern-session:hidden-header-details:v1:${projectId}`;
-
 export const sessionHeaderDynamicDetailKey = (
   type: "metadata" | "score" | "user",
   identity: string,
@@ -26,11 +10,4 @@ export const sessionHeaderDynamicDetailKey = (
     secondFingerprint = Math.imul(secondFingerprint ^ codeUnit, 2_246_822_519);
   }
   return `${type}-${(firstFingerprint >>> 0).toString(36)}-${(secondFingerprint >>> 0).toString(36)}`;
-};
-
-export const parseStoredHiddenSessionHeaderDetails = (
-  raw: unknown,
-): StoredHiddenSessionHeaderDetails => {
-  const result = storedHiddenSessionHeaderDetailsSchema.safeParse(raw);
-  return result.success ? result.data : [];
 };

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -150,7 +150,6 @@ const events = {
     "inline_tools_toggled",
     "system_prompt_toggled",
     "metadata_jsonpath_config_changed",
-    "header_detail_visibility_changed",
   ],
   eval_config: [
     "new_form_submit",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17239 app preview](https://pr-17239.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

| Change | Detail |
|---|---|
| Chips render bare | Removed the per-chip hide affordance from the session header; every detail chip always renders, no per-chip toggle |
| Hidden-details half of the "+N" popover removed | The overflow popover no longer offers a hide/show-hidden view; it only handles overflow, not visibility |
| localStorage preference removed | Dropped the `modern-session:hidden-header-details:v1:<projectId>` stored preference and its parsing/schema (`sessionHeaderVisibility.ts`) |
| Analytics event removed | Dropped the now-unused `header_detail_visibility_changed` event from the capture registry |

## How to test

Preview: https://pr-17239.preview.langfuse.com
1. Open any session page.
2. Confirm every detail chip in the header renders without a per-chip hide control, and the "+N" overflow popover only shows overflowed chips (no hide/show-hidden section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62039407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The behavioral change appears safe to merge, with a non-blocking cleanup concern for legacy localStorage preferences.

<details><summary><h3>Summary</h3></summary>

- Removes hidden-detail state, parsing, persistence, and visibility-change analytics.
- Renders session detail chips directly without hide/show controls.
- Updates client tests and Storybook interactions for the new overflow behavior.
- Leaves previously stored visibility preferences orphaned unless a one-time cleanup is added.
</details>

<!-- /greptile_comment -->