### PR TITLE
fix(experiments): link the error count to failing items

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -1956,7 +1956,9 @@ const EXPERIMENTS_AGGREGATION_FIELDS = {
     "nullIf(any(e.experiment_dataset_id), '') AS experiment_dataset_id",
   startTime: "min(e.start_time) AS start_time",
   itemCount: "uniq(e.experiment_item_id) AS item_count",
-  errorCount: "countIf(e.level = 'ERROR') AS error_count",
+  // Distinct items that carry any ERROR event, so the number matches the
+  // items-view Status=ERROR list the badge opens.
+  errorCount: "uniqIf(e.experiment_item_id, e.level = 'ERROR') AS error_count",
   prompts:
     "groupUniqArrayIf(tuple(e.prompt_name, e.prompt_version), e.prompt_name != '') AS prompts",
   experimentMetadata:

--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -4,6 +4,7 @@
 
 import {
   EventsAggregationQueryBuilder,
+  EventsAggQueryBuilder,
   EventsQueryBuilder,
   EventsSessionAggregationQueryBuilder,
   ExperimentsAggregationFieldSetName,
@@ -438,6 +439,33 @@ export const eventsExperimentsRootSpans = (params: {
   eventsExperimentsForItems(params).whereRaw(
     "e.experiment_item_root_span_id = e.span_id",
   );
+
+/**
+ * Worst observation level per experiment item, computed across the item's
+ * full subtree. Filter tables before joining (query-join-filter-before):
+ * scoped to the experiments in play so the CTE never scans the project.
+ */
+export const experimentItemLevelsAggregation = (params: {
+  projectId: string;
+  experimentIds: string[];
+}): { query: string; params: Record<string, any> } =>
+  new EventsAggQueryBuilder({
+    projectId: params.projectId,
+    groupByColumn: "e.experiment_id, e.experiment_item_id",
+    selectExpression: `e.experiment_id AS experiment_id,
+      e.experiment_item_id AS experiment_item_id,
+      multiIf(
+        countIf(e.level = 'ERROR') > 0, 'ERROR',
+        countIf(e.level = 'WARNING') > 0, 'WARNING',
+        countIf(e.level = 'DEFAULT') > 0, 'DEFAULT',
+        'DEBUG'
+      ) AS aggregated_level`,
+  })
+    .whereRaw("e.experiment_id IN ({itemLevelExperimentIds: Array(String)})", {
+      itemLevelExperimentIds: params.experimentIds,
+    })
+    .whereRaw("e.experiment_id != ''")
+    .buildWithParams();
 
 /**
  * Session-level scores aggregation CTE.

--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -24,6 +24,7 @@ import {
   eventsExperiments,
   eventsExperimentsAggregation,
   eventsTracesScoresAggregation,
+  experimentItemLevelsAggregation,
   scoreBooleansAggregation,
 } from "../queries/clickhouse-sql/query-fragments";
 import {
@@ -984,12 +985,22 @@ type BuildQualificationPlanInput = {
   };
 };
 
+const EXPERIMENT_ITEM_LEVEL_FILTER_COLUMNS = [
+  "level",
+  "Status",
+  "Level",
+] as const;
+
+const isExperimentItemLevelFilter = (column: string) =>
+  (EXPERIMENT_ITEM_LEVEL_FILTER_COLUMNS as readonly string[]).includes(column);
+
 type QualificationPlan = {
   where: { query: string; params: Record<string, any> };
   having: { query: string; params: Record<string, any> } | null;
   orderBy: string | null;
   hasAgnosticScoreFilters: boolean;
   hasTraceScoreFilters: boolean;
+  hasLevelFilters: boolean;
 };
 
 function combineConditions(
@@ -1076,6 +1087,9 @@ const buildQualificationPlan = (
       "trace_score_booleans",
     ].includes(f.column),
   );
+  const hasLevelFilters = filters.some((f) =>
+    isExperimentItemLevelFilter(f.column),
+  );
 
   const allExperimentIds = [
     ...(baseExperimentId ? [baseExperimentId] : []),
@@ -1113,6 +1127,7 @@ const buildQualificationPlan = (
     orderBy: `ORDER BY e.experiment_item_id ASC`,
     hasAgnosticScoreFilters,
     hasTraceScoreFilters,
+    hasLevelFilters,
   };
 };
 
@@ -1148,6 +1163,7 @@ const getExperimentItemsFromEventsGeneric = (params: {
     orderBy,
     hasAgnosticScoreFilters,
     hasTraceScoreFilters,
+    hasLevelFilters,
   } = buildQualificationPlan({
     baseExperimentId,
     compExperimentIds,
@@ -1209,6 +1225,24 @@ const getExperimentItemsFromEventsGeneric = (params: {
       b.leftJoin(
         "trace_scores_agg AS ts",
         "ON ts.trace_id = e.trace_id AND ts.project_id = e.project_id",
+      ),
+    )
+    .when(hasLevelFilters, (b) =>
+      b.withCTE(
+        "item_levels",
+        experimentItemLevelsAggregation({
+          projectId,
+          experimentIds: [
+            ...(baseExperimentId ? [baseExperimentId] : []),
+            ...compExperimentIds,
+          ],
+        }),
+      ),
+    )
+    .when(hasLevelFilters, (b) =>
+      b.leftJoin(
+        "item_levels AS il",
+        "ON il.experiment_id = e.experiment_id AND il.experiment_item_id = e.experiment_item_id",
       ),
     )
     .where(where)

--- a/packages/shared/src/server/tableMappings/mapExperimentItemsTable.ts
+++ b/packages/shared/src/server/tableMappings/mapExperimentItemsTable.ts
@@ -58,4 +58,13 @@ export const experimentItemsTableNativeUiColumnDefinitions: UiColumnMappings = [
     clickhouseSelect: "metadata",
     queryPrefix: "e",
   },
+  {
+    uiTableName: "Status",
+    uiTableId: "level",
+    aliases: ["Level"],
+    clickhouseTableName: "events_proto",
+    // Worst level across every event on the item, not just the root span.
+    // An item whose children carry ERROR still matches Status=ERROR.
+    clickhouseSelect: "il.aggregated_level",
+  },
 ];

--- a/packages/shared/src/utils/productUrl.test.ts
+++ b/packages/shared/src/utils/productUrl.test.ts
@@ -2,9 +2,40 @@ import { describe, expect, it } from "vitest";
 import { TableViewPresetTableName } from "../domain/table-view-presets";
 import {
   buildCurrentPageSavedViewPermalink,
+  buildExperimentPath,
   parseSavedViewFromURL,
   tableViewPresetPermalinkUsesCurrentPath,
 } from "./productUrl";
+
+describe("buildExperimentPath", () => {
+  it("links a run to its items view", () => {
+    expect(
+      buildExperimentPath({
+        projectId: "proj_1",
+        experimentId: "exp_1",
+      }),
+    ).toBe("/project/proj_1/experiments/results?baseline=exp_1");
+  });
+
+  it("can pre-apply a shareable items filter", () => {
+    expect(
+      buildExperimentPath({
+        projectId: "proj_1",
+        experimentId: "exp_1",
+        filters: [
+          {
+            column: "level",
+            type: "stringOptions",
+            operator: "any of",
+            value: ["ERROR"],
+          },
+        ],
+      }),
+    ).toBe(
+      "/project/proj_1/experiments/results?baseline=exp_1&filter=level%3BstringOptions%3B%3Bany+of%3BERROR",
+    );
+  });
+});
 
 describe("tableViewPresetPermalinkUsesCurrentPath", () => {
   it("is true only for session detail, which embeds a session id in the path", () => {

--- a/packages/shared/src/utils/productUrl.ts
+++ b/packages/shared/src/utils/productUrl.ts
@@ -192,9 +192,14 @@ export const buildExperimentsPath = (params: { projectId: string }) =>
 export const buildExperimentPath = (params: {
   projectId: string;
   experimentId: string;
+  filters?: FilterState;
 }) =>
   appendProductPathQuery(`${buildExperimentsPath(params)}/results`, {
     baseline: params.experimentId,
+    filter:
+      params.filters && params.filters.length > 0
+        ? encodeFiltersGeneric(params.filters)
+        : undefined,
   });
 
 export const buildModelsPath = (params: { projectId: string }) =>

--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -942,4 +942,17 @@ describe("ExperimentsAggregationQueryBuilder", () => {
       startTimeFrom: "2026-01-01 00:00:00.000",
     });
   });
+
+  it("counts distinct items that carry an ERROR event", () => {
+    const { query } = new ExperimentsAggregationQueryBuilder({
+      projectId: "test-project",
+    })
+      .selectFieldSet("base")
+      .whereRaw("e.experiment_id != ''")
+      .buildWithParams();
+
+    expect(query).toContain(
+      "uniqIf(e.experiment_item_id, e.level = 'ERROR') AS error_count",
+    );
+  });
 });

--- a/web/src/__tests__/server/repositories/experiment-items-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/experiment-items-repository.servertest.ts
@@ -1473,6 +1473,84 @@ describe("Clickhouse Experiment Items Repository Test", () => {
     });
   });
 
+  maybe("getExperimentItemsFromEvents - Level Filtering", () => {
+    it("should include items that carry an ERROR event and exclude items that do not", async () => {
+      const baselineExpId = randomUUID();
+      const datasetId = randomUUID();
+      const failingItemId = randomUUID();
+      const cleanItemId = randomUUID();
+      const failingTraceId = randomUUID();
+      const cleanTraceId = randomUUID();
+      const failingRootId = randomUUID();
+      const failingChildId = randomUUID();
+      const cleanRootId = randomUUID();
+      const now = Date.now() * 1000;
+
+      await createEventsCh([
+        createExperimentEvent({
+          project_id: projectId,
+          trace_id: failingTraceId,
+          span_id: failingRootId,
+          experimentId: baselineExpId,
+          experimentName: "baseline-exp",
+          datasetId,
+          itemId: failingItemId,
+          experimentItemRootSpanId: failingRootId,
+          level: "DEFAULT",
+          start_time: now,
+        }),
+        createExperimentEvent({
+          project_id: projectId,
+          trace_id: failingTraceId,
+          span_id: failingChildId,
+          parent_span_id: failingRootId,
+          experimentId: baselineExpId,
+          experimentName: "baseline-exp",
+          datasetId,
+          itemId: failingItemId,
+          experimentItemRootSpanId: failingRootId,
+          level: "ERROR",
+          start_time: now + 1,
+        }),
+        createExperimentEvent({
+          project_id: projectId,
+          trace_id: cleanTraceId,
+          span_id: cleanRootId,
+          experimentId: baselineExpId,
+          experimentName: "baseline-exp",
+          datasetId,
+          itemId: cleanItemId,
+          experimentItemRootSpanId: cleanRootId,
+          level: "DEFAULT",
+          start_time: now + 2,
+        }),
+      ]);
+
+      const result = await getExperimentItemsFromEvents({
+        projectId,
+        baseExperimentId: baselineExpId,
+        compExperimentIds: [],
+        filterByExperiment: [
+          {
+            experimentId: baselineExpId,
+            filters: [
+              {
+                column: "level",
+                type: "stringOptions",
+                operator: "any of",
+                value: ["ERROR"],
+              } as FilterCondition,
+            ],
+          },
+        ],
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(result.map((row) => row.itemId)).toEqual([failingItemId]);
+    });
+  });
+
   maybe("getExperimentItemsBatchIO", () => {
     it("should fetch IO and truncate to specified length", async () => {
       // GIVEN: Item with long input/output strings

--- a/web/src/__tests__/server/repositories/experiment-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/experiment-repository.servertest.ts
@@ -195,6 +195,91 @@ describe("Clickhouse Experiment Repository Test", () => {
       expect(experiment?.itemCount).toBe(2);
     });
 
+    it("should count items that carry an ERROR event, not every ERROR event", async () => {
+      const experimentId = randomUUID();
+      const experimentName = "experiment-errors-" + randomUUID();
+      const datasetId = randomUUID();
+      const failingItemId = randomUUID();
+      const cleanItemId = randomUUID();
+      const failingRootId = randomUUID();
+      const failingChildId = randomUUID();
+      const cleanRootId = randomUUID();
+      const now = Date.now() * 1000;
+
+      await createEventsCh([
+        createEvent({
+          id: failingRootId,
+          span_id: failingRootId,
+          project_id: projectId,
+          trace_id: randomUUID(),
+          type: "SPAN",
+          experiment_id: experimentId,
+          experiment_name: experimentName,
+          experiment_dataset_id: datasetId,
+          experiment_item_id: failingItemId,
+          experiment_item_root_span_id: failingRootId,
+          level: "DEFAULT",
+          start_time: now,
+        }),
+        createEvent({
+          id: failingChildId,
+          span_id: failingChildId,
+          parent_span_id: failingRootId,
+          project_id: projectId,
+          trace_id: randomUUID(),
+          type: "SPAN",
+          experiment_id: experimentId,
+          experiment_name: experimentName,
+          experiment_dataset_id: datasetId,
+          experiment_item_id: failingItemId,
+          experiment_item_root_span_id: failingRootId,
+          level: "ERROR",
+          start_time: now + 1,
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          parent_span_id: failingRootId,
+          project_id: projectId,
+          trace_id: randomUUID(),
+          type: "SPAN",
+          experiment_id: experimentId,
+          experiment_name: experimentName,
+          experiment_dataset_id: datasetId,
+          experiment_item_id: failingItemId,
+          experiment_item_root_span_id: failingRootId,
+          level: "ERROR",
+          start_time: now + 2,
+        }),
+        createEvent({
+          id: cleanRootId,
+          span_id: cleanRootId,
+          project_id: projectId,
+          trace_id: randomUUID(),
+          type: "SPAN",
+          experiment_id: experimentId,
+          experiment_name: experimentName,
+          experiment_dataset_id: datasetId,
+          experiment_item_id: cleanItemId,
+          experiment_item_root_span_id: cleanRootId,
+          level: "DEFAULT",
+          start_time: now + 3,
+        }),
+      ]);
+
+      const result = await getExperimentsFromEvents({
+        projectId,
+        filter: [],
+        limit: 1000,
+        page: 0,
+      });
+
+      const experiment = result.find((e) => e.id === experimentId);
+      expect(experiment).toBeDefined();
+      expect(experiment?.itemCount).toBe(2);
+      expect(experiment?.errorCount).toBe(1);
+    });
+
     it("should order by startTime DESC", async () => {
       const experimentId1 = randomUUID();
       const experimentName1 = "experiment-1-" + randomUUID();

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -33,6 +33,7 @@ import {
   BatchExportTableName,
   ActionId,
   BatchActionType,
+  buildExperimentPath,
 } from "@langfuse/shared";
 import { numberFormatter } from "@/src/utils/numbers";
 import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
@@ -600,13 +601,42 @@ export default function ExperimentsTable({
       size: 100,
       cell: ({ row }) => {
         const value: number = row.getValue("errorCount");
+        const formatted = numberFormatter(value, 0);
+
+        if (value <= 0) {
+          return (
+            <Badge
+              variant="secondary"
+              className="max-w-fit rounded-sm px-1 font-normal"
+            >
+              {formatted}
+            </Badge>
+          );
+        }
+
         return (
-          <Badge
-            variant={value > 0 ? "destructive" : "secondary"}
-            className="max-w-fit rounded-sm px-1 font-normal"
+          <Link
+            href={buildExperimentPath({
+              projectId,
+              experimentId: row.id,
+              filters: [
+                {
+                  column: "level",
+                  type: "stringOptions",
+                  operator: "any of",
+                  value: ["ERROR"],
+                },
+              ],
+            })}
+            aria-label={`View ${formatted} failing items`}
           >
-            {numberFormatter(value, 0)}
-          </Badge>
+            <Badge
+              variant="destructive"
+              className="hover:bg-destructive/80 max-w-fit cursor-pointer rounded-sm px-1 font-normal"
+            >
+              {formatted}
+            </Badge>
+          </Link>
         );
       },
       enableHiding: true,

--- a/web/src/features/experiments/config/experiment-items-filter-config.ts
+++ b/web/src/features/experiments/config/experiment-items-filter-config.ts
@@ -1,4 +1,5 @@
 import type { FilterConfig } from "@/src/features/filters";
+import { renderLevelIcon } from "@/src/components/level-colors";
 import type { ColumnDefinition, ObservationLevelType } from "@langfuse/shared";
 
 /**
@@ -151,6 +152,12 @@ export const experimentItemsFilterConfig: FilterConfig = {
   columnDefinitions: experimentItemsTableCols,
 
   facets: [
+    {
+      type: "categorical" as const,
+      column: "level",
+      label: getExperimentItemsColumnName("level"),
+      renderIcon: renderLevelIcon,
+    },
     {
       type: "stringKeyValue" as const,
       column: "itemMetadata",

--- a/web/src/features/experiments/hooks/useExperimentItemsFilterOptions.ts
+++ b/web/src/features/experiments/hooks/useExperimentItemsFilterOptions.ts
@@ -8,6 +8,8 @@ export type ScoreColumnDef = {
   source: string;
 };
 
+const EXPERIMENT_ITEM_LEVEL_OPTIONS = ["DEBUG", "DEFAULT", "WARNING", "ERROR"];
+
 const processCategoricalScoreOptions = (
   categories: Array<{ label: string; values: string[] }>,
 ): Record<string, string[]> =>
@@ -53,6 +55,7 @@ export const useExperimentItemsFilterOptions = ({
         score_name_levels_numeric: undefined,
         score_name_levels_categorical: undefined,
         score_name_levels_boolean: undefined,
+        level: EXPERIMENT_ITEM_LEVEL_OPTIONS,
       } satisfies ExperimentItemScoreFilterOptions;
     }
 
@@ -69,6 +72,7 @@ export const useExperimentItemsFilterOptions = ({
       score_name_levels_categorical:
         filterOptions.data.score_name_levels_categorical,
       score_name_levels_boolean: filterOptions.data.score_name_levels_boolean,
+      level: EXPERIMENT_ITEM_LEVEL_OPTIONS,
     } satisfies ExperimentItemScoreFilterOptions;
   }, [filterOptions.data]);
 

--- a/web/src/features/experiments/types/charts.ts
+++ b/web/src/features/experiments/types/charts.ts
@@ -48,6 +48,7 @@ export type ExperimentItemScoreFilterOptions = {
   score_name_levels_numeric?: ScoreNameLevels;
   score_name_levels_categorical?: ScoreNameLevels;
   score_name_levels_boolean?: ScoreNameLevels;
+  level?: string[];
 };
 
 /**


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17243 app preview](https://pr-17243.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The experiment error-count badge was a plain, non-interactive number. Clicking it fired the row handler and opened an unfiltered comparison view, so a workshop learner who saw "22 errors" had no way to open those items.

The badge now:

- counts **distinct items that carry an ERROR-level event** (`uniqIf(experiment_item_id, level = 'ERROR')`), not ERROR events. One item with three failing child spans is `1`, next to the item count.
- is a shareable link into that run's items view with `Status = ERROR` pre-applied, when the count is greater than zero.
- stays a non-interactive badge when the count is zero (the row click still opens the unfiltered run, as it always did).

The items view could not filter by Status at all: `level` existed as a column definition but was missing from the facet list and from the ClickHouse table mapping. This PR adds that mapping as **subtree-worst level** (an ERROR anywhere under the item counts), because a root-only filter would open an empty list for the common case where only child spans fail.

The Status **column** still shows the root span's own level. A filtered ERROR row can therefore still display DEFAULT in the Status cell. That is the main thing to doubt in review.

[pr-17243 app preview](https://pr-17243.preview.langfuse.com)

![Red error-count 1 badge on a 2-item run; status bar shows the Status=ERROR items URL](https://cursor.com/artifacts/c/art-3494cd7e-62a0-4fb0-b79d-a77086295be3)

![Items view with Status ERROR checked and one item whose cell still says DEFAULT](https://cursor.com/artifacts/c/art-602585da-9fbf-4e09-baa6-31475081cc6b)

<a href="https://cursor.com/agents/bc-611fac07-2809-4e4b-ae61-3f256d93c390/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ferror_count_badge_opens_failing_items.mp4"><img src="https://cursor.com/artifacts/c/art-f4cb5ca0-e399-482f-b46d-e229599b5fed" alt="error_count_badge_opens_failing_items.mp4" /></a>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `packages/shared` — error-count aggregation, items-table `level` mapping, subtree-level CTE, `buildExperimentPath` filter query
- `web` — error badge link, Status facet, static level options, repository tests

## Verification

- `pnpm exec turbo run lint --force --filter=web --filter=@langfuse/shared` → Tasks: 5 successful, 5 total; Cached: 0 cached, 5 total
- `pnpm --filter web run test event-query-builder.servertest.ts` → 50 passed
- `pnpm --filter web run test experiment-items-repository.servertest.ts` → 19 passed
- `pnpm --filter web run test experiment-repository.servertest.ts` → 27 passed
- `packages/shared/src/utils/productUrl.test.ts` → 4 passed
- Browser: Cloud stack at `http://localhost:3000`, demo project. Clicked the red `1` on `experiment-errors-08d479a7-…` (2 items). Landed on `/experiments/results?baseline=…&filter=level%3BstringOptions%3B%3Bany+of%3BERROR` with 1 item and Status=ERROR checked. Zero badge on `cost-consistency-exp` opened the unfiltered run (row click; no ERROR filter).

The standard `db:seed` path does not write experiment ERROR rows. Local proof used leftover ClickHouse events from the web repository tests. On the preview, you need a run that already has at least one ERROR-level event.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project (`pnpm run format`)
- I have commented hard-to-understand areas
- I have checked if my PR needs changes to the documentation (no docs change; in-product navigation only)
- I have checked that my changes generate no new warnings (`pnpm run lint`)
- I have added tests that prove the distinct error count and the subtree-level items filter
- I have checked that new and existing unit tests pass locally with my changes

## Test this

Preview: [pr-17243 app preview](https://pr-17243.preview.langfuse.com) (Mon–Fri 08:00–24:00 Europe/Berlin)

1. Open Experiments on a project that already has a run with at least one ERROR-level event.
2. Confirm a non-zero Error Count is smaller than or equal to Item Count when one item has several failing child spans.
3. Click the red badge (not the rest of the row). Expect the items view with Status = ERROR and a row count that matches the badge.
4. Confirm a zero Error Count badge is not a link. Clicking the cell still opens the run via the existing row handler, with no level filter.

Sandbox: same path on `http://localhost:3000` after `bash scripts/agents/start-cursor-cloud.sh`. Demo login `demo@langfuse.com` / `password`. After `pnpm --filter web run test experiment-repository.servertest.ts`, search Experiments for `experiment-errors`.

## What to doubt

- The Status **column** still shows the root span level. After the badge click you will see an ERROR-filtered row whose Status cell says DEFAULT. If the column should follow the filter, that is a follow-up, not this PR.
- The badge now counts items, not events. Anyone who was using the old event count as a tracing shortcut will see a smaller number.
- There is no `pnpm run seed` scenario that creates this shape. Preview synthetic data may have no failing experiment items.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-16114](https://linear.app/clickhouse/issue/LFE-16114/the-experiment-error-count-leads-nowhere-make-it-open-the-failing)

<div><a href="https://cursor.com/agents/bc-611fac07-2809-4e4b-ae61-3f256d93c390?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-611fac07-2809-4e4b-ae61-3f256d93c390&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62074197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no actionable correctness, security, or repository-rule issue remains.

<details><summary><h3>Summary</h3></summary>

- Counts distinct failing experiment items rather than individual ERROR events.
- Adds a subtree-wide worst-level aggregation for experiment-item filtering.
- Exposes Status as an experiment-items filter with static observation-level options.
- Keeps the displayed Status column rooted in the selected root span while filtering against the full item subtree.
- Adds repository and URL-generation coverage for the new behavior.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Experiment events] --> B[Distinct item IDs with ERROR events]
  B --> C[Nonzero error-count badge]
  C -->|click| D[Results URL with baseline and Status=ERROR]
  D --> E[Decode URL filter]
  E --> F[Build item-level aggregation CTE]
  F --> G[Worst level across each item's subtree]
  G --> H[Return matching experiment items]
```
</details>

<!-- /greptile_comment -->