### PR TITLE
refactor(web): thin auth/sign-in into SignInPage

### DIFF
--- a/web/src/__tests__/auth-sign-in-page.clienttest.tsx
+++ b/web/src/__tests__/auth-sign-in-page.clienttest.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import SignIn, { type PageProps } from "@/src/features/auth/SignInPage";
+import SignInPage, { type PageProps } from "@/src/features/auth/SignInPage";
 
 const { captureExceptionMock, addBreadcrumbMock, signInMock, routerState } =
   vi.hoisted(() => ({
@@ -81,7 +81,7 @@ const renderSignIn = (
   } = {},
 ) =>
   render(
-    <SignIn
+    <SignInPage
       authProviders={authProviders}
       signUpDisabled={false}
       runningOnHuggingFaceSpaces={false}

--- a/web/src/__tests__/auth-sign-in-page.clienttest.tsx
+++ b/web/src/__tests__/auth-sign-in-page.clienttest.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import SignIn, { type PageProps } from "@/src/pages/auth/sign-in";
+import SignIn, { type PageProps } from "@/src/features/auth/SignInPage";
 
 const { captureExceptionMock, addBreadcrumbMock, signInMock, routerState } =
   vi.hoisted(() => ({

--- a/web/src/features/auth/SignInPage.tsx
+++ b/web/src/features/auth/SignInPage.tsx
@@ -273,281 +273,285 @@ export function SSOButtons({
   const showSeparator = authProviders.credentials || action !== "sign in";
 
   return (
-    // any authprovider from props is enabled
-    Object.entries(authProviders).some(
-      ([name, enabled]) => enabled && name !== "credentials",
-    ) ? (
-      <div>
-        {showSeparator ? (
-          action === "sign in" ? (
-            <div className="border-border my-6 border-t"></div>
-          ) : (
-            <div className="text-muted-foreground my-6 text-center text-xs">
-              or {action} with
-            </div>
-          )
-        ) : null}
-        <div className="flex flex-row flex-wrap items-center justify-center gap-2">
-          {authProviders.google && (
-            <AuthProviderButton
-              icon={<SiGoogle className="mr-3" size={18} />}
-              label="Google"
-              onClick={() => handleSignIn("google")}
-              loading={providerSigningIn === "google"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "google"
-              }
-            />
-          )}
-          {authProviders.github && (
-            <AuthProviderButton
-              icon={<SiGithub className="mr-3" size={18} />}
-              label="GitHub"
-              onClick={() => handleSignIn("github")}
-              loading={providerSigningIn === "github"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "github"
-              }
-            />
-          )}
-          {authProviders.githubEnterprise && (
-            <AuthProviderButton
-              icon={<SiGithub className="mr-3" size={18} />}
-              label="GitHub Enterprise"
-              onClick={() => handleSignIn("github-enterprise")}
-              loading={providerSigningIn === "github-enterprise"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "github-enterprise"
-              }
-            />
-          )}
-          {authProviders.gitlab && (
-            <AuthProviderButton
-              icon={<SiGitlab className="mr-3" size={18} />}
-              label="Gitlab"
-              onClick={() => handleSignIn("gitlab")}
-              loading={providerSigningIn === "gitlab"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "gitlab"
-              }
-            />
-          )}
-          {authProviders.azureAd && (
-            <AuthProviderButton
-              icon={<TbBrandAzure className="mr-3" size={18} />}
-              label="Azure AD"
-              onClick={() => handleSignIn("azure-ad")}
-              loading={providerSigningIn === "azure-ad"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "azure-ad"
-              }
-            />
-          )}
-          {authProviders.okta && (
-            <AuthProviderButton
-              icon={<SiOkta className="mr-3" size={18} />}
-              label="Okta"
-              onClick={() => handleSignIn("okta")}
-              loading={providerSigningIn === "okta"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "okta"
-              }
-            />
-          )}
-          {authProviders.authentik && (
-            <AuthProviderButton
-              icon={<SiAuthentik className="mr-3" size={18} />}
-              label="Authentik"
-              onClick={() => handleSignIn("authentik")}
-              loading={providerSigningIn === "authentik"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "authentik"
-              }
-            />
-          )}
-          {authProviders.onelogin && (
-            <AuthProviderButton
-              icon={<Key className="mr-3" size={18} />}
-              label="OneLogin"
-              onClick={() => handleSignIn("onelogin")}
-              loading={providerSigningIn === "onelogin"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "onelogin"
-              }
-            />
-          )}
-          {authProviders.auth0 && (
-            <AuthProviderButton
-              icon={<SiAuth0 className="mr-3" size={18} />}
-              label="Auth0"
-              onClick={() => handleSignIn("auth0")}
-              loading={providerSigningIn === "auth0"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "auth0"
-              }
-            />
-          )}
-          {authProviders.clickhouseCloud && (
-            <AuthProviderButton
-              icon={<SiClickhouse className="mr-3" size={18} />}
-              label="ClickHouse Cloud"
-              onClick={() => handleSignIn("clickhouse-cloud")}
-              loading={providerSigningIn === "clickhouse-cloud"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "clickhouse-cloud"
-              }
-            />
-          )}
-          {authProviders.cognito && (
-            <AuthProviderButton
-              icon={<SiAmazoncognito className="mr-3" size={18} />}
-              label="Cognito"
-              onClick={() => handleSignIn("cognito")}
-              loading={providerSigningIn === "cognito"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "cognito"
-              }
-            />
-          )}
-          {authProviders.jumpcloud && (
-            <AuthProviderButton
-              icon={<TbBrandOauth className="mr-3" size={18} />}
-              label="JumpCloud"
-              onClick={() => handleSignIn("jumpcloud")}
-              loading={providerSigningIn === "jumpcloud"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "jumpcloud"
-              }
-            />
-          )}
-          {authProviders.keycloak && (
-            <AuthProviderButton
-              icon={<SiKeycloak className="mr-3" size={18} />}
-              label={
-                typeof authProviders.keycloak === "object"
-                  ? authProviders.keycloak.name
-                  : "Keycloak"
-              }
-              onClick={() => {
-                capture("sign_in:button_click", { provider: "keycloak" });
-                onProviderSelect?.("keycloak");
-                signIn("keycloak");
-              }}
-              loading={providerSigningIn === "keycloak"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "keycloak"
-              }
-            />
-          )}
-          {typeof authProviders.workos === "object" &&
-            "connectionId" in authProviders.workos && (
+    <>
+      {/* any authprovider from props is enabled */}
+      {Object.entries(authProviders).some(
+        ([name, enabled]) => enabled && name !== "credentials",
+      ) ? (
+        <div>
+          {showSeparator ? (
+            action === "sign in" ? (
+              <div className="border-border my-6 border-t"></div>
+            ) : (
+              <div className="text-muted-foreground my-6 text-center text-xs">
+                or {action} with
+              </div>
+            )
+          ) : null}
+          <div className="flex flex-row flex-wrap items-center justify-center gap-2">
+            {authProviders.google && (
               <AuthProviderButton
-                icon={<Code className="mr-3" size={18} />}
-                label="WorkOS"
-                onClick={() => {
-                  capture("sign_in:button_click", { provider: "workos" });
-                  onProviderSelect?.("workos");
-                  signIn("workos", undefined, {
-                    connection: (
-                      authProviders.workos as { connectionId: string }
-                    ).connectionId,
-                  });
-                }}
-                loading={providerSigningIn === "workos"}
+                icon={<SiGoogle className="mr-3" size={18} />}
+                label="Google"
+                onClick={() => handleSignIn("google")}
+                loading={providerSigningIn === "google"}
                 showLastUsedBadge={
-                  hasMultipleAuthMethods && lastUsedMethod === "workos"
+                  hasMultipleAuthMethods && lastUsedMethod === "google"
                 }
               />
             )}
-          {typeof authProviders.workos === "object" &&
-            "organizationId" in authProviders.workos && (
+            {authProviders.github && (
               <AuthProviderButton
-                icon={<Code className="mr-3" size={18} />}
-                label="WorkOS"
-                onClick={() => {
-                  capture("sign_in:button_click", { provider: "workos" });
-                  onProviderSelect?.("workos");
-                  signIn("workos", undefined, {
-                    organization: (
-                      authProviders.workos as { organizationId: string }
-                    ).organizationId,
-                  });
-                }}
-                loading={providerSigningIn === "workos"}
+                icon={<SiGithub className="mr-3" size={18} />}
+                label="GitHub"
+                onClick={() => handleSignIn("github")}
+                loading={providerSigningIn === "github"}
                 showLastUsedBadge={
-                  hasMultipleAuthMethods && lastUsedMethod === "workos"
+                  hasMultipleAuthMethods && lastUsedMethod === "github"
                 }
               />
             )}
-          {authProviders.workos === true && (
-            <>
+            {authProviders.githubEnterprise && (
               <AuthProviderButton
-                icon={<Code className="mr-3" size={18} />}
-                label="WorkOS (organization)"
+                icon={<SiGithub className="mr-3" size={18} />}
+                label="GitHub Enterprise"
+                onClick={() => handleSignIn("github-enterprise")}
+                loading={providerSigningIn === "github-enterprise"}
+                showLastUsedBadge={
+                  hasMultipleAuthMethods &&
+                  lastUsedMethod === "github-enterprise"
+                }
+              />
+            )}
+            {authProviders.gitlab && (
+              <AuthProviderButton
+                icon={<SiGitlab className="mr-3" size={18} />}
+                label="Gitlab"
+                onClick={() => handleSignIn("gitlab")}
+                loading={providerSigningIn === "gitlab"}
+                showLastUsedBadge={
+                  hasMultipleAuthMethods && lastUsedMethod === "gitlab"
+                }
+              />
+            )}
+            {authProviders.azureAd && (
+              <AuthProviderButton
+                icon={<TbBrandAzure className="mr-3" size={18} />}
+                label="Azure AD"
+                onClick={() => handleSignIn("azure-ad")}
+                loading={providerSigningIn === "azure-ad"}
+                showLastUsedBadge={
+                  hasMultipleAuthMethods && lastUsedMethod === "azure-ad"
+                }
+              />
+            )}
+            {authProviders.okta && (
+              <AuthProviderButton
+                icon={<SiOkta className="mr-3" size={18} />}
+                label="Okta"
+                onClick={() => handleSignIn("okta")}
+                loading={providerSigningIn === "okta"}
+                showLastUsedBadge={
+                  hasMultipleAuthMethods && lastUsedMethod === "okta"
+                }
+              />
+            )}
+            {authProviders.authentik && (
+              <AuthProviderButton
+                icon={<SiAuthentik className="mr-3" size={18} />}
+                label="Authentik"
+                onClick={() => handleSignIn("authentik")}
+                loading={providerSigningIn === "authentik"}
+                showLastUsedBadge={
+                  hasMultipleAuthMethods && lastUsedMethod === "authentik"
+                }
+              />
+            )}
+            {authProviders.onelogin && (
+              <AuthProviderButton
+                icon={<Key className="mr-3" size={18} />}
+                label="OneLogin"
+                onClick={() => handleSignIn("onelogin")}
+                loading={providerSigningIn === "onelogin"}
+                showLastUsedBadge={
+                  hasMultipleAuthMethods && lastUsedMethod === "onelogin"
+                }
+              />
+            )}
+            {authProviders.auth0 && (
+              <AuthProviderButton
+                icon={<SiAuth0 className="mr-3" size={18} />}
+                label="Auth0"
+                onClick={() => handleSignIn("auth0")}
+                loading={providerSigningIn === "auth0"}
+                showLastUsedBadge={
+                  hasMultipleAuthMethods && lastUsedMethod === "auth0"
+                }
+              />
+            )}
+            {authProviders.clickhouseCloud && (
+              <AuthProviderButton
+                icon={<SiClickhouse className="mr-3" size={18} />}
+                label="ClickHouse Cloud"
+                onClick={() => handleSignIn("clickhouse-cloud")}
+                loading={providerSigningIn === "clickhouse-cloud"}
+                showLastUsedBadge={
+                  hasMultipleAuthMethods &&
+                  lastUsedMethod === "clickhouse-cloud"
+                }
+              />
+            )}
+            {authProviders.cognito && (
+              <AuthProviderButton
+                icon={<SiAmazoncognito className="mr-3" size={18} />}
+                label="Cognito"
+                onClick={() => handleSignIn("cognito")}
+                loading={providerSigningIn === "cognito"}
+                showLastUsedBadge={
+                  hasMultipleAuthMethods && lastUsedMethod === "cognito"
+                }
+              />
+            )}
+            {authProviders.jumpcloud && (
+              <AuthProviderButton
+                icon={<TbBrandOauth className="mr-3" size={18} />}
+                label="JumpCloud"
+                onClick={() => handleSignIn("jumpcloud")}
+                loading={providerSigningIn === "jumpcloud"}
+                showLastUsedBadge={
+                  hasMultipleAuthMethods && lastUsedMethod === "jumpcloud"
+                }
+              />
+            )}
+            {authProviders.keycloak && (
+              <AuthProviderButton
+                icon={<SiKeycloak className="mr-3" size={18} />}
+                label={
+                  typeof authProviders.keycloak === "object"
+                    ? authProviders.keycloak.name
+                    : "Keycloak"
+                }
                 onClick={() => {
-                  const organization = window.prompt(
-                    "Please enter your organization ID",
-                  );
-                  if (organization) {
+                  capture("sign_in:button_click", { provider: "keycloak" });
+                  onProviderSelect?.("keycloak");
+                  signIn("keycloak");
+                }}
+                loading={providerSigningIn === "keycloak"}
+                showLastUsedBadge={
+                  hasMultipleAuthMethods && lastUsedMethod === "keycloak"
+                }
+              />
+            )}
+            {typeof authProviders.workos === "object" &&
+              "connectionId" in authProviders.workos && (
+                <AuthProviderButton
+                  icon={<Code className="mr-3" size={18} />}
+                  label="WorkOS"
+                  onClick={() => {
                     capture("sign_in:button_click", { provider: "workos" });
                     onProviderSelect?.("workos");
                     signIn("workos", undefined, {
-                      organization,
+                      connection: (
+                        authProviders.workos as { connectionId: string }
+                      ).connectionId,
                     });
+                  }}
+                  loading={providerSigningIn === "workos"}
+                  showLastUsedBadge={
+                    hasMultipleAuthMethods && lastUsedMethod === "workos"
                   }
-                }}
-                loading={providerSigningIn === "workos"}
-                showLastUsedBadge={
-                  hasMultipleAuthMethods && lastUsedMethod === "workos"
-                }
-              />
-              <AuthProviderButton
-                icon={<Code className="mr-3" size={18} />}
-                label="WorkOS (connection)"
-                onClick={() => {
-                  const connection = window.prompt(
-                    "Please enter your connection ID",
-                  );
-                  if (connection) {
+                />
+              )}
+            {typeof authProviders.workos === "object" &&
+              "organizationId" in authProviders.workos && (
+                <AuthProviderButton
+                  icon={<Code className="mr-3" size={18} />}
+                  label="WorkOS"
+                  onClick={() => {
                     capture("sign_in:button_click", { provider: "workos" });
                     onProviderSelect?.("workos");
                     signIn("workos", undefined, {
-                      connection,
+                      organization: (
+                        authProviders.workos as { organizationId: string }
+                      ).organizationId,
                     });
+                  }}
+                  loading={providerSigningIn === "workos"}
+                  showLastUsedBadge={
+                    hasMultipleAuthMethods && lastUsedMethod === "workos"
                   }
-                }}
-                loading={providerSigningIn === "workos"}
+                />
+              )}
+            {authProviders.workos === true && (
+              <>
+                <AuthProviderButton
+                  icon={<Code className="mr-3" size={18} />}
+                  label="WorkOS (organization)"
+                  onClick={() => {
+                    const organization = window.prompt(
+                      "Please enter your organization ID",
+                    );
+                    if (organization) {
+                      capture("sign_in:button_click", { provider: "workos" });
+                      onProviderSelect?.("workos");
+                      signIn("workos", undefined, {
+                        organization,
+                      });
+                    }
+                  }}
+                  loading={providerSigningIn === "workos"}
+                  showLastUsedBadge={
+                    hasMultipleAuthMethods && lastUsedMethod === "workos"
+                  }
+                />
+                <AuthProviderButton
+                  icon={<Code className="mr-3" size={18} />}
+                  label="WorkOS (connection)"
+                  onClick={() => {
+                    const connection = window.prompt(
+                      "Please enter your connection ID",
+                    );
+                    if (connection) {
+                      capture("sign_in:button_click", { provider: "workos" });
+                      onProviderSelect?.("workos");
+                      signIn("workos", undefined, {
+                        connection,
+                      });
+                    }
+                  }}
+                  loading={providerSigningIn === "workos"}
+                  showLastUsedBadge={
+                    hasMultipleAuthMethods && lastUsedMethod === "workos"
+                  }
+                />
+              </>
+            )}
+            {authProviders.wordpress && (
+              <AuthProviderButton
+                icon={<SiWordpress className="mr-3" size={18} />}
+                label="WordPress"
+                onClick={() => handleSignIn("wordpress")}
+                loading={providerSigningIn === "wordpress"}
                 showLastUsedBadge={
-                  hasMultipleAuthMethods && lastUsedMethod === "workos"
+                  hasMultipleAuthMethods && lastUsedMethod === "wordpress"
                 }
               />
-            </>
-          )}
-          {authProviders.wordpress && (
-            <AuthProviderButton
-              icon={<SiWordpress className="mr-3" size={18} />}
-              label="WordPress"
-              onClick={() => handleSignIn("wordpress")}
-              loading={providerSigningIn === "wordpress"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "wordpress"
-              }
-            />
-          )}
-          {authProviders.custom && (
-            <AuthProviderButton
-              icon={<TbBrandOauth className="mr-3" size={18} />}
-              label={authProviders.custom.name}
-              onClick={() => handleSignIn("custom")}
-              loading={providerSigningIn === "custom"}
-              showLastUsedBadge={
-                hasMultipleAuthMethods && lastUsedMethod === "custom"
-              }
-            />
-          )}
+            )}
+            {authProviders.custom && (
+              <AuthProviderButton
+                icon={<TbBrandOauth className="mr-3" size={18} />}
+                label={authProviders.custom.name}
+                onClick={() => handleSignIn("custom")}
+                loading={providerSigningIn === "custom"}
+                showLastUsedBadge={
+                  hasMultipleAuthMethods && lastUsedMethod === "custom"
+                }
+              />
+            )}
+          </div>
         </div>
-      </div>
-    ) : null
+      ) : null}
+    </>
   );
 }
 

--- a/web/src/features/auth/SignInPage.tsx
+++ b/web/src/features/auth/SignInPage.tsx
@@ -590,7 +590,7 @@ const signInErrors = [
   },
 ];
 
-export default function SignIn({
+export default function SignInPage({
   authProviders = FALLBACK_AUTH_PROVIDERS,
   signUpDisabled,
   runningOnHuggingFaceSpaces,

--- a/web/src/features/auth/SignInPage.tsx
+++ b/web/src/features/auth/SignInPage.tsx
@@ -1,4 +1,3 @@
-import { type GetServerSideProps } from "next";
 import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import { Button } from "@/src/components/ui/button";
 import {
@@ -34,8 +33,6 @@ import * as z from "zod";
 import { CloudPrivacyNotice } from "@/src/features/auth/components/AuthCloudPrivacyNotice";
 import { CloudRegionSwitch } from "@/src/features/auth/components/AuthCloudRegionSwitch";
 import { PasswordInput } from "@/src/components/design-system/PasswordInput/PasswordInput";
-import { isAnySsoConfigured } from "@/src/ee/features/multi-tenant-sso/utils";
-import { isEmailVerificationRequired } from "@/src/features/auth-credentials/lib/credentialsUtils";
 import { Code, Key } from "lucide-react";
 import { useRouter } from "next/router";
 import { reportError } from "@/src/utils/reportError";
@@ -107,100 +104,6 @@ export type PageProps = {
   runningOnHuggingFaceSpaces: boolean;
   signUpDisabled: boolean;
   emailVerificationRequired: boolean;
-};
-
-// Also used in src/pages/auth/sign-up.tsx
-
-export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
-  const sso: boolean = await isAnySsoConfigured();
-  return {
-    props: {
-      authProviders: {
-        google:
-          env.AUTH_GOOGLE_CLIENT_ID !== undefined &&
-          env.AUTH_GOOGLE_CLIENT_SECRET !== undefined,
-        github:
-          env.AUTH_GITHUB_CLIENT_ID !== undefined &&
-          env.AUTH_GITHUB_CLIENT_SECRET !== undefined,
-        githubEnterprise:
-          env.AUTH_GITHUB_ENTERPRISE_CLIENT_ID !== undefined &&
-          env.AUTH_GITHUB_ENTERPRISE_CLIENT_SECRET !== undefined &&
-          env.AUTH_GITHUB_ENTERPRISE_BASE_URL !== undefined,
-        gitlab:
-          env.AUTH_GITLAB_CLIENT_ID !== undefined &&
-          env.AUTH_GITLAB_CLIENT_SECRET !== undefined,
-        okta:
-          env.AUTH_OKTA_CLIENT_ID !== undefined &&
-          env.AUTH_OKTA_CLIENT_SECRET !== undefined &&
-          env.AUTH_OKTA_ISSUER !== undefined,
-        authentik:
-          env.AUTH_AUTHENTIK_CLIENT_ID !== undefined &&
-          env.AUTH_AUTHENTIK_CLIENT_SECRET !== undefined &&
-          env.AUTH_AUTHENTIK_ISSUER !== undefined,
-        onelogin:
-          env.AUTH_ONELOGIN_CLIENT_ID !== undefined &&
-          env.AUTH_ONELOGIN_CLIENT_SECRET !== undefined &&
-          env.AUTH_ONELOGIN_ISSUER !== undefined,
-        credentials: env.AUTH_DISABLE_USERNAME_PASSWORD !== "true",
-        azureAd:
-          env.AUTH_AZURE_AD_CLIENT_ID !== undefined &&
-          env.AUTH_AZURE_AD_CLIENT_SECRET !== undefined &&
-          env.AUTH_AZURE_AD_TENANT_ID !== undefined,
-        auth0:
-          env.AUTH_AUTH0_CLIENT_ID !== undefined &&
-          env.AUTH_AUTH0_CLIENT_SECRET !== undefined &&
-          env.AUTH_AUTH0_ISSUER !== undefined,
-        // Langfuse Cloud only — NOT for self-hosted Langfuse
-        clickhouseCloud:
-          env.AUTH_CLICKHOUSE_CLOUD_CLIENT_ID !== undefined &&
-          env.AUTH_CLICKHOUSE_CLOUD_CLIENT_SECRET !== undefined &&
-          env.AUTH_CLICKHOUSE_CLOUD_ISSUER !== undefined &&
-          env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined,
-        cognito:
-          env.AUTH_COGNITO_CLIENT_ID !== undefined &&
-          env.AUTH_COGNITO_CLIENT_SECRET !== undefined &&
-          env.AUTH_COGNITO_ISSUER !== undefined,
-        jumpcloud:
-          env.AUTH_JUMPCLOUD_CLIENT_ID !== undefined &&
-          env.AUTH_JUMPCLOUD_CLIENT_SECRET !== undefined &&
-          env.AUTH_JUMPCLOUD_ISSUER !== undefined,
-        keycloak:
-          env.AUTH_KEYCLOAK_CLIENT_ID !== undefined &&
-          env.AUTH_KEYCLOAK_CLIENT_SECRET !== undefined &&
-          env.AUTH_KEYCLOAK_ISSUER !== undefined
-            ? env.AUTH_KEYCLOAK_NAME !== undefined
-              ? { name: env.AUTH_KEYCLOAK_NAME }
-              : true
-            : false,
-        workos:
-          env.AUTH_WORKOS_CLIENT_ID !== undefined &&
-          env.AUTH_WORKOS_CLIENT_SECRET !== undefined
-            ? env.AUTH_WORKOS_ORGANIZATION_ID !== undefined
-              ? { organizationId: env.AUTH_WORKOS_ORGANIZATION_ID }
-              : env.AUTH_WORKOS_CONNECTION_ID !== undefined
-                ? { connectionId: env.AUTH_WORKOS_CONNECTION_ID }
-                : true
-            : false,
-        wordpress:
-          env.AUTH_WORDPRESS_CLIENT_ID !== undefined &&
-          env.AUTH_WORDPRESS_CLIENT_SECRET !== undefined,
-        custom:
-          env.AUTH_CUSTOM_CLIENT_ID !== undefined &&
-          env.AUTH_CUSTOM_CLIENT_SECRET !== undefined &&
-          env.AUTH_CUSTOM_ISSUER !== undefined &&
-          env.AUTH_CUSTOM_NAME !== undefined
-            ? { name: env.AUTH_CUSTOM_NAME }
-            : false,
-        sso,
-      },
-      signUpDisabled: env.AUTH_DISABLE_SIGNUP === "true",
-      emailVerificationRequired: isEmailVerificationRequired(),
-      runningOnHuggingFaceSpaces: env.NEXTAUTH_URL?.replace(
-        "/api/auth",
-        "",
-      ).endsWith(".hf.space"),
-    },
-  };
 };
 
 // A client-side navigation whose props fetch fails (e.g. deploy skew) can

--- a/web/src/features/auth/server/getSignInPageServerSideProps.ts
+++ b/web/src/features/auth/server/getSignInPageServerSideProps.ts
@@ -1,0 +1,98 @@
+import { type GetServerSideProps } from "next";
+import { env } from "@/src/env.mjs";
+import { isAnySsoConfigured } from "@/src/ee/features/multi-tenant-sso/utils";
+import { isEmailVerificationRequired } from "@/src/features/auth-credentials/lib/credentialsUtils";
+import { type PageProps } from "@/src/features/auth/SignInPage";
+
+// Also used in src/pages/auth/sign-up.tsx via the pages/auth/sign-in shim.
+export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
+  const sso: boolean = await isAnySsoConfigured();
+  return {
+    props: {
+      authProviders: {
+        google:
+          env.AUTH_GOOGLE_CLIENT_ID !== undefined &&
+          env.AUTH_GOOGLE_CLIENT_SECRET !== undefined,
+        github:
+          env.AUTH_GITHUB_CLIENT_ID !== undefined &&
+          env.AUTH_GITHUB_CLIENT_SECRET !== undefined,
+        githubEnterprise:
+          env.AUTH_GITHUB_ENTERPRISE_CLIENT_ID !== undefined &&
+          env.AUTH_GITHUB_ENTERPRISE_CLIENT_SECRET !== undefined &&
+          env.AUTH_GITHUB_ENTERPRISE_BASE_URL !== undefined,
+        gitlab:
+          env.AUTH_GITLAB_CLIENT_ID !== undefined &&
+          env.AUTH_GITLAB_CLIENT_SECRET !== undefined,
+        okta:
+          env.AUTH_OKTA_CLIENT_ID !== undefined &&
+          env.AUTH_OKTA_CLIENT_SECRET !== undefined &&
+          env.AUTH_OKTA_ISSUER !== undefined,
+        authentik:
+          env.AUTH_AUTHENTIK_CLIENT_ID !== undefined &&
+          env.AUTH_AUTHENTIK_CLIENT_SECRET !== undefined &&
+          env.AUTH_AUTHENTIK_ISSUER !== undefined,
+        onelogin:
+          env.AUTH_ONELOGIN_CLIENT_ID !== undefined &&
+          env.AUTH_ONELOGIN_CLIENT_SECRET !== undefined &&
+          env.AUTH_ONELOGIN_ISSUER !== undefined,
+        credentials: env.AUTH_DISABLE_USERNAME_PASSWORD !== "true",
+        azureAd:
+          env.AUTH_AZURE_AD_CLIENT_ID !== undefined &&
+          env.AUTH_AZURE_AD_CLIENT_SECRET !== undefined &&
+          env.AUTH_AZURE_AD_TENANT_ID !== undefined,
+        auth0:
+          env.AUTH_AUTH0_CLIENT_ID !== undefined &&
+          env.AUTH_AUTH0_CLIENT_SECRET !== undefined &&
+          env.AUTH_AUTH0_ISSUER !== undefined,
+        // Langfuse Cloud only — NOT for self-hosted Langfuse
+        clickhouseCloud:
+          env.AUTH_CLICKHOUSE_CLOUD_CLIENT_ID !== undefined &&
+          env.AUTH_CLICKHOUSE_CLOUD_CLIENT_SECRET !== undefined &&
+          env.AUTH_CLICKHOUSE_CLOUD_ISSUER !== undefined &&
+          env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined,
+        cognito:
+          env.AUTH_COGNITO_CLIENT_ID !== undefined &&
+          env.AUTH_COGNITO_CLIENT_SECRET !== undefined &&
+          env.AUTH_COGNITO_ISSUER !== undefined,
+        jumpcloud:
+          env.AUTH_JUMPCLOUD_CLIENT_ID !== undefined &&
+          env.AUTH_JUMPCLOUD_CLIENT_SECRET !== undefined &&
+          env.AUTH_JUMPCLOUD_ISSUER !== undefined,
+        keycloak:
+          env.AUTH_KEYCLOAK_CLIENT_ID !== undefined &&
+          env.AUTH_KEYCLOAK_CLIENT_SECRET !== undefined &&
+          env.AUTH_KEYCLOAK_ISSUER !== undefined
+            ? env.AUTH_KEYCLOAK_NAME !== undefined
+              ? { name: env.AUTH_KEYCLOAK_NAME }
+              : true
+            : false,
+        workos:
+          env.AUTH_WORKOS_CLIENT_ID !== undefined &&
+          env.AUTH_WORKOS_CLIENT_SECRET !== undefined
+            ? env.AUTH_WORKOS_ORGANIZATION_ID !== undefined
+              ? { organizationId: env.AUTH_WORKOS_ORGANIZATION_ID }
+              : env.AUTH_WORKOS_CONNECTION_ID !== undefined
+                ? { connectionId: env.AUTH_WORKOS_CONNECTION_ID }
+                : true
+            : false,
+        wordpress:
+          env.AUTH_WORDPRESS_CLIENT_ID !== undefined &&
+          env.AUTH_WORDPRESS_CLIENT_SECRET !== undefined,
+        custom:
+          env.AUTH_CUSTOM_CLIENT_ID !== undefined &&
+          env.AUTH_CUSTOM_CLIENT_SECRET !== undefined &&
+          env.AUTH_CUSTOM_ISSUER !== undefined &&
+          env.AUTH_CUSTOM_NAME !== undefined
+            ? { name: env.AUTH_CUSTOM_NAME }
+            : false,
+        sso,
+      },
+      signUpDisabled: env.AUTH_DISABLE_SIGNUP === "true",
+      emailVerificationRequired: isEmailVerificationRequired(),
+      runningOnHuggingFaceSpaces: env.NEXTAUTH_URL?.replace(
+        "/api/auth",
+        "",
+      ).endsWith(".hf.space"),
+    },
+  };
+};

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -1,8 +1,8 @@
 export {
   default,
-  getServerSideProps,
   SSOButtons,
   useHuggingFaceRedirect,
   FALLBACK_AUTH_PROVIDERS,
   type PageProps,
 } from "@/src/features/auth/SignInPage";
+export { getServerSideProps } from "@/src/features/auth/server/getSignInPageServerSideProps";

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -1,0 +1,8 @@
+export {
+  default,
+  getServerSideProps,
+  SSOButtons,
+  useHuggingFaceRedirect,
+  FALLBACK_AUTH_PROVIDERS,
+  type PageProps,
+} from "@/src/features/auth/SignInPage";

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -25,7 +25,7 @@ import {
   SSOButtons,
   useHuggingFaceRedirect,
   type PageProps,
-} from "@/src/features/auth/SignInPage";
+} from "@/src/pages/auth/sign-in";
 import { PasswordInput } from "@/src/components/design-system/PasswordInput/PasswordInput";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useRouter } from "next/router";
@@ -38,7 +38,7 @@ import { noUrlCheck, StringNoHTMLNonEmpty } from "@langfuse/shared";
 import { PASSWORD_SETUP_EMAIL_STORAGE_KEY } from "@/src/features/auth-credentials/lib/credentialsUtils";
 
 // Use the same getServerSideProps function as src/features/auth/SignInPage.tsx
-export { getServerSideProps } from "@/src/features/auth/SignInPage";
+export { getServerSideProps } from "@/src/pages/auth/sign-in";
 
 type NextAuthProvider = NonNullable<Parameters<typeof signIn>[0]>;
 

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -25,7 +25,7 @@ import {
   SSOButtons,
   useHuggingFaceRedirect,
   type PageProps,
-} from "@/src/pages/auth/sign-in";
+} from "@/src/features/auth/SignInPage";
 import { PasswordInput } from "@/src/components/design-system/PasswordInput/PasswordInput";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useRouter } from "next/router";
@@ -37,8 +37,8 @@ import useLocalStorage from "@/src/components/useLocalStorage";
 import { noUrlCheck, StringNoHTMLNonEmpty } from "@langfuse/shared";
 import { PASSWORD_SETUP_EMAIL_STORAGE_KEY } from "@/src/features/auth-credentials/lib/credentialsUtils";
 
-// Use the same getServerSideProps function as src/pages/auth/sign-in.tsx
-export { getServerSideProps } from "@/src/pages/auth/sign-in";
+// Use the same getServerSideProps function as src/features/auth/SignInPage.tsx
+export { getServerSideProps } from "@/src/features/auth/SignInPage";
 
 type NextAuthProvider = NonNullable<Parameters<typeof signIn>[0]>;
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17240 app preview](https://pr-17240.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Thin `src/pages/auth/sign-in.tsx` (~1041 LOC) into `src/features/auth/SignInPage.tsx` and leave a Next.js route shim that re-exports the Page plus shared helpers (`SSOButtons`, `FALLBACK_AUTH_PROVIDERS`, `useHuggingFaceRedirect`, `PageProps`).

`getServerSideProps` lives in `features/auth/server/getSignInPageServerSideProps.ts` and is re-exported from the pages shim — keeping SSO server utils (`isAnySsoConfigured` → `@langfuse/shared/src/server`) off the browser Turbopack graph.

- `pnpm structure:move` preserves history
- `SSOButtons` empty branch wrapped in a fragment for `@repo/no-null-render`
- Client tests updated for the `SignInPage` rename; 16/16 pass
- `pnpm --filter web run build` succeeds after the GSSP split

No intentional auth behavior change. `sign-up.tsx` remains fat for a follow-up.

## Type of change

- [x] Refactor (restructures existing code without changing behavior)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Self-reviewed
- Husky lint + Prettier on commit
- `pnpm --filter web run test-client auth-sign-in-page` — **Tests 16 passed (16)**
- `pnpm --filter web run build` — **Compiled successfully**
- `pnpm exec knip` clean
- `structure:stats`: rule 12 **562 → 547** (−15); thin pages **44 → 45** of 97

## Test plan

1. Open `/auth/sign-in` — credentials + SSO UI render
2. Open `/auth/sign-up` — still shares SSO buttons / GSSP from the shim
3. Preview auto-sign-in path still works when applicable

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08066-8784-7bc3-beaa-d9970a3f2507?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08066-8784-7bc3-beaa-d9970a3f2507&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62051604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with a non-blocking recommendation to split the newly moved feature module according to the repository's structure conventions.

<details><summary><h3>Summary</h3></summary>

- Preserves the sign-in page, server-side props, and shared auth helpers through the route shim.
- Updates the client test to render `SignInPage` from its new location.
- Keeps sign-up consuming the shared exports through the existing route path.
- Introduces feature-module structure debt by retaining multiple components and unrelated value exports in `SignInPage.tsx`.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Route["pages/auth/sign-in.tsx"] --> Feature["features/auth/SignInPage.tsx"]
  SignUp["pages/auth/sign-up.tsx"] --> Route
  Test["auth-sign-in-page.clienttest.tsx"] --> Feature
  Feature --> Page["SignInPage"]
  Feature --> Shared["SSOButtons and shared helpers"]
  Feature --> GSSP["getServerSideProps"]
```
</details>

<!-- /greptile_comment -->