### PR TITLE
feat(web): unify the Users filter experience with Traces

### DIFF
--- a/web/src/__tests__/server/users-facet-coverage.servertest.ts
+++ b/web/src/__tests__/server/users-facet-coverage.servertest.ts
@@ -13,6 +13,8 @@
  */
 import { randomUUID } from "crypto";
 
+import { observationEventsFilterConfig } from "@/src/features/events/config/filter-config";
+import { traceFilterConfig } from "@/src/features/filters/config/traces-config";
 import {
   usersEventsFilterConfig,
   usersFilterConfig,
@@ -234,4 +236,28 @@ describe("users sidebar facet coverage", () => {
     await expect(runV3(scoreFilter)).rejects.toThrow();
     await expect(runV4(scoreFilter)).rejects.toThrow();
   });
+
+  // Dropping a facet only hides it from the sidebar. `columnDefinitions` stays
+  // whole on both paths, so a filter on a dropped column that arrives by URL or
+  // saved view still decodes and still reaches the query that rejects it above.
+  // `omittedFilterColumns` is what drops it, which makes the two lists one
+  // decision: a facet this page removes is a filter this page never applies.
+  it.each([
+    ["v3", traceFilterConfig, usersFilterConfig],
+    ["v4", observationEventsFilterConfig, usersEventsFilterConfig],
+  ] as const)(
+    "%s users config never applies a facet it drops",
+    (_, base, config) => {
+      const dropped = base.facets
+        .map((facet) => facet.column)
+        .filter(
+          (column) => !config.facets.some((facet) => facet.column === column),
+        );
+
+      expect(dropped.length).toBeGreaterThan(0);
+      expect(config.omittedFilterColumns ?? []).toEqual(
+        expect.arrayContaining(dropped),
+      );
+    },
+  );
 });

--- a/web/src/__tests__/server/users-facet-coverage.servertest.ts
+++ b/web/src/__tests__/server/users-facet-coverage.servertest.ts
@@ -1,0 +1,237 @@
+/**
+ * The Users sidebar inherits its facets from the Traces and Observations
+ * configs, and both Users read paths scan a single table with no observation,
+ * score, or comment join. So a facet that is perfectly valid on Traces can be
+ * a 400 on Users, and nothing in the type system says so — the failure is a
+ * ClickHouse "unknown identifier s.value" at request time, or an
+ * `InvalidRequestError` out of the filter factory.
+ *
+ * This pins the deny-lists in `users-config.ts` to the queries they describe:
+ * every facet the sidebar offers is run through the real Users query on its
+ * own read path, so inheriting a new join-dependent facet fails here instead
+ * of in a user's browser.
+ */
+import { randomUUID } from "crypto";
+
+import {
+  usersEventsFilterConfig,
+  usersFilterConfig,
+} from "@/src/features/filters/config/users-config";
+import type { FilterConfig } from "@/src/features/filters/lib/filter-config";
+import { type ColumnDefinition, type FilterState } from "@langfuse/shared";
+import {
+  createEvent,
+  createEventsCh,
+  createObservation,
+  createObservationsCh,
+  createTrace,
+  createTracesCh,
+  getTotalUserCount,
+  getTracesGroupedByUsers,
+  getUserMetrics,
+  getUserMetricsFromEventsTable,
+  getUsersCountFromEventsTable,
+  getUsersFromEventsTable,
+} from "@langfuse/shared/src/server";
+
+const projectId = randomUUID();
+const userId = `facet-coverage-${randomUUID()}`;
+const traceId = randomUUID();
+
+const PROBE_KEY = "__facet_probe_key__";
+
+type Facet = FilterConfig["facets"][number];
+
+/**
+ * The FilterState the sidebar persists for this facet, matching the
+ * type/operator pairs `sidebar-filter-actions.ts` writes. Values are chosen to
+ * match the seeded row where possible: a filter that compiles but excludes
+ * everything still proves the SQL is legal, but matching keeps the assertion
+ * honest about the join actually resolving.
+ */
+function buildFilter(
+  facet: Facet,
+  columnDefinitions: ColumnDefinition[],
+): FilterState {
+  const column = facet.column;
+  const colType = columnDefinitions.find(
+    (c) => c.id === column || c.name === column,
+  )?.type;
+
+  switch (facet.type) {
+    case "categorical":
+      return [
+        {
+          column,
+          type: colType === "arrayOptions" ? "arrayOptions" : "stringOptions",
+          operator: "any of",
+          value: ["default"],
+        },
+      ] as FilterState;
+    case "string":
+      return [
+        { column, type: "string", operator: "contains", value: "" },
+      ] as FilterState;
+    case "numeric":
+      // ">= 0" matches every seeded row and stays inside the narrow
+      // Decimal64(12) range the cost columns cast to.
+      return [
+        { column, type: "number", operator: ">=", value: 0 },
+      ] as FilterState;
+    case "boolean":
+      return [
+        { column, type: "boolean", operator: "=", value: true },
+      ] as FilterState;
+    case "stringKeyValue":
+      return [
+        {
+          column,
+          type: "stringObject",
+          operator: "=",
+          key: PROBE_KEY,
+          value: "",
+        },
+      ] as FilterState;
+    case "keyValue":
+      return [
+        {
+          column,
+          type: "categoryOptions",
+          operator: "any of",
+          key: PROBE_KEY,
+          value: ["probe"],
+        },
+      ] as FilterState;
+    case "numericKeyValue":
+      return [
+        {
+          column,
+          type: "numberObject",
+          operator: ">=",
+          key: PROBE_KEY,
+          value: 0,
+        },
+      ] as FilterState;
+    case "booleanKeyValue":
+      return [
+        {
+          column,
+          type: "booleanObject",
+          operator: "=",
+          key: PROBE_KEY,
+          value: true,
+        },
+      ] as FilterState;
+  }
+}
+
+const runV3 = async (filter: FilterState) => {
+  // The router passes no `columns`/`columnDefinitions`, so the defaults
+  // (tracesTableUiColumnDefinitions + tracesTableCols) apply here too.
+  await getTracesGroupedByUsers(projectId, filter, undefined, 50, 0, undefined);
+  await getTotalUserCount(projectId, filter, undefined);
+  await getUserMetrics(projectId, [userId], filter);
+};
+
+const runV4 = async (filter: FilterState) => {
+  await getUsersFromEventsTable(projectId, filter, undefined, 50, 0);
+  await getUsersCountFromEventsTable(projectId, filter, undefined);
+  await getUserMetricsFromEventsTable(projectId, [userId], filter);
+};
+
+describe("users sidebar facet coverage", () => {
+  beforeAll(async () => {
+    await createTracesCh([
+      createTrace({
+        id: traceId,
+        project_id: projectId,
+        user_id: userId,
+        session_id: `facet-coverage-session-${randomUUID()}`,
+        environment: "default",
+        name: "facet-coverage-trace",
+        tags: ["facet-coverage-tag"],
+        version: "v1",
+        release: "r1",
+      }),
+    ]);
+
+    await createObservationsCh([
+      createObservation({
+        id: randomUUID(),
+        trace_id: traceId,
+        project_id: projectId,
+        type: "GENERATION",
+        usage_details: { input: 10, output: 20, total: 30 },
+        total_cost: 5,
+      }),
+    ]);
+
+    await createEventsCh([
+      createEvent({
+        id: randomUUID(),
+        span_id: randomUUID(),
+        parent_span_id: "",
+        type: "SPAN",
+        project_id: projectId,
+        trace_id: traceId,
+        user_id: userId,
+        session_id: `facet-coverage-session-${randomUUID()}`,
+        environment: "default",
+        name: "facet-coverage-event",
+        trace_name: "facet-coverage-trace",
+        tags: ["facet-coverage-tag"],
+        version: "v1",
+        release: "r1",
+      }),
+    ]);
+  });
+
+  it("seeds a user reachable on both read paths", async () => {
+    const v3 = await getTracesGroupedByUsers(
+      projectId,
+      [],
+      undefined,
+      50,
+      0,
+      undefined,
+    );
+    const v4 = await getUsersFromEventsTable(projectId, [], undefined, 50, 0);
+    expect(v3.map((u) => u.user)).toContain(userId);
+    expect(v4.map((u) => u.user)).toContain(userId);
+  });
+
+  it.each(usersFilterConfig.facets.map((f) => [f.column, f] as const))(
+    "v3 users query answers the %s facet",
+    async (_column, facet) => {
+      await expect(
+        runV3(buildFilter(facet, usersFilterConfig.columnDefinitions)),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  it.each(usersEventsFilterConfig.facets.map((f) => [f.column, f] as const))(
+    "v4 users query answers the %s facet",
+    async (_column, facet) => {
+      await expect(
+        runV4(buildFilter(facet, usersEventsFilterConfig.columnDefinitions)),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  // Without this the suite passes just as happily if every facet were removed
+  // from the config, or if the queries had quietly stopped rejecting anything.
+  it("rejects the score facet both configs exclude", async () => {
+    const scoreFilter = [
+      {
+        column: "scores_avg",
+        type: "numberObject",
+        operator: ">=",
+        key: "quality",
+        value: 0,
+      },
+    ] as FilterState;
+
+    await expect(runV3(scoreFilter)).rejects.toThrow();
+    await expect(runV4(scoreFilter)).rejects.toThrow();
+  });
+});

--- a/web/src/features/events/hooks/useEventsFilterOptions.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.ts
@@ -142,6 +142,14 @@ type UseEventsFilterOptionsParams = {
    * typed into.
    */
   lazy?: boolean;
+  /**
+   * Off keeps every query unmounted and reports "settled with nothing". For a
+   * surface that exists on both read paths (Users) and picks its option source
+   * per path: a v3 project must not scan `events_core`, and a disabled query is
+   * `pending` forever in react-query, which would skeleton the sidebar for good
+   * if that flag were passed through unchanged.
+   */
+  enabled?: boolean;
 };
 
 export function useEventsFilterOptions({
@@ -152,6 +160,7 @@ export function useEventsFilterOptions({
   isRootObservation,
   columns,
   lazy = false,
+  enabled = true,
 }: UseEventsFilterOptionsParams) {
   // User-authored start-time conditions (search-bar `startTime:>…`) merge into
   // the authoritative startTimeFilter channel — the server ignores them in
@@ -236,6 +245,7 @@ export function useEventsFilterOptions({
       includeApproxCount,
     },
     {
+      enabled,
       trpc: { context: { skipBatch: true } },
       ...FILTER_OPTION_QUERY_OPTIONS,
     },
@@ -285,7 +295,7 @@ export function useEventsFilterOptions({
       perColumnPlan.map(({ column, filter }) =>
         t.events.filterOptions(
           { ...baseInput, filter, columns: [column] },
-          FILTER_OPTION_QUERY_OPTIONS,
+          { enabled, ...FILTER_OPTION_QUERY_OPTIONS },
         ),
       ),
     { combine: combineLazy },
@@ -380,6 +390,9 @@ export function useEventsFilterOptions({
   // Each entry is gated on an in-flight fetch: a skeleton means "loading", not
   // "no data". On a terminal error the column is dropped (no auto-retry, so the
   // facet renders its empty state instead of skeletoning forever).
+  // A disabled query never leaves `pending`, so report it as settled-empty
+  // rather than letting consumers skeleton forever.
+  const isEagerPending = enabled && eagerQuery.isPending;
   const isEagerFetching = eagerQuery.isFetching;
   const bulkColumns = plan.bulk.columns;
   const loadingColumns = useMemo<ReadonlySet<string> | undefined>(() => {
@@ -427,7 +440,7 @@ export function useEventsFilterOptions({
 
   return {
     filterOptions: newFilterOptions,
-    isFilterOptionsPending: eagerQuery.isPending,
+    isFilterOptionsPending: isEagerPending,
     /** Approximate total observation count matching the refined filter, or null. */
     approxTotalCount,
     /** True while the first approximate-count value is still loading. */

--- a/web/src/features/filters/config/users-config.ts
+++ b/web/src/features/filters/config/users-config.ts
@@ -1,6 +1,9 @@
 import { observationEventsFilterConfig } from "@/src/features/events/config/filter-config";
 import { traceFilterConfig } from "@/src/features/filters/config/traces-config";
-import type { FilterConfig } from "@/src/features/filters/lib/filter-config";
+import {
+  omitFilterFacets,
+  type FilterConfig,
+} from "@/src/features/filters/lib/filter-config";
 
 /**
  * The Users list is the traces/events population grouped by `user_id`, so its
@@ -17,6 +20,12 @@ import type { FilterConfig } from "@/src/features/filters/lib/filter-config";
  * filter factory refuses to lower against this query). Those are excluded per
  * path below.
  *
+ * Exclusions go through `omitFilterFacets` rather than a local facet filter, so
+ * a dropped column is also dropped from the filter state. `columnDefinitions`
+ * stays whole on both paths, so a filter on an excluded column that arrives by
+ * URL or saved view still decodes; without the omission it would reach the
+ * query and fail there.
+ *
  * `users-facet-coverage.servertest.ts` runs every facet declared here through
  * the real query, so a newly inherited facet that needs a join fails there
  * rather than in a user's browser.
@@ -27,7 +36,7 @@ import type { FilterConfig } from "@/src/features/filters/lib/filter-config";
  * config's `level`, `latency`, token and cost facets all map to an
  * `observations` alias the users query never joins.
  */
-const TRACE_FACET_COLUMNS_UNAVAILABLE_ON_USERS = new Set([
+const TRACE_FACET_COLUMNS_UNAVAILABLE_ON_USERS = [
   "level",
   "latency",
   "inputTokens",
@@ -41,7 +50,7 @@ const TRACE_FACET_COLUMNS_UNAVAILABLE_ON_USERS = new Set([
   "score_booleans",
   "commentCount",
   "commentContent",
-]);
+];
 
 /**
  * v4 filters `events_core e` alone. Every native event column resolves —
@@ -49,40 +58,33 @@ const TRACE_FACET_COLUMNS_UNAVAILABLE_ON_USERS = new Set([
  * so only the score aggregates (an `s.` join) and the comment facets (which
  * lower against the `comments` table this query never reaches) fall out.
  */
-const EVENT_FACET_COLUMNS_UNAVAILABLE_ON_USERS = new Set([
+const EVENT_FACET_COLUMNS_UNAVAILABLE_ON_USERS = [
   "scores_avg",
   "score_categories",
   "score_booleans",
   "commentCount",
   "commentContent",
-]);
-
-function withoutFacets(config: FilterConfig, omitted: ReadonlySet<string>) {
-  return config.facets.filter((facet) => !omitted.has(facet.column));
-}
+];
 
 export const usersFilterConfig: FilterConfig = {
+  ...omitFilterFacets(
+    traceFilterConfig,
+    TRACE_FACET_COLUMNS_UNAVAILABLE_ON_USERS,
+  ),
   // v3 and v4 expose different facet sets, so they persist under different
   // table names. Sharing one would let a v4-only filter (`level`) rehydrate on
   // a v3 project, where it is a 400 rather than a narrowed table.
   tableName: "users",
-  columnDefinitions: traceFilterConfig.columnDefinitions,
   defaultExpanded: ["environment", "traceName"],
-  facets: withoutFacets(
-    traceFilterConfig,
-    TRACE_FACET_COLUMNS_UNAVAILABLE_ON_USERS,
-  ),
 };
 
 export const usersEventsFilterConfig: FilterConfig = {
-  tableName: "users-events",
-  columnDefinitions: observationEventsFilterConfig.columnDefinitions,
-  defaultExpanded: ["environment", "name"],
-  migrateFilterState: observationEventsFilterConfig.migrateFilterState,
-  facets: withoutFacets(
+  ...omitFilterFacets(
     observationEventsFilterConfig,
     EVENT_FACET_COLUMNS_UNAVAILABLE_ON_USERS,
   ),
+  tableName: "users-events",
+  defaultExpanded: ["environment", "name"],
 };
 
 export function getUsersFilterConfig(fromEvents: boolean): FilterConfig {

--- a/web/src/features/filters/config/users-config.ts
+++ b/web/src/features/filters/config/users-config.ts
@@ -1,0 +1,90 @@
+import { observationEventsFilterConfig } from "@/src/features/events/config/filter-config";
+import { traceFilterConfig } from "@/src/features/filters/config/traces-config";
+import type { FilterConfig } from "@/src/features/filters/lib/filter-config";
+
+/**
+ * The Users list is the traces/events population grouped by `user_id`, so its
+ * sidebar is the Traces sidebar: same facets, same labels, same lowering. The
+ * facet sets below are therefore derived from the trace and observation
+ * configs rather than restated, so a facet added there reaches Users too.
+ *
+ * What Users cannot inherit is anything that needs a join. Both read paths
+ * scan a single table — v3 `from traces t`, v4 `from events_core e` — with no
+ * observation, score, or comment join. A score facet lowers to an `s.` alias
+ * that does not exist and fails in ClickHouse; the comment facets fail earlier,
+ * in `createFilterFromFilterState`, though for different reasons per path (v3
+ * has no `commentCount` mapping at all, v4 maps it to a `comments` table the
+ * filter factory refuses to lower against this query). Those are excluded per
+ * path below.
+ *
+ * `users-facet-coverage.servertest.ts` runs every facet declared here through
+ * the real query, so a newly inherited facet that needs a join fails there
+ * rather than in a user's browser.
+ */
+
+/**
+ * v3 filters `traces t` alone. Only trace-table columns resolve: the trace
+ * config's `level`, `latency`, token and cost facets all map to an
+ * `observations` alias the users query never joins.
+ */
+const TRACE_FACET_COLUMNS_UNAVAILABLE_ON_USERS = new Set([
+  "level",
+  "latency",
+  "inputTokens",
+  "outputTokens",
+  "totalTokens",
+  "inputCost",
+  "outputCost",
+  "totalCost",
+  "scores_avg",
+  "score_categories",
+  "score_booleans",
+  "commentCount",
+  "commentContent",
+]);
+
+/**
+ * v4 filters `events_core e` alone. Every native event column resolves —
+ * including the `level`, `latency`, token and cost columns v3 has to drop —
+ * so only the score aggregates (an `s.` join) and the comment facets (which
+ * lower against the `comments` table this query never reaches) fall out.
+ */
+const EVENT_FACET_COLUMNS_UNAVAILABLE_ON_USERS = new Set([
+  "scores_avg",
+  "score_categories",
+  "score_booleans",
+  "commentCount",
+  "commentContent",
+]);
+
+function withoutFacets(config: FilterConfig, omitted: ReadonlySet<string>) {
+  return config.facets.filter((facet) => !omitted.has(facet.column));
+}
+
+export const usersFilterConfig: FilterConfig = {
+  // v3 and v4 expose different facet sets, so they persist under different
+  // table names. Sharing one would let a v4-only filter (`level`) rehydrate on
+  // a v3 project, where it is a 400 rather than a narrowed table.
+  tableName: "users",
+  columnDefinitions: traceFilterConfig.columnDefinitions,
+  defaultExpanded: ["environment", "traceName"],
+  facets: withoutFacets(
+    traceFilterConfig,
+    TRACE_FACET_COLUMNS_UNAVAILABLE_ON_USERS,
+  ),
+};
+
+export const usersEventsFilterConfig: FilterConfig = {
+  tableName: "users-events",
+  columnDefinitions: observationEventsFilterConfig.columnDefinitions,
+  defaultExpanded: ["environment", "name"],
+  migrateFilterState: observationEventsFilterConfig.migrateFilterState,
+  facets: withoutFacets(
+    observationEventsFilterConfig,
+    EVENT_FACET_COLUMNS_UNAVAILABLE_ON_USERS,
+  ),
+};
+
+export function getUsersFilterConfig(fromEvents: boolean): FilterConfig {
+  return fromEvents ? usersEventsFilterConfig : usersFilterConfig;
+}

--- a/web/src/features/filters/config/usersSearchRegistry.ts
+++ b/web/src/features/filters/config/usersSearchRegistry.ts
@@ -1,0 +1,75 @@
+import {
+  createFieldRegistry,
+  EVENTS_FIELD_REGISTRY,
+  type FieldRegistry,
+} from "@/src/features/search-bar/lib/fields";
+import type { FilterConfig } from "@/src/features/filters/lib/filter-config";
+
+import { usersEventsFilterConfig } from "./users-config";
+
+/**
+ * The Users bar is the Events bar with the facets the Users query cannot answer
+ * removed — the same relationship the Users sidebar has to the Traces sidebar.
+ * So its fields are taken from `EVENTS_FIELD_REGISTRY` rather than re-derived
+ * from the column definitions: the events defs carry hand-tuned sync modes
+ * (`name` searches as a substring even though its column is option-backed), and
+ * re-deriving them would give the same token two different meanings depending on
+ * which page you typed it into.
+ *
+ * The subset is keyed on the SIDEBAR's facets, which keeps the bar a subset of
+ * the sidebar by construction: every field the bar can write, the sidebar can
+ * show and remove.
+ */
+function usersFields(config: FilterConfig) {
+  const exposed = new Set(config.facets.map((facet) => facet.column));
+  return EVENTS_FIELD_REGISTRY.fields.filter((field) =>
+    exposed.has(field.filterColumn ?? field.id),
+  );
+}
+
+function usersColumns(config: FilterConfig) {
+  const exposed = new Set(config.facets.map((facet) => facet.column));
+  return config.columnDefinitions.filter((column) => exposed.has(column.id));
+}
+
+/**
+ * v4 (events-backed) Users. Only the v4 registry exists because the bar is
+ * gated on v4 — a v3 variant would be unreachable.
+ */
+export const USERS_FIELD_REGISTRY: FieldRegistry = createFieldRegistry({
+  id: "users",
+  fields: usersFields(usersEventsFilterConfig),
+  columns: usersColumns(usersEventsFilterConfig),
+  metadata: true,
+  // The users queries group `events_core` alone with no score join, so the
+  // sidebar offers no score facet and the `scores.` namespace stays closed at
+  // both levels. Leaving it open would let the bar write a filter that 500s.
+  scores: false,
+  traceScores: false,
+  // A bare word is the user-id search the page has always had: `searchQuery`
+  // lowers to `user_id ILIKE %q%` on this read path, so free text keeps its
+  // own lane rather than being rewritten onto a column.
+  allowFreeText: true,
+  defaultTextField: null,
+  freeTextScopeLabel: "user IDs",
+  searchExamples: [
+    "level:ERROR",
+    "-env:dev",
+    "totalCost:>1",
+    "traceTags:billing",
+  ],
+  hasExample: "sessionId",
+  recentSearches: true,
+  // No `buildFilterSystemPrompt` branch for this view yet, so Ask AI stays
+  // hidden — the fallback prompt is the events one and would steer the model at
+  // score columns this page cannot filter on. Write the branch, then flip this.
+  aiFilterPrompt: false,
+  aiContextFields: [
+    { observedOptionsKey: "environment", promptLabel: "environment" },
+    { observedOptionsKey: "userId", promptLabel: "userId (user)" },
+    { observedOptionsKey: "traceName", promptLabel: "traceName" },
+    { observedOptionsKey: "name", promptLabel: "name" },
+    { observedOptionsKey: "traceTags", promptLabel: "traceTags (tags)" },
+    { observedOptionsKey: "level", promptLabel: "level" },
+  ],
+});

--- a/web/src/features/filters/config/usersSearchRegistry.ts
+++ b/web/src/features/filters/config/usersSearchRegistry.ts
@@ -52,12 +52,9 @@ export const USERS_FIELD_REGISTRY: FieldRegistry = createFieldRegistry({
   allowFreeText: true,
   defaultTextField: null,
   freeTextScopeLabel: "user IDs",
-  searchExamples: [
-    "level:ERROR",
-    "-env:dev",
-    "totalCost:>1",
-    "traceTags:billing",
-  ],
+  // Leads with a bare word: the substring user-id lookup is what this page is
+  // searched for, and it is the one lane the `key:value` examples cannot show.
+  searchExamples: ["alice", "level:ERROR", "-env:dev", "traceTags:billing"],
   hasExample: "sessionId",
   recentSearches: true,
   // No `buildFilterSystemPrompt` branch for this view yet, so Ask AI stays

--- a/web/src/features/search-bar/lib/completions.ts
+++ b/web/src/features/search-bar/lib/completions.ts
@@ -983,7 +983,7 @@ function valueStageSections(input: ValueStageInput): {
         // complement (mirrors the free-text → scope path, gated on !negated).
         const scopeSwitches =
           !negated && (f.id === "input" || f.id === "output")
-            ? scopeSwitchOptions(f.id, typed, tokenSpan)
+            ? scopeSwitchOptions(f.id, typed, tokenSpan, registry)
             : [];
         return {
           sections: [
@@ -1188,14 +1188,21 @@ type FullTextScope = "default" | "input" | "output";
 // explicit "this is the default-scope search" option (the anchor) ahead of the
 // input:/output: rewrites. Value-stage switches leave it off, so an `input:`
 // value never offers a no-op switch back to `input:`.
+//
+// The scoped forms are offered only where the registry actually resolves them.
+// Users narrows the events catalog to what its grouped query can answer, and
+// `input:` is not in it — offering the rewrite there would hand the user a
+// token the parser rejects. With nothing left to switch to, the anchor alone is
+// noise, so the section drops out entirely.
 function scopeSwitchOptions(
   current: FullTextScope,
   value: string,
   span: { from: number; to: number },
+  registry: FieldRegistry,
   opts?: { keepCurrentFirst?: boolean },
 ): CompletionOption[] {
   const v = serializeValue(value);
-  const defs: { scope: FullTextScope; insert: string; detail: string }[] = [
+  const allDefs: { scope: FullTextScope; insert: string; detail: string }[] = [
     {
       scope: "input",
       insert: `input:${v}`,
@@ -1209,15 +1216,20 @@ function scopeSwitchOptions(
     {
       scope: "default",
       insert: v,
-      detail: "default: ids, names, input & output",
+      detail: registry.freeTextScopeLabel
+        ? `default: ${registry.freeTextScopeLabel}`
+        : "default full-text search",
     },
   ];
+  const defs = allDefs.filter(
+    (d) =>
+      d.scope === "default" || registry.resolveField(d.scope)?.type === "field",
+  );
+  const alternatives = defs.filter((d) => d.scope !== current);
+  if (alternatives.length === 0) return [];
   const ordered = opts?.keepCurrentFirst
-    ? [
-        ...defs.filter((d) => d.scope === current),
-        ...defs.filter((d) => d.scope !== current),
-      ]
-    : defs.filter((d) => d.scope !== current);
+    ? [...defs.filter((d) => d.scope === current), ...alternatives]
+    : alternatives;
   return ordered.map((d) => ({
     id: `scope:${d.scope}`,
     kind: "pattern" as const,
@@ -1422,6 +1434,7 @@ export function planInputCompletions(
             // re-quotes it once.
             run.text,
             { from: run.from, to: run.to },
+            registry,
             // Surface the typed text itself (default scope) as the first option,
             // ahead of the input:/output: rewrites.
             { keepCurrentFirst: true },

--- a/web/src/features/search-bar/lib/explain.clienttest.ts
+++ b/web/src/features/search-bar/lib/explain.clienttest.ts
@@ -72,7 +72,7 @@ describe("explainSegment", () => {
     // The label already says "per second" — don't spell the unit out twice.
     expect(explain("tps:>=50")).toBe("Tokens per second is 50 or more.");
     expect(explain("refund policy")).toBe(
-      'Full-text search for "refund policy" — matches id, name, input and output.',
+      'Full-text search for "refund policy" — matches ids, names, input & output.',
     );
     expect(explain("level:ERROR AND latency:>2", 1)).toBe(
       "AND — every filter has to match.",

--- a/web/src/features/search-bar/lib/explain.ts
+++ b/web/src/features/search-bar/lib/explain.ts
@@ -236,7 +236,9 @@ export function explainSegment(
     case "freeText":
       return {
         subject: "Full-text search",
-        predicate: `for ${quote(seg.raw.trim())} — matches id, name, input and output.`,
+        predicate: registry.freeTextScopeLabel
+          ? `for ${quote(seg.raw.trim())} — matches ${registry.freeTextScopeLabel}.`
+          : `for ${quote(seg.raw.trim())}.`,
       };
     case "operator":
       return KEYWORDS[seg.raw.toUpperCase()] ?? null;

--- a/web/src/features/search-bar/lib/fields.ts
+++ b/web/src/features/search-bar/lib/fields.ts
@@ -74,7 +74,8 @@ export type FieldRegistry = {
     | "evaluatorSamples"
     | "ruleSamples"
     | "sessions"
-    | "experiments";
+    | "experiments"
+    | "users";
   fields: readonly FieldDef[];
   columns: readonly ColumnDefinition[];
   allowFreeText: boolean;
@@ -87,6 +88,15 @@ export type FieldRegistry = {
    *  no searchQuery, but `id contains` is its most-applied filter by far, so a
    *  bare word means that instead of being rejected. Null = reject. */
   defaultTextField: string | null;
+  /**
+   * What a bare word matches, phrased for the hint and the scope list
+   * ("ids, names, input & output"). Written per view because the registry
+   * cannot see it: `searchQuery` lowers to a column list the BACKEND picks,
+   * and the users query narrows that list to `user_id` while keeping the same
+   * field catalog. Null drops the clause rather than guessing — vague beats
+   * naming columns a view does not search.
+   */
+  freeTextScopeLabel: string | null;
   /** Placeholder examples. Written per view, never derived from field ids: the
    *  events examples advertise `latency:`/`level:` on a view that has neither. */
   searchExamples: readonly string[];
@@ -144,6 +154,7 @@ export function fieldRegistryFromColumns(
     traceScores?: boolean;
     allowFreeText?: boolean;
     defaultTextField?: string;
+    freeTextScopeLabel?: string;
     searchExamples?: readonly string[];
     hasExample?: string;
     recentSearches?: boolean;
@@ -205,6 +216,7 @@ export function fieldRegistryFromColumns(
     traceScores: overlay.traceScores ?? scores,
     allowFreeText: overlay.allowFreeText ?? true,
     defaultTextField: overlay.defaultTextField ?? null,
+    freeTextScopeLabel: overlay.freeTextScopeLabel ?? null,
     searchExamples: overlay.searchExamples ?? [],
     hasExample: overlay.hasExample ?? null,
     recentSearches: overlay.recentSearches ?? false,
@@ -232,6 +244,7 @@ export function extendFieldRegistryWithColumns(
     traceScores: registry.traceScores,
     allowFreeText: registry.allowFreeText,
     defaultTextField: registry.defaultTextField,
+    freeTextScopeLabel: registry.freeTextScopeLabel,
     searchExamples: registry.searchExamples,
     hasExample: registry.hasExample,
     recentSearches: registry.recentSearches,
@@ -274,6 +287,7 @@ export function withFieldOptions(
     traceScores: registry.traceScores,
     allowFreeText: registry.allowFreeText,
     defaultTextField: registry.defaultTextField,
+    freeTextScopeLabel: registry.freeTextScopeLabel,
     searchExamples: registry.searchExamples,
     hasExample: registry.hasExample,
     recentSearches: registry.recentSearches,
@@ -377,7 +391,15 @@ export type FieldRef =
   | { type: "scores"; key: string; level: "observation" | "trace" }
   | { type: "pseudo"; id: typeof HAS_KEY };
 
-function createFieldRegistry({
+/**
+ * Assembles a registry from field defs that already exist. `fieldRegistryFromColumns`
+ * derives its defs from `ColumnDefinition.type`, which is right for a view with no
+ * grammar of its own — but a view that narrows ANOTHER view's grammar must reuse that
+ * view's defs verbatim. Deriving them again would silently re-decide `syncMode` from
+ * the column type and give the same field a different meaning on the two bars
+ * (`name:checkout` an exact match on one, a substring on the other).
+ */
+export function createFieldRegistry({
   id,
   fields,
   columns,
@@ -386,6 +408,7 @@ function createFieldRegistry({
   traceScores,
   allowFreeText,
   defaultTextField,
+  freeTextScopeLabel,
   searchExamples,
   hasExample,
   recentSearches,
@@ -400,6 +423,7 @@ function createFieldRegistry({
   traceScores: boolean;
   allowFreeText: boolean;
   defaultTextField: string | null;
+  freeTextScopeLabel: string | null;
   searchExamples: readonly string[];
   hasExample: string | null;
   recentSearches: boolean;
@@ -435,6 +459,7 @@ function createFieldRegistry({
     scores,
     traceScores,
     defaultTextField,
+    freeTextScopeLabel,
     searchExamples,
     hasExample,
     recentSearches,
@@ -465,6 +490,7 @@ export const EVENTS_FIELD_REGISTRY = createFieldRegistry({
   traceScores: true,
   allowFreeText: true,
   defaultTextField: null,
+  freeTextScopeLabel: "ids, names, input & output",
   searchExamples: [
     "level:ERROR",
     "-env:dev",

--- a/web/src/features/search-bar/lib/searchBarInvariants.clienttest.ts
+++ b/web/src/features/search-bar/lib/searchBarInvariants.clienttest.ts
@@ -13,9 +13,11 @@ import {
   RULE_SAMPLE_FIELD_REGISTRY,
 } from "@/src/features/evals/v2/constants/evaluatorSearchRegistry";
 import { SESSIONS_FIELD_REGISTRY } from "@/src/features/filters";
+import { usersEventsFilterConfig } from "@/src/features/filters/config/users-config";
+import { USERS_FIELD_REGISTRY } from "@/src/features/filters/config/usersSearchRegistry";
 import { EXPERIMENTS_FIELD_REGISTRY } from "@/src/features/experiments/constants/experimentsSearchRegistry";
 import { validateQuery } from "./validate";
-import { planCommit } from "./commit";
+import { DEFAULT_SEARCH_TYPE, planCommit } from "./commit";
 import { filterStateToQueryText } from "./filter-state-to-query";
 import {
   applyPick,
@@ -753,6 +755,158 @@ describe("search bar invariants — sessions registry", () => {
     // has:name; it is written down so reordering FIELDS cannot rewrite copy.
     expect(EVENTS_FIELD_REGISTRY.hasExample).toBe("endTime");
     expect(SESSIONS_FIELD_REGISTRY.hasExample).toBe("userIds");
+  });
+});
+
+const usersView: RegistryUnderTest = {
+  name: "users v4",
+  registry: USERS_FIELD_REGISTRY,
+  extraKeys: [
+    "metadata.region",
+    'metadata."my key"',
+    "has:latency",
+    "has:sessionId",
+  ],
+  // The users queries group `events_core` with no score join, so `scores.` is
+  // closed at both levels and there is no context to vary.
+  scoreContexts: [],
+  fieldValues: ["x", "ERROR", "5", "0.8", "true", "a b", "gpt-4"],
+  // Free text is its own lane here (it lowers to `user_id ILIKE`), so the same
+  // reserved-token quoting the events bar needs has to hold.
+  freeTextValues: [
+    "hello",
+    "alice smith",
+    "or",
+    "and",
+    "NOT",
+    "!important",
+    "-foo",
+    "key:value",
+  ],
+  sidebarFilters: [
+    // Trace-score columns reach this page only from an older saved view. The
+    // bar does not own them, so it must skip rather than emit a token that
+    // renders as an unknown field.
+    [
+      {
+        type: "numberObject",
+        column: "trace_scores_avg",
+        key: "nps",
+        operator: ">",
+        value: 5,
+      },
+    ],
+  ],
+};
+
+describe("search bar invariants — users registry", () => {
+  it("holds all three invariants (parity, round-trip, serialize symmetry)", () => {
+    const failures = runSearchBarInvariants(usersView);
+    expect(
+      failures,
+      failures.length === 0
+        ? "ok"
+        : `\n${failures
+            .slice(0, 25)
+            .map((f) => `  [${f.invariant}] ${f.case} — ${f.detail}`)
+            .join(
+              "\n",
+            )}${failures.length > 25 ? `\n  …and ${failures.length - 25} more` : ""}`,
+    ).toEqual([]);
+  });
+
+  it("is the events grammar minus what the users query cannot answer", () => {
+    // Users groups `events_core` alone: no score join, no comments join. Those
+    // facets are excluded from the sidebar, so the bar must not resolve them
+    // either — a `scores.` token here would commit a filter that 500s.
+    expect(USERS_FIELD_REGISTRY.resolveField("scores.accuracy")).toBeNull();
+    expect(USERS_FIELD_REGISTRY.resolveField("traceScores.nps")).toBeNull();
+    for (const key of ["comment", "commentCount", "commentContent"]) {
+      expect(USERS_FIELD_REGISTRY.resolveField(key)).toBeNull();
+    }
+    // Everything else the events bar offers survives, and is exactly the
+    // sidebar's facet set (metadata excepted — it resolves by dot-path, not as
+    // a plain field).
+    const facetColumns = new Set(
+      usersEventsFilterConfig.facets.map((f) => f.column),
+    );
+    for (const field of USERS_FIELD_REGISTRY.fields) {
+      expect(facetColumns.has(field.filterColumn ?? field.id)).toBe(true);
+    }
+    expect(USERS_FIELD_REGISTRY.resolveField("metadata.region")).toEqual({
+      type: "metadata",
+      key: "region",
+    });
+    // The two aliases that make the events grammar worth reusing rather than
+    // re-deriving: `env:` and `tag:` are overlay-only, absent from the columns.
+    expect(USERS_FIELD_REGISTRY.resolveField("env")).toMatchObject({
+      type: "field",
+      field: { id: "environment" },
+    });
+    expect(USERS_FIELD_REGISTRY.resolveField("user")).toMatchObject({
+      type: "field",
+      field: { id: "userId" },
+    });
+  });
+
+  it("keeps a bare word in the free-text lane rather than rewriting it", () => {
+    // Unlike sessions (`id contains`), the users backend already has a search
+    // lane: `searchQuery` lowers to `user_id ILIKE %q%`. Rewriting a bare word
+    // onto the userId column would turn a substring search into an exact
+    // any-of match against the facet list.
+    const committed = planCommit("alice", undefined, USERS_FIELD_REGISTRY);
+    expect(committed).toMatchObject({
+      status: "committed",
+      searchQuery: "alice",
+      filters: [],
+    });
+    // …and it renders back as the same bare word, so the bar does not churn.
+    expect(
+      filterStateToQueryText(
+        [],
+        { searchQuery: "alice", searchType: DEFAULT_SEARCH_TYPE },
+        USERS_FIELD_REGISTRY,
+      ).text,
+    ).toBe("alice");
+  });
+
+  it("describes the free-text lane as user ids, and offers no other scope", () => {
+    // The generic copy claims a bare word matches "ids, names, input and
+    // output". On this page it matches user ids and nothing else, and there is
+    // no `input:`/`output:` field to switch into — offering the rewrite would
+    // hand the user a token the parser rejects.
+    expect(USERS_FIELD_REGISTRY.freeTextScopeLabel).toBe("user IDs");
+    expect(USERS_FIELD_REGISTRY.resolveField("input")).toBeNull();
+    expect(USERS_FIELD_REGISTRY.resolveField("output")).toBeNull();
+
+    const scopeOptionIds = (registry: FieldRegistry) =>
+      (
+        planInputCompletions(
+          {
+            input: "alice",
+            caret: 5,
+            observed: {},
+            recents: [],
+            currentQueryText: "alice",
+          },
+          registry,
+        )?.sections ?? []
+      )
+        .flatMap((section) => section.options)
+        .map((option) => option.id)
+        .filter((id) => id.startsWith("scope:"));
+
+    expect(scopeOptionIds(USERS_FIELD_REGISTRY)).toEqual([]);
+    // The same input on a registry that does have the columns still offers them.
+    expect(scopeOptionIds(EVENTS_FIELD_REGISTRY)).toEqual(
+      expect.arrayContaining(["scope:input", "scope:output"]),
+    );
+  });
+
+  it("does not offer Ask AI until the view has its own prompt", () => {
+    // buildFilterSystemPrompt falls back to the EVENTS prompt, whose worked
+    // examples filter on score columns this page cannot reach.
+    expect(USERS_FIELD_REGISTRY.aiFilterPrompt).toBe(false);
   });
 });
 

--- a/web/src/features/search-bar/server/router.ts
+++ b/web/src/features/search-bar/server/router.ts
@@ -55,6 +55,7 @@ import {
 } from "@/src/features/evals/v2/constants/evaluatorSearchRegistry";
 import { DATASET_NAME_COLUMN } from "@/src/features/evals/v2/utils/datasetNameFilter";
 import { SESSIONS_FIELD_REGISTRY } from "@/src/features/filters/config/sessionsSearchRegistry";
+import { USERS_FIELD_REGISTRY } from "@/src/features/filters/config/usersSearchRegistry";
 import { EXPERIMENTS_FIELD_REGISTRY } from "@/src/features/experiments/constants/experimentsSearchRegistry";
 import {
   EVENTS_FIELD_REGISTRY,
@@ -75,6 +76,7 @@ const REGISTRY_IDS = [
   "ruleSamples",
   "sessions",
   "experiments",
+  "users",
 ] as const;
 
 /**
@@ -90,6 +92,7 @@ const REGISTRIES_BY_ID: Record<(typeof REGISTRY_IDS)[number], FieldRegistry> = {
   ruleSamples: RULE_SAMPLE_FIELD_REGISTRY,
   sessions: SESSIONS_FIELD_REGISTRY,
   experiments: EXPERIMENTS_FIELD_REGISTRY,
+  users: USERS_FIELD_REGISTRY,
 };
 
 const GenerateFilterInput = z.object({

--- a/web/src/pages/project/[projectId]/users/index.tsx
+++ b/web/src/pages/project/[projectId]/users/index.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   NumberParam,
   StringParam,
@@ -9,28 +9,47 @@ import {
 } from "use-query-params";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { DataTable } from "@/src/components/table/data-table";
+import {
+  DataTableControls,
+  DataTableControlsProvider,
+} from "@/src/components/table/data-table-controls";
+import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { createBadgeTableColumn } from "@/src/components/design-system/table/columns/createBadgeTableColumn";
 import { createLinkTableColumn } from "@/src/components/design-system/table/columns/createLinkTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
-import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
+import { getUsersFilterConfig } from "@/src/features/filters/config/users-config";
+import { USERS_FIELD_REGISTRY } from "@/src/features/filters/config/usersSearchRegistry";
+import {
+  useSidebarFilterPresentation,
+  useSidebarFilterStateCore,
+  type FacetOptions,
+  type UseSidebarFilterStateOptions,
+} from "@/src/features/filters/hooks/useSidebarFilterState";
+import { buildSidebarFilterSessionContextId } from "@/src/features/filters/lib/persistedSidebarFilterQuery";
+import { sortOptionValues } from "@/src/features/filters";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
+import { useEventsFilterOptions } from "@/src/features/events/hooks/useEventsFilterOptions";
 import { useReadPath } from "@/src/features/events/hooks/useReadPath";
+import { EventsSearchBarRow } from "@/src/features/search-bar/components/EventsSearchBarRow";
+import { useEventsSearchBar } from "@/src/features/search-bar/hooks/useEventsSearchBar";
+import { DEFAULT_SEARCH_TYPE } from "@/src/features/search-bar/lib/commit";
+import { toObservedOptions } from "@/src/features/search-bar/lib/observed-options";
 import { api } from "@/src/utils/api";
 import { compactNumberFormatter, usdFormatter } from "@/src/utils/numbers";
+import { cn } from "@/src/utils/tailwind";
 import { type RouterOutput } from "@/src/utils/types";
-import { type FilterState, usersTableCols } from "@langfuse/shared";
+import {
+  DEFAULT_SIDEBAR_IMPLICIT_ENVIRONMENT_CONFIG,
+  type FilterState,
+  type TimeFilter,
+} from "@langfuse/shared";
 import { joinTableCoreAndMetrics } from "@/src/components/table/utils/joinTableCoreAndMetrics";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
 import { toAbsoluteTimeRange } from "@/src/utils/date-range-utils";
-import { useDebounce } from "@/src/hooks/useDebounce";
 import Page from "@/src/components/layouts/page";
 import { TableHeaderControls } from "@/src/components/table/table-header-controls";
 import { UsersOnboarding } from "@/src/components/onboarding/UsersOnboarding";
-import {
-  useEnvironmentFilter,
-  convertSelectedEnvironmentsToFilter,
-} from "@/src/hooks/useEnvironmentFilter";
 
 type RowData = {
   userId: string;
@@ -125,11 +144,10 @@ const UsersTable = ({
   const router = useRouter();
   const projectId = router.query.projectId as string;
 
-  const [userFilterState, setUserFilterState] = useQueryFilterState(
-    [],
-    "users",
-    projectId,
-  );
+  // The two read paths answer different facet sets from different tables, so
+  // they get different configs — and different persistence keys, or a v4-only
+  // filter would rehydrate on a v3 project as a failed query.
+  const usersFilterConfig = useMemo(() => getUsersFilterConfig(isV4), [isV4]);
 
   const { setDetailPageList } = useDetailPageLists();
 
@@ -147,22 +165,68 @@ const UsersTable = ({
     return toAbsoluteTimeRange(timeRange) ?? undefined;
   }, [timeRange]);
 
-  const dateRangeFilter: FilterState = dateRange
-    ? [
-        {
-          column: "Timestamp",
-          type: "datetime",
-          operator: ">=",
-          value: dateRange.from,
-        },
-        {
-          column: "Timestamp",
-          type: "datetime",
-          operator: "<=",
-          value: dateRange.to,
-        },
-      ]
-    : [];
+  // Both users queries map "Timestamp" onto their own time column
+  // (`t.timestamp` on v3, `e.start_time` on v4), so one filter serves both.
+  const dateRangeFilter = useMemo<FilterState>(
+    () =>
+      dateRange
+        ? [
+            {
+              column: "Timestamp",
+              type: "datetime",
+              operator: ">=",
+              value: dateRange.from,
+            },
+            {
+              column: "Timestamp",
+              type: "datetime",
+              operator: "<=",
+              value: dateRange.to,
+            },
+          ]
+        : [],
+    [dateRange],
+  );
+
+  const filterStateOptions: UseSidebarFilterStateOptions = useMemo(
+    () => ({
+      stateLocation: "urlAndSessionStorage",
+      sessionFilterContextId: buildSidebarFilterSessionContextId(projectId),
+      // Environment is a sidebar facet here, like every other filter — the page
+      // no longer keeps its own environment selection beside the filter state.
+      implicitDefaultConfig: DEFAULT_SIDEBAR_IMPLICIT_ENVIRONMENT_CONFIG,
+      isV4,
+    }),
+    [isV4, projectId],
+  );
+
+  // Split core/presentation so the v4 facet scan can refine its counts against
+  // the filters already applied — the presentation half needs the options the
+  // scan produces, so it cannot also be the thing that supplies the filters.
+  const filterCore = useSidebarFilterStateCore(
+    usersFilterConfig,
+    filterStateOptions,
+  );
+
+  // v3 facet options: the trace facets this page inherits, from the traces
+  // endpoint that already answers them.
+  const traceFilterOptionsResponse = api.traces.filterOptions.useQuery(
+    {
+      projectId,
+      timestampFilter:
+        dateRangeFilter.length > 0
+          ? (dateRangeFilter as TimeFilter[])
+          : undefined,
+    },
+    {
+      enabled: !isV4,
+      trpc: { context: { skipBatch: true } },
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: Infinity,
+    },
+  );
 
   const environmentFilterOptions =
     api.projects.environmentFilterOptions.useQuery(
@@ -171,6 +235,7 @@ const UsersTable = ({
         fromTimestamp: dateRange?.from,
       },
       {
+        enabled: !isV4,
         trpc: { context: { skipBatch: true } },
         refetchOnMount: false,
         refetchOnWindowFocus: false,
@@ -179,26 +244,141 @@ const UsersTable = ({
       },
     );
 
-  const environmentOptions =
-    environmentFilterOptions.data?.map((value) => value.environment) || [];
-
-  const { selectedEnvironments, setSelectedEnvironments } =
-    useEnvironmentFilter(environmentOptions, projectId);
-
-  const environmentFilter = convertSelectedEnvironmentsToFilter(
-    ["environment"],
-    selectedEnvironments,
+  const v3FacetOptions = useMemo<FacetOptions>(
+    () => ({
+      environment:
+        environmentFilterOptions.data?.map((value) => value.environment) ??
+        undefined,
+      traceName:
+        traceFilterOptionsResponse.data?.name?.map((n) => ({
+          value: n.value,
+          count: Number(n.count),
+        })) ?? undefined,
+      // tags don't have counts; they read A→Z
+      traceTags: sortOptionValues(
+        traceFilterOptionsResponse.data?.tags?.map((t) => t.value),
+      ),
+      userId:
+        traceFilterOptionsResponse.data?.users?.map((u) => ({
+          value: u.value,
+          count: Number(u.count),
+        })) ?? undefined,
+      sessionId:
+        traceFilterOptionsResponse.data?.sessions?.map((s) => ({
+          value: s.value,
+          count: Number(s.count),
+        })) ?? undefined,
+    }),
+    [environmentFilterOptions.data, traceFilterOptionsResponse.data],
   );
 
-  const filterState = userFilterState.concat(
-    dateRangeFilter,
-    environmentFilter,
+  // v4 facet options: the events facet scan, lazily per column, refined by the
+  // filters already applied.
+  const facetStartTimeFilter = useMemo<TimeFilter[]>(
+    () =>
+      dateRange
+        ? [
+            {
+              column: "startTime",
+              type: "datetime",
+              operator: ">=",
+              value: dateRange.from,
+            },
+            {
+              column: "startTime",
+              type: "datetime",
+              operator: "<=",
+              value: dateRange.to,
+            },
+          ]
+        : [],
+    [dateRange],
   );
+
+  const {
+    filterOptions: v4FacetOptions,
+    isFilterOptionsPending: isV4FacetOptionsPending,
+    erroredColumns,
+    loadingColumns,
+    requestColumns,
+  } = useEventsFilterOptions({
+    projectId,
+    startTimeFilter: facetStartTimeFilter,
+    refiningFilter: filterCore.filterState,
+    lazy: true,
+    enabled: isV4,
+  });
+
+  const isSidebarFilterLoading = isV4
+    ? isV4FacetOptionsPending
+    : traceFilterOptionsResponse.isPending ||
+      environmentFilterOptions.isPending;
+
+  const queryFilter = useSidebarFilterPresentation(
+    filterCore,
+    usersFilterConfig,
+    isV4 ? v4FacetOptions : v3FacetOptions,
+    {
+      loading: isSidebarFilterLoading,
+      loadingColumns,
+      isV4,
+    },
+  );
+
+  // Lazy filter-options: load a facet's values when its sidebar section is
+  // expanded (also covers active filters, which auto-expand on mount).
+  const expandedFacets = queryFilter.expanded;
+  useEffect(() => {
+    requestColumns(expandedFacets);
+  }, [expandedFacets, requestColumns]);
 
   const [searchQuery, setSearchQuery] = useQueryParam(
     "search",
     withDefault(StringParam, null),
   );
+
+  // The grammar bar is v4-only: it writes the events facet grammar, which the
+  // trace-backed v3 query cannot answer. v3 keeps the toolbar's search field.
+  const searchBarEnabled = isV4;
+
+  const queryFilterRef = useRef(queryFilter);
+  queryFilterRef.current = queryFilter;
+
+  const setFiltersWrapper = useCallback(
+    (filters: FilterState) =>
+      queryFilterRef.current?.setFilterState(filters, { origin: "user" }),
+    [],
+  );
+
+  const observedOptions = useMemo(
+    () => toObservedOptions(v4FacetOptions, isV4FacetOptionsPending),
+    [v4FacetOptions, isV4FacetOptionsPending],
+  );
+
+  // Both users queries take a `searchQuery` but no search type — free text
+  // always lowers to `user_id ILIKE`. The bar reports the default lane; there
+  // is nothing on this page for a write to it to change.
+  const setSearchTypeNoop = useCallback(() => {}, []);
+
+  const {
+    store: searchBarStore,
+    commit: searchBarCommit,
+    applyFilters: searchBarApplyFilters,
+  } = useEventsSearchBar({
+    projectId,
+    tableName: usersFilterConfig.tableName,
+    enabled: searchBarEnabled,
+    filterState: queryFilter.searchBarFilterState,
+    searchQuery,
+    searchType: DEFAULT_SEARCH_TYPE,
+    observed: observedOptions,
+    setFilterState: setFiltersWrapper,
+    setSearchQuery,
+    setSearchType: setSearchTypeNoop,
+    registry: USERS_FIELD_REGISTRY,
+  });
+
+  const filterState = queryFilter.effectiveFilterState.concat(dateRangeFilter);
 
   const usersV3 = api.users.all.useQuery(
     {
@@ -376,81 +556,111 @@ const UsersTable = ({
   ];
 
   return (
-    <>
-      {showControlsInPageHeader && (
-        <TableHeaderControls
-          timeRange={timeRange}
-          setTimeRange={setTimeRange}
-        />
-      )}
-      <DataTableToolbar
-        tableName="users"
-        filterColumnDefinition={usersTableCols}
-        filterState={userFilterState}
-        setFilterState={useDebounce(setUserFilterState)}
-        columns={columns}
-        timeRange={showControlsInPageHeader ? undefined : timeRange}
-        setTimeRange={showControlsInPageHeader ? undefined : setTimeRange}
-        searchConfig={{
-          metadataSearchFields: ["User ID"],
-          updateQuery: setSearchQuery,
-          currentQuery: searchQuery ?? undefined,
-          tableAllowsFullTextSearch: false,
-          setSearchType: undefined,
-          searchType: undefined,
-        }}
-        environmentFilter={{
-          values: selectedEnvironments,
-          onValueChange: setSelectedEnvironments,
-          options: environmentOptions.map((env) => ({ value: env })),
-        }}
-      />
-      <DataTable
-        tableName="users"
-        columns={columns}
-        data={
-          users.isLoading
-            ? { isLoading: true, isError: false }
-            : users.isError
-              ? {
-                  isLoading: false,
-                  isError: true,
-                  error: users.error.message,
-                }
-              : {
-                  isLoading: false,
-                  isError: false,
-                  data: userRowData.rows?.map((t) => {
-                    return {
-                      userId: t.id,
-                      environment: t.environment ?? undefined,
-                      firstEvent:
-                        t.firstTrace?.toLocaleString() ?? "No event yet",
-                      lastEvent:
-                        t.lastTrace?.toLocaleString() ?? "No event yet",
-                      totalEvents: compactNumberFormatter(
-                        isV4
-                          ? Number(t.totalObservations ?? 0)
-                          : Number(t.totalTraces ?? 0) +
-                              Number(t.totalObservations ?? 0),
-                      ),
-                      totalTokens: compactNumberFormatter(t.totalTokens ?? 0),
-                      totalCost: usdFormatter(
-                        t.sumCalculatedTotalCost ?? 0,
-                        2,
-                        2,
-                      ),
-                    };
-                  }),
-                }
-        }
-        pagination={{
-          totalCount,
-          onChange: setPaginationState,
-          state: paginationState,
-        }}
-        cellPadding="comfortable"
-      />
-    </>
+    <DataTableControlsProvider tableName={usersFilterConfig.tableName}>
+      <div className="flex h-full w-full flex-col">
+        {showControlsInPageHeader && (
+          <TableHeaderControls
+            timeRange={timeRange}
+            setTimeRange={setTimeRange}
+          />
+        )}
+        {/* In bar mode the composer and the toolbar stick together as one band
+            so the toolbar cannot scroll under the composer and render
+            half-clipped. */}
+        <div
+          className={cn(
+            searchBarEnabled && "bg-background sticky top-0 z-30 pb-1.5",
+          )}
+        >
+          {searchBarEnabled && (
+            <EventsSearchBarRow
+              projectId={projectId}
+              tableName={usersFilterConfig.tableName}
+              store={searchBarStore}
+              commit={searchBarCommit}
+              observed={observedOptions}
+              erroredColumns={erroredColumns}
+              onApplyFilters={searchBarApplyFilters}
+              onRequestColumns={requestColumns}
+              registry={USERS_FIELD_REGISTRY}
+            />
+          )}
+          <DataTableToolbar
+            tableName={usersFilterConfig.tableName}
+            isV4={isV4}
+            rowClassName={searchBarEnabled ? "my-1" : undefined}
+            filterState={queryFilter.explicitFilterState}
+            columns={columns}
+            timeRange={showControlsInPageHeader ? undefined : timeRange}
+            setTimeRange={showControlsInPageHeader ? undefined : setTimeRange}
+            searchConfig={
+              searchBarEnabled
+                ? undefined
+                : {
+                    metadataSearchFields: ["User ID"],
+                    updateQuery: setSearchQuery,
+                    currentQuery: searchQuery ?? undefined,
+                    tableAllowsFullTextSearch: false,
+                    setSearchType: undefined,
+                    searchType: undefined,
+                  }
+            }
+          />
+        </div>
+        <ResizableFilterLayout>
+          <DataTableControls queryFilter={queryFilter} />
+          <div className="flex flex-1 flex-col overflow-hidden">
+            <DataTable
+              tableName="users"
+              columns={columns}
+              data={
+                users.isLoading
+                  ? { isLoading: true, isError: false }
+                  : users.isError
+                    ? {
+                        isLoading: false,
+                        isError: true,
+                        error: users.error.message,
+                      }
+                    : {
+                        isLoading: false,
+                        isError: false,
+                        data: userRowData.rows?.map((t) => {
+                          return {
+                            userId: t.id,
+                            environment: t.environment ?? undefined,
+                            firstEvent:
+                              t.firstTrace?.toLocaleString() ?? "No event yet",
+                            lastEvent:
+                              t.lastTrace?.toLocaleString() ?? "No event yet",
+                            totalEvents: compactNumberFormatter(
+                              isV4
+                                ? Number(t.totalObservations ?? 0)
+                                : Number(t.totalTraces ?? 0) +
+                                    Number(t.totalObservations ?? 0),
+                            ),
+                            totalTokens: compactNumberFormatter(
+                              t.totalTokens ?? 0,
+                            ),
+                            totalCost: usdFormatter(
+                              t.sumCalculatedTotalCost ?? 0,
+                              2,
+                              2,
+                            ),
+                          };
+                        }),
+                      }
+              }
+              pagination={{
+                totalCount,
+                onChange: setPaginationState,
+                state: paginationState,
+              }}
+              cellPadding="comfortable"
+            />
+          </div>
+        </ResizableFilterLayout>
+      </div>
+    </DataTableControlsProvider>
   );
 };


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17241 app preview](https://pr-17241.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The Users list kept its own filtering stack: a popover filter builder, a separate environment dropdown beside it, and its own session-storage filter state. Traces, Observations and Sessions had all moved to the shared sidebar plus the grammar search bar, so the same project offered two unrelated ways to narrow the same population — and the environment selection lived outside the filter state everything else round-trips.

Users now renders the shared sidebar filter stack on both read paths, with environment as an ordinary facet, and the grammar search bar on the events read path.

**Facet sets are derived, not restated.** They come from the Traces and Observations configs minus the facets the Users query cannot answer: both read paths group a single table with no observation, score or comment join, so a score facet lowers to an alias that does not exist. A new server test runs every declared facet through the real Users query on its own read path, so inheriting a join-dependent facet fails in CI rather than in someone's browser.

**A facet this page hides is a filter it never applies.** Dropping a facet only removes it from the sidebar — `columnDefinitions` stays whole, so a filter on a dropped column arriving by URL or saved view still decodes and still reaches the query. Sending one is not a no-op: `users.all` with a `level` filter and `users.allFromEvents` with a `scores_avg` filter both return **500** today, against the same project where the unfiltered call returns 71 users. The exclusions therefore go through the shared `omitFilterFacets`, which every other surface already uses, so the same list that removes a facet also populates `omittedFilterColumns` and strips the filter on the read boundary.

The same `filter=` parameter, pasted onto each page — applied on Observations, dropped on Users:

| Observations (score facet exists) | Users (score facet does not) |
|---|---|
| ![Observations page with a scores_avg filter applied from the URL, Numeric Scores section active](https://cursor.com/artifacts/c/art-87a84b9b-2d2e-4335-875d-70d5ae79932a) | ![Users page with the same filter parameter, silently dropped from the URL and the table rendering normally](https://cursor.com/artifacts/c/art-8df83e2b-089a-4533-868e-70d92cefd8a6) |

The Users URL rewrites itself back to bare `/users`, the table renders, and no score section appears in the sidebar.

**The search bar reuses the events field definitions** instead of re-deriving them from column types, so a token means the same thing on both bars. The registry is keyed on the sidebar's facets, so the bar stays a subset of the sidebar by construction — every field it can write, the sidebar can show and remove. A bare word stays in its own lane here: it lowers to `user_id ILIKE`, not to a column filter, so the hint, the placeholder and the scope list describe what this view actually searches instead of the generic "ids, names, input and output".

Side-by-side, the two pages now produce the same URL for the same interaction:

| | Users | Tracing |
|---|---|---|
| | ![Users page with the shared filter sidebar and an environment:production filter](https://cursor.com/artifacts/c/art-9d29f2b6-e246-43fc-abe8-9ce105eeb606) | ![Tracing page with the same sidebar and the same filter URL shape](https://cursor.com/artifacts/c/art-4379c26e-e78b-428f-9ff9-c7f64819270a) |

Clicking `production` in the Environment facet writes `?filter=environment;stringOptions;;any of;production` on both pages. The 8 users returned match `countDistinct(user_id) … where environment='production'` in ClickHouse for the same window.

The bar and the sidebar are one state, in both directions:

<a href="https://cursor.com/agents/bc-f5436b5a-a22f-4cfa-bed2-a74372a391f6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fusers_filter_bar_and_sidebar_stay_in_sync.mp4"><img src="https://cursor.com/artifacts/c/art-0bdb5197-524c-4417-8e70-057a660810e4" alt="users_filter_bar_and_sidebar_stay_in_sync.mp4" /></a>

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## How to test

Preview: `pr-17241.preview.langfuse.com`, or locally with `pnpm run seed -- session-variety --v4`.

1. Open **Users**. The left sidebar is the Traces sidebar, and there is a query bar above the table.
2. Type `user-pro` and press Enter — the list narrows by user-id substring (this is the same `searchQuery` the old plain input drove).
3. Append ` env:production` — the sidebar's Environment section shows `production` selected.
4. Tick `dev` in the sidebar — the bar rewrites itself to `environment:(production OR dev)`.
5. Apply a score filter on **Observations**, copy the `filter=` parameter, and paste it onto `/users`. The table loads normally and the parameter disappears, rather than erroring.
6. Switch the v4 preview off and reload: the sidebar is still there, the grammar bar is replaced by the legacy `Search (User ID)` input, and the facet set drops the columns the trace-backed query cannot answer.

## Verification

- `pnpm exec turbo run lint --force` — `Tasks: 7 successful, 7 total`, `Cached: 0 cached, 7 total`
- `pnpm run typecheck` — `Tasks: 8 successful, 8 total`
- `pnpm exec knip` — clean
- `pnpm --filter web run test users-facet-coverage` — `Tests 51 passed (51)` (the two new cases fail against the previous commit)
- `pnpm --filter web run test users-ui-table` — `Tests 2 passed (2)`
- `pnpm --filter web run test-client searchBarInvariants` — `Tests 31 passed (31)`
- `pnpm --filter web run test-client sidebarFilterSessionPersistence` — `Tests 13 passed (13)`
- `pnpm --filter web run test-client filter-config` — `Tests 7 passed (7)`
- Browser: both read paths driven manually against seeded data, plus the cross-page filter paste above.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5436b5a-a22f-4cfa-bed2-a74372a391f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5436b5a-a22f-4cfa-bed2-a74372a391f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62063013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not safe to merge until unsupported v4 URL filters are prevented from reaching the legacy Users query.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**V4 filters break legacy queries** <a href="https://github.com/langfuse/langfuse/pull/17241#discussion_r3967741271">▶</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/filters/config/users-config.ts:67
Both read paths share the `filter` URL parameter, but the v3 config validates persisted filters against the full trace column definitions. Those definitions still include v4-only, join-dependent columns such as `level`, even though they are removed from the v3 facet list. If someone disables v4 while a `level` filter is active, or opens that v4 Users URL using the legacy path, the filter reaches the trace-backed Users query and refers to an observations alias that the query does not join, causing the request to fail. Please restrict the v3 definitions or omit unsupported columns when restoring filter state.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Derives separate v3 and v4 Users facet configurations from existing trace/event definitions.
- Adds a Users-specific search registry and scope-aware completion/explanation behavior.
- Adds server coverage that executes every exposed facet against each Users query path.
- Introduces one read-path transition bug: v4-only URL filters can reach the legacy query.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  URL["URL: filter + search"] --> Core[Users sidebar filter state]
  Core --> Path{Users read path}
  Path -->|v4| EventConfig[Events-derived facets]
  Path -->|v3| TraceConfig[Traces-derived facets]
  EventConfig --> SearchBar[Users grammar search bar]
  SearchBar --> Core
  EventConfig --> EventQuery[events_core grouped by user_id]
  TraceConfig --> TraceQuery[traces grouped by user_id]
  URL -. "v4-only filter survives switch" .-> TraceConfig
  TraceConfig -. "level lowers to unjoined observations alias" .-> Failure[Legacy query failure]
```
</details>

<!-- /greptile_comment -->