### PR TITLE
fix(agents): keep onboarding identity inside the checkout

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -8,20 +8,20 @@ evaluating, and debugging AI applications.
 This repo serves two different people, and they get different halves of it.
 Work out which before anything else, and never guess silently.
 
-It is a configuration question, not an interview. Read `.langfuse/me.md` if
-it exists in this checkout. Do **not** Read or Write
-`~/.config/langfuse/me.md` — that path is outside the project, and
-workspace-scoped harnesses (OpenCode) prompt on it. Identity there is
-optional; if the workspace file is missing, `langfuse-onboarding` step 1
-names them. On Cursor Cloud that is the run owner (`cursor-cloud`
-`run-info`) plus the team roster — **not** `gh api …permissions`, because
-Cloud's GitHub token is a read-only integration and reports `push: false`
-for maintainers. Desktop still uses `gh api user` then `.permissions.push`.
-For anything those cannot tell you — which areas they work on — **just
-ask, once**, and write the answer to `.langfuse/me.md` so nobody asks
-again. Someone who has worked here for a year does not need onboarding;
-they need you to know their name. `langfuse-onboarding` is for people who
-are actually new.
+It is a configuration question, not an interview. Read the workspace
+identity file in `.langfuse/` (`me.md`, gitignored) if it exists. Do
+**not** Read or Write `~/.config/langfuse/me.md` — that path is outside
+the project, and workspace-scoped harnesses (OpenCode) prompt on it.
+Identity there is optional; if the workspace file is missing,
+`langfuse-onboarding` step 1 names them. On Cursor Cloud that is the run
+owner (`cursor-cloud` `run-info`) plus the team roster — **not**
+`gh api …permissions`, because Cloud's GitHub token is a read-only
+integration and reports `push: false` for maintainers. Desktop still uses
+`gh api user` then `.permissions.push`. For anything those cannot tell
+you — which areas they work on — **just ask, once**, and write the
+answer into `.langfuse/` so nobody asks again. Someone who has worked
+here for a year does not need onboarding; they need you to know their
+name. `langfuse-onboarding` is for people who are actually new.
 
 **An outside contributor** gets the code and `CONTRIBUTING.md`: how to build it,
 what the checks require, how to open a pull request. Nothing about the tracker,
@@ -62,9 +62,10 @@ than two sentences they read.
 
 - Know who you are working for before you assume what they may do. An outside
   contributor and a Langfuse maintainer get different halves of this repo, and
-  the difference is derivable — `.langfuse/me.md` if it exists, else
-  `langfuse-onboarding` step 1 (Cloud run owner, not Cloud `gh` permissions).
-  Do not Read `~/.config/langfuse/me.md`. Never guess it silently.
+  the difference is derivable — the workspace identity file in `.langfuse/`
+  if it exists, else `langfuse-onboarding` step 1 (Cloud run owner, not
+  Cloud `gh` permissions). Do not Read `~/.config/langfuse/me.md`. Never
+  guess it silently.
 - Read the minimal local context required for the task.
 - Keep changes scoped and avoid unrelated refactors.
 - Delegate exploratory or noisy work — broad code search, multi-file
@@ -205,11 +206,11 @@ langfuse/
 ### Cursor Cloud specific instructions
 
 - Identity: `cursor-cloud` `run-info` (`owningUserName`, `owningUserEmail`),
-  then the roster. Repo postinstall and Cloud start normally recover
-  `.langfuse/me.md` from `LINEAR_API_KEY` first (and a machine-level copy
-  under `~/.config/langfuse` when the harness allows it). Read the
-  workspace file. Ignore `git config` (`cursoragent@cursor.com`) and Cloud
-  `gh` `.permissions.push`.
+  then the roster. Repo postinstall and Cloud start normally recover the
+  workspace identity file in `.langfuse/` from `LINEAR_API_KEY` first (and
+  a machine-level copy under `~/.config/langfuse` when the harness allows
+  it). Read the workspace file. Ignore `git config`
+  (`cursoragent@cursor.com`) and Cloud `gh` `.permissions.push`.
 - Linear: MCP if already authorized; else a real read with `LINEAR_API_KEY`
   (or `LINEAR_TOKEN` / `LINEAR_API_TOKEN`). Interactive `mcp_auth` does not
   work in Cloud. If neither works, tell them to add **`LINEAR_API_KEY`** as a

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -8,16 +8,20 @@ evaluating, and debugging AI applications.
 This repo serves two different people, and they get different halves of it.
 Work out which before anything else, and never guess silently.
 
-It is a configuration question, not an interview. Read
-`~/.config/langfuse/me.md`; if it is not there, `langfuse-onboarding` step 1
-names them. On Cursor Cloud that is the run owner (`cursor-cloud` `run-info`)
-plus the team roster — **not** `gh api …permissions`, because Cloud's GitHub
-token is a read-only integration and reports `push: false` for maintainers.
-Desktop still uses `gh api user` then `.permissions.push`. For anything those
-cannot tell you — which areas they work on — **just ask, once**, and write the
-answer to that file so nobody asks again. Someone who has worked here for a
-year does not need onboarding; they need you to know their name.
-`langfuse-onboarding` is for people who are actually new.
+It is a configuration question, not an interview. Read `.langfuse/me.md` if
+it exists in this checkout. Do **not** Read or Write
+`~/.config/langfuse/me.md` — that path is outside the project, and
+workspace-scoped harnesses (OpenCode) prompt on it. Identity there is
+optional; if the workspace file is missing, `langfuse-onboarding` step 1
+names them. On Cursor Cloud that is the run owner (`cursor-cloud`
+`run-info`) plus the team roster — **not** `gh api …permissions`, because
+Cloud's GitHub token is a read-only integration and reports `push: false`
+for maintainers. Desktop still uses `gh api user` then `.permissions.push`.
+For anything those cannot tell you — which areas they work on — **just
+ask, once**, and write the answer to `.langfuse/me.md` so nobody asks
+again. Someone who has worked here for a year does not need onboarding;
+they need you to know their name. `langfuse-onboarding` is for people who
+are actually new.
 
 **An outside contributor** gets the code and `CONTRIBUTING.md`: how to build it,
 what the checks require, how to open a pull request. Nothing about the tracker,
@@ -58,9 +62,9 @@ than two sentences they read.
 
 - Know who you are working for before you assume what they may do. An outside
   contributor and a Langfuse maintainer get different halves of this repo, and
-  the difference is derivable — `~/.config/langfuse/me.md` if it exists, else
+  the difference is derivable — `.langfuse/me.md` if it exists, else
   `langfuse-onboarding` step 1 (Cloud run owner, not Cloud `gh` permissions).
-  Never guess it silently.
+  Do not Read `~/.config/langfuse/me.md`. Never guess it silently.
 - Read the minimal local context required for the task.
 - Keep changes scoped and avoid unrelated refactors.
 - Delegate exploratory or noisy work — broad code search, multi-file
@@ -202,8 +206,10 @@ langfuse/
 
 - Identity: `cursor-cloud` `run-info` (`owningUserName`, `owningUserEmail`),
   then the roster. Repo postinstall and Cloud start normally recover
-  `~/.config/langfuse/me.md` from `LINEAR_API_KEY` first. Ignore `git config`
-  (`cursoragent@cursor.com`) and Cloud `gh` `.permissions.push`.
+  `.langfuse/me.md` from `LINEAR_API_KEY` first (and a machine-level copy
+  under `~/.config/langfuse` when the harness allows it). Read the
+  workspace file. Ignore `git config` (`cursoragent@cursor.com`) and Cloud
+  `gh` `.permissions.push`.
 - Linear: MCP if already authorized; else a real read with `LINEAR_API_KEY`
   (or `LINEAR_TOKEN` / `LINEAR_API_TOKEN`). Interactive `mcp_auth` does not
   work in Cloud. If neither works, tell them to add **`LINEAR_API_KEY`** as a

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -234,10 +234,13 @@ Each agent run starts the six-service source stack with
 
 Identity recovery runs in both repo postinstall and Cursor Cloud start. When
 `LINEAR_API_KEY` is available, it verifies the viewer belongs to the Langfuse
-team and creates `~/.config/langfuse/me.md` without exposing the key. The file
-is never overwritten, so human corrections survive repeated installs and
-worktrees. Running it at Cloud start matters because environment builds do not
-rerun install for each new agent.
+team and writes `.langfuse/me.md` (gitignored, inside the checkout) without
+exposing the key. A machine-level copy under `~/.config/langfuse` is also
+written when the harness allows home-dir access; OpenCode and similar
+workspace-scoped tools skip that path so they do not prompt on the user
+dir. Neither file is overwritten, so human corrections survive repeated
+installs and worktrees. Running it at Cloud start matters because
+environment builds do not rerun install for each new agent.
 
 The start script builds and waits for web, worker, PostgreSQL, ClickHouse,
 Redis, and MinIO, seeds the synthetic demo project, and verifies the web and

--- a/.agents/skills/langfuse-onboarding/SKILL.md
+++ b/.agents/skills/langfuse-onboarding/SKILL.md
@@ -6,8 +6,10 @@ description: |
   Cloud, identify the run owner (not Cloud gh permissions) and treat missing
   Linear as a LINEAR_API_KEY secret to set. Use on "onboard me", "I'm new here",
   "what do I need to set up", "am I set up correctly", "why can't you see my
-  tickets", "what should I do today" when me.md is missing, and whenever you
-  need someone's role and no identity file exists yet.
+  tickets", "what should I do today" when me.md is missing, whenever you
+  need someone's role and no identity file exists yet, and when a
+  workspace-scoped harness (OpenCode) prompts on ~/.config or other
+  user-dir paths.
 ---
 
 # Onboarding at Langfuse
@@ -27,10 +29,14 @@ for a maintainer comes from the first, so do that before anything else.
 ## Step 1 — name them, then prove Linear; do not ask what you can find out
 
 Normal path: `scripts/agents/configure-langfuse-identity.sh` already ran from
-repo postinstall or Cursor Cloud start and created
-`~/.config/langfuse/me.md` from the Linear viewer. Read it and continue. It
-never overwrites an existing file, so the human's Focus and corrections survive
-across worktrees.
+repo postinstall or Cursor Cloud start and wrote a workspace identity file
+at `.langfuse/me.md` (gitignored) from the Linear viewer. Read **that**
+file — it is inside the project. Do **not** Read, Write, or bash
+`~/.config/langfuse/me.md` or any other path under `$HOME`. Workspace-scoped
+harnesses (OpenCode and similar) prompt on every access outside the project;
+identity is optional there, so skip it rather than ask the human to approve
+the user dir. If a tool call to a home path is denied, treat identity as
+absent and continue — do not retry.
 
 Run the local probe first, then stop at the first path that names a person:
 
@@ -38,14 +44,17 @@ Run the local probe first, then stop at the first path that names a person:
 bash .agents/skills/langfuse-onboarding/scripts/whoami.sh
 ```
 
-It reports whether `me.md` exists, whether a Linear token is in the environment
-(boolean only — it never prints the secret), a `linear_viewer` line if that
-token works, and whether `gh api user` works. On Cursor Cloud, a working
-`linear_viewer` is tracker identity even when Linear MCP is `needsAuth`.
+The probe does not stat `$HOME` unless `LANGFUSE_ALLOW_HOME_IDENTITY=1`.
+It reports whether a workspace (or opted-in) `me.md` exists, whether a
+Linear token is in the environment (boolean only — it never prints the
+secret), a `linear_viewer` line if that token works, and whether
+`gh api user` works. On Cursor Cloud, a working `linear_viewer` is tracker
+identity even when Linear MCP is `needsAuth`.
 
 **Who, in this order:**
 
-1. **`~/.config/langfuse/me.md`** — already recorded. Skip to Linear.
+1. **Workspace `me.md`** — `.langfuse/me.md` in this checkout, as reported
+   by `whoami.sh`. Already recorded. Skip to Linear.
 2. **Cursor Cloud run owner.** If `cursor-cloud` tools exist, call `run-info`.
    Use `owningUserName` and `owningUserEmail`. Join the name to the roster
    (`components-mdx/team-members.mdx` in a docs checkout, or
@@ -93,9 +102,11 @@ Say what you found and let them correct it. Never announce a role silently.
 
 ## Step 2 — record it, so this happens once
 
-Write `~/.config/langfuse/me.md`. Machine-level on purpose: it has to answer the
-question in `langfuse`, in `langfuse-docs`, and in a scratch directory, so it
-cannot live in one repo. Create the directory if it does not exist.
+Write `.langfuse/me.md` in this checkout (gitignored). That path stays inside
+the project, so OpenCode and other workspace-scoped harnesses do not prompt.
+Do not write `~/.config/langfuse/me.md` from an agent session — postinstall
+and Cloud start still recover a machine-level copy when the harness allows
+it. If a home-dir write is denied, ignore it and keep the workspace file.
 
 ```markdown
 # Me, at Langfuse
@@ -110,9 +121,10 @@ cannot live in one repo. Create the directory if it does not exist.
 - *Recorded <date> by an agent. Edit freely; delete to be asked again.*
 ```
 
-**Never commit this file, and never put a secret in it.** It is notes, not
-config: no tokens, no keys. A repo `.env` is the wrong home — those are
-app configuration and one careless `git add` publishes them.
+**Never commit this file, and never put a secret in it.** `.langfuse/` is
+gitignored. It is notes, not config: no tokens, no keys. A repo `.env` is
+the wrong home — those are app configuration and one careless `git add`
+publishes them.
 
 **Ask for Focus — once — rather than deriving it.** What someone owns on paper
 and what they are responsible for this quarter are different things, and only
@@ -219,11 +231,12 @@ alternative is a clone in the middle of a task.
 
 ```bash
 git rev-parse --show-toplevel                        # where am I
-ls -d ../langfuse-docs ~/code/langfuse-docs 2>/dev/null   # is the docs repo here
+ls -d ../langfuse-docs 2>/dev/null                   # is the docs repo a sibling
 ```
 
-If `langfuse-docs` is missing, say so plainly and give the command — do not
-carry on and hope:
+Do not `ls` under `$HOME` (`~/code/langfuse-docs` and similar). If the
+sibling path is missing, say so plainly and give the clone command — do
+not search the user dir, and do not carry on and hope:
 
 ```bash
 git clone git@github.com:langfuse/langfuse-docs.git

--- a/.agents/skills/langfuse-onboarding/SKILL.md
+++ b/.agents/skills/langfuse-onboarding/SKILL.md
@@ -124,7 +124,8 @@ it. If a home-dir write is denied, ignore it and keep the workspace file.
 **Never commit this file, and never put a secret in it.** `.langfuse/` is
 gitignored. It is notes, not config: no tokens, no keys. A repo `.env` is
 the wrong home — those are app configuration and one careless `git add`
-publishes them.
+publishes them. Delete the workspace `me.md` to be asked again — recovery
+re-queries Linear and does not copy `~/.config/langfuse/me.md` back over it.
 
 **Ask for Focus — once — rather than deriving it.** What someone owns on paper
 and what they are responsible for this quarter are different things, and only

--- a/.agents/skills/langfuse-onboarding/agents/openai.yaml
+++ b/.agents/skills/langfuse-onboarding/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Langfuse Onboarding"
-  short_description: "Name you, then check Linear, including Cursor Cloud"
-  default_prompt: "Use $langfuse-onboarding to work out who I am (Cloud run owner, not Cloud gh permissions), whether Linear answers, and if not tell me to set LINEAR_API_KEY."
+  short_description: "Name you, then check Linear, without leaving the project"
+  default_prompt: "Use $langfuse-onboarding to work out who I am from the workspace identity file or Cloud run owner (not Cloud gh permissions), whether Linear answers, and if not tell me to set LINEAR_API_KEY. Do not read ~/.config."

--- a/.agents/skills/langfuse-onboarding/scripts/whoami.sh
+++ b/.agents/skills/langfuse-onboarding/scripts/whoami.sh
@@ -1,15 +1,34 @@
 #!/usr/bin/env bash
 # Probe identity signals for langfuse-onboarding. Never prints secret values.
+#
+# Do not stat $HOME/.config unless the caller opted in. Workspace-scoped
+# harnesses (OpenCode and similar) prompt on any path outside the project,
+# and identity is optional there — skip it rather than ask the human.
 set -euo pipefail
 
-me="${HOME}/.config/langfuse/me.md"
-if [[ -f "${me}" ]]; then
-  echo "me.md: present (${me})"
-else
-  echo "me.md: absent"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+workspace_me="${LANGFUSE_WORKSPACE_IDENTITY_DIR:-$repo_root/.langfuse}/me.md"
+
+me_reported=0
+report_me() {
+  echo "me.md: present (${1})"
+  me_reported=1
+}
+
+if [[ -n "${LANGFUSE_CONFIG_DIR:-}" && -f "${LANGFUSE_CONFIG_DIR}/me.md" ]]; then
+  report_me "${LANGFUSE_CONFIG_DIR}/me.md"
+elif [[ -f "${workspace_me}" ]]; then
+  report_me "${workspace_me}"
+elif [[ "${LANGFUSE_ALLOW_HOME_IDENTITY:-}" == "1" ]]; then
+  home_me="${HOME}/.config/langfuse/me.md"
+  if [[ -f "${home_me}" ]]; then
+    report_me "${home_me}"
+  fi
 fi
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+if [[ "${me_reported}" -eq 0 ]]; then
+  echo "me.md: absent"
+fi
 
 # Every signal below is independent, so no probe may abort the others: a
 # blocked Linear route must not hide the GitHub lines, and vice versa.

--- a/.agents/skills/linear-work-rhythm/SKILL.md
+++ b/.agents/skills/linear-work-rhythm/SKILL.md
@@ -18,8 +18,10 @@ description: |
 change daily, and a plausible answer assembled from memory is worse than no
 answer because nobody can tell it is stale.
 
-Who the person is comes from `~/.config/langfuse/me.md`. If it is not there,
-run [`langfuse-onboarding`](../langfuse-onboarding/SKILL.md) step 1 — on Cursor
+Who the person is comes from `.langfuse/me.md` in this checkout, or from
+`langfuse-onboarding` `whoami.sh`. Do not Read `~/.config/langfuse/me.md`.
+If the workspace file is not there, run
+[`langfuse-onboarding`](../langfuse-onboarding/SKILL.md) step 1 — on Cursor
 Cloud that is `run-info` plus the roster, **not** Cloud `gh` permissions, and
 not a "what's your name" interview. Do not guess, and do not answer this
 question for an outside contributor, who owns none of it.

--- a/.gitignore
+++ b/.gitignore
@@ -113,5 +113,8 @@ web/test-results/*
 # Local overrides for AGENTS.md
 **/AGENTS.override.md
 
+# Agent identity (workspace copy; never commit)
+.langfuse/
+
 # Superset config
 .superset/

--- a/scripts/agents/configure-langfuse-identity.sh
+++ b/scripts/agents/configure-langfuse-identity.sh
@@ -71,6 +71,9 @@ fi
 
 if [[ "$mode" = "write" && -n "$workspace_identity_file" && -f "$workspace_identity_file" ]]; then
   echo "Langfuse identity: already configured at $workspace_identity_file"
+  # An OpenCode-first run may have only the workspace file. A later Cloud
+  # start or desktop postinstall should still seed the machine-level copy.
+  install_identity_file "$identity_dir" "$workspace_identity_file"
   exit 0
 fi
 

--- a/scripts/agents/configure-langfuse-identity.sh
+++ b/scripts/agents/configure-langfuse-identity.sh
@@ -3,8 +3,6 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-identity_dir="${LANGFUSE_CONFIG_DIR:-$HOME/.config/langfuse}"
-identity_file="$identity_dir/me.md"
 mode="${1:-write}"
 
 if [[ "$mode" != "write" && "$mode" != "--probe" ]]; then
@@ -12,8 +10,67 @@ if [[ "$mode" != "write" && "$mode" != "--probe" ]]; then
   exit 2
 fi
 
-if [[ -f "$identity_file" && "$mode" = "write" ]]; then
+# Home identity is machine-level. Workspace-scoped harnesses (OpenCode) prompt
+# on any $HOME path, so only touch it when the caller redirected the directory,
+# opted in, or this is a normal non-OpenCode install.
+opencode_env="${OPENCODE:-}${OPENCODE_DIR:-}${OPENCODE_BIN:-}${OPENCODE_CONFIG:-}"
+allow_home=0
+if [[ -n "${LANGFUSE_CONFIG_DIR:-}" || "${LANGFUSE_ALLOW_HOME_IDENTITY:-}" == "1" ]]; then
+  allow_home=1
+elif [[ -z "$opencode_env" ]]; then
+  allow_home=1
+fi
+
+if [[ -n "${LANGFUSE_CONFIG_DIR:-}" ]]; then
+  identity_dir="$LANGFUSE_CONFIG_DIR"
+elif [[ "$allow_home" -eq 1 ]]; then
+  identity_dir="$HOME/.config/langfuse"
+else
+  identity_dir=""
+fi
+identity_file="${identity_dir:+$identity_dir/me.md}"
+
+# Mirror into the checkout so agents can read identity without leaving the
+# project. Tests that redirect LANGFUSE_CONFIG_DIR must set
+# LANGFUSE_WORKSPACE_IDENTITY_DIR if they want this path exercised.
+workspace_identity_dir=""
+if [[ -n "${LANGFUSE_WORKSPACE_IDENTITY_DIR:-}" ]]; then
+  workspace_identity_dir="$LANGFUSE_WORKSPACE_IDENTITY_DIR"
+elif [[ -z "${LANGFUSE_CONFIG_DIR:-}" ]]; then
+  workspace_identity_dir="$repo_root/.langfuse"
+fi
+workspace_identity_file="${workspace_identity_dir:+$workspace_identity_dir/me.md}"
+
+install_identity_file() {
+  local dest_dir="$1"
+  local source="$2"
+  local dest_file="$dest_dir/me.md"
+
+  if [[ -z "$dest_dir" || ! -f "$source" ]]; then
+    return 0
+  fi
+  if [[ -f "$dest_file" ]]; then
+    return 0
+  fi
+  umask 077
+  if ! mkdir -p "$dest_dir"; then
+    echo "Langfuse identity: could not create $dest_dir; onboarding can retry during the agent session."
+    return 0
+  fi
+  chmod 700 "$dest_dir" || true
+  if cp "$source" "$dest_file"; then
+    echo "Langfuse identity: wrote $dest_file"
+  fi
+}
+
+if [[ "$mode" = "write" && -n "$identity_file" && -f "$identity_file" ]]; then
   echo "Langfuse identity: already configured at $identity_file"
+  install_identity_file "$workspace_identity_dir" "$identity_file"
+  exit 0
+fi
+
+if [[ "$mode" = "write" && -n "$workspace_identity_file" && -f "$workspace_identity_file" ]]; then
+  echo "Langfuse identity: already configured at $workspace_identity_file"
   exit 0
 fi
 
@@ -82,27 +139,21 @@ PY
   exit 0
 fi
 
-umask 077
-if ! mkdir -p "$identity_dir"; then
-  echo "Langfuse identity: could not create $identity_dir; onboarding can retry during the agent session."
-  exit 0
-fi
-chmod 700 "$identity_dir"
-
-tmp_file="$(mktemp "$identity_dir/.me.md.XXXXXX")"
+tmp_dir="$(mktemp -d)"
+tmp_file="$tmp_dir/me.md"
 cleanup() {
-  rm -f "$tmp_file"
+  rm -rf "$tmp_dir"
 }
 trap cleanup EXIT
 
 set +e
-LINEAR_RESPONSE="$response" python3 - "$identity_file" "$tmp_file" "$repo_root" <<'PY'
+LINEAR_RESPONSE="$response" python3 - "$tmp_file" "$repo_root" <<'PY'
 import datetime
 import json
 import os
 import sys
 
-identity_file, tmp_file, repo_root = sys.argv[1:]
+tmp_file, repo_root = sys.argv[1:]
 try:
     payload = json.loads(os.environ["LINEAR_RESPONSE"])
 except json.JSONDecodeError:
@@ -143,8 +194,7 @@ content = f"""# Me, at Langfuse
 
 with open(tmp_file, "w", encoding="utf-8") as file:
     file.write(content)
-os.replace(tmp_file, identity_file)
-print(f"Langfuse identity: recovered {name} <{email}> at {identity_file}")
+print(f"Langfuse identity: recovered {name} <{email}>")
 PY
 status=$?
 set -e
@@ -153,3 +203,6 @@ if [[ "$status" -ne 0 ]]; then
   echo "Langfuse identity: recovery skipped; onboarding can retry during the agent session."
   exit 0
 fi
+
+install_identity_file "$identity_dir" "$tmp_file"
+install_identity_file "$workspace_identity_dir" "$tmp_file"

--- a/scripts/agents/configure-langfuse-identity.sh
+++ b/scripts/agents/configure-langfuse-identity.sh
@@ -58,21 +58,21 @@ install_identity_file() {
     return 0
   fi
   chmod 700 "$dest_dir" || true
-  if cp "$source" "$dest_file"; then
+  local tmp_file
+  tmp_file="$(mktemp "$dest_dir/.me.md.XXXXXX")" || return 0
+  if cp "$source" "$tmp_file" && mv -f "$tmp_file" "$dest_file"; then
     echo "Langfuse identity: wrote $dest_file"
+  else
+    rm -f "$tmp_file"
   fi
 }
 
-if [[ "$mode" = "write" && -n "$identity_file" && -f "$identity_file" ]]; then
-  echo "Langfuse identity: already configured at $identity_file"
-  install_identity_file "$workspace_identity_dir" "$identity_file"
-  exit 0
-fi
-
+# The workspace file is what agents edit and delete. Do not refill it from
+# the home copy — that would undo "delete to be asked again". A missing
+# workspace copy falls through to Linear. If only the workspace file
+# exists, still seed a missing home copy.
 if [[ "$mode" = "write" && -n "$workspace_identity_file" && -f "$workspace_identity_file" ]]; then
   echo "Langfuse identity: already configured at $workspace_identity_file"
-  # An OpenCode-first run may have only the workspace file. A later Cloud
-  # start or desktop postinstall should still seed the machine-level copy.
   install_identity_file "$identity_dir" "$workspace_identity_file"
   exit 0
 fi

--- a/scripts/agents/configure-langfuse-identity.test.sh
+++ b/scripts/agents/configure-langfuse-identity.test.sh
@@ -143,4 +143,76 @@ grep -Fq "linear_token: set (LINEAR_API_KEY)" <<<"$unreachable_output"
 grep -Fq "linear_viewer: unavailable" <<<"$unreachable_output"
 test ! -e "$tmpdir/unreachable/me.md"
 
+cat >"$tmpdir/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s' "$LINEAR_FIXTURE"
+EOF
+chmod +x "$tmpdir/bin/curl"
+
+# Workspace-scoped harnesses must not stat $HOME/.config. A file that exists
+# only under HOME is absent unless LANGFUSE_ALLOW_HOME_IDENTITY=1.
+mkdir -p "$tmpdir/hidden-home/.config/langfuse"
+printf 'home identity\n' >"$tmpdir/hidden-home/.config/langfuse/me.md"
+whoami_script="$repo_root/.agents/skills/langfuse-onboarding/scripts/whoami.sh"
+
+empty_workspace="$tmpdir/empty-workspace"
+mkdir -p "$empty_workspace"
+hidden_home_output="$(
+  env \
+    -u LANGFUSE_CONFIG_DIR \
+    -u LANGFUSE_ALLOW_HOME_IDENTITY \
+    PATH="$tmpdir/bin:$PATH" \
+    HOME="$tmpdir/hidden-home" \
+    LANGFUSE_WORKSPACE_IDENTITY_DIR="$empty_workspace" \
+      bash "$whoami_script"
+)"
+grep -Fq "me.md: absent" <<<"$hidden_home_output"
+if grep -Fq "hidden-home" <<<"$hidden_home_output"; then
+  echo "whoami.sh touched HOME without LANGFUSE_ALLOW_HOME_IDENTITY"
+  exit 1
+fi
+
+opt_in_home_output="$(
+  PATH="$tmpdir/bin:$PATH" \
+  HOME="$tmpdir/hidden-home" \
+  LANGFUSE_ALLOW_HOME_IDENTITY=1 \
+  LANGFUSE_WORKSPACE_IDENTITY_DIR="$empty_workspace" \
+    bash "$whoami_script"
+)"
+grep -Fq "me.md: present ($tmpdir/hidden-home/.config/langfuse/me.md)" <<<"$opt_in_home_output"
+
+workspace_identity="$tmpdir/workspace-identity"
+mkdir -p "$workspace_identity"
+printf 'workspace identity\n' >"$workspace_identity/me.md"
+workspace_output="$(
+  PATH="$tmpdir/bin:$PATH" \
+  HOME="$tmpdir/hidden-home" \
+  LANGFUSE_WORKSPACE_IDENTITY_DIR="$workspace_identity" \
+    bash "$whoami_script"
+)"
+grep -Fq "me.md: present ($workspace_identity/me.md)" <<<"$workspace_output"
+
+# Recovery under OpenCode must write the workspace copy and leave HOME alone.
+opencode_home="$tmpdir/opencode-home"
+opencode_workspace="$tmpdir/opencode-workspace"
+PATH="$tmpdir/bin:$PATH" \
+LINEAR_API_KEY="test-secret-that-must-not-be-written" \
+LINEAR_FIXTURE="$fixture" \
+OPENCODE=1 \
+HOME="$opencode_home" \
+LANGFUSE_WORKSPACE_IDENTITY_DIR="$opencode_workspace" \
+  bash "$repo_root/scripts/agents/configure-langfuse-identity.sh"
+test ! -e "$opencode_home/.config/langfuse/me.md"
+grep -Fq -- "- **Name:** Nikita Kabardin" "$opencode_workspace/me.md"
+
+# Redirected LANGFUSE_CONFIG_DIR still seeds an explicit workspace copy.
+PATH="$tmpdir/bin:$PATH" \
+LINEAR_API_KEY="test-secret-that-must-not-be-written" \
+LINEAR_FIXTURE="$fixture" \
+LANGFUSE_CONFIG_DIR="$tmpdir/redirected-home" \
+LANGFUSE_WORKSPACE_IDENTITY_DIR="$tmpdir/redirected-workspace" \
+  bash "$repo_root/scripts/agents/configure-langfuse-identity.sh"
+grep -Fq -- "- **Name:** Nikita Kabardin" "$tmpdir/redirected-home/me.md"
+grep -Fq -- "- **Name:** Nikita Kabardin" "$tmpdir/redirected-workspace/me.md"
+
 echo "Langfuse identity recovery tests passed"

--- a/scripts/agents/configure-langfuse-identity.test.sh
+++ b/scripts/agents/configure-langfuse-identity.test.sh
@@ -216,6 +216,23 @@ LANGFUSE_WORKSPACE_IDENTITY_DIR="$opencode_workspace" \
   bash "$repo_root/scripts/agents/configure-langfuse-identity.sh"
 grep -Fq -- "- **Name:** Nikita Kabardin" "$opencode_then_home/me.md"
 
+# Deleting the workspace file must re-query Linear, not copy a stale home
+# file back. The home copy is left as the human last edited it.
+printf '\nstale home focus\n' >>"$opencode_then_home/me.md"
+rm -f "$opencode_workspace/me.md"
+PATH="$tmpdir/bin:$PATH" \
+LINEAR_API_KEY="test-secret-that-must-not-be-written" \
+LINEAR_FIXTURE="$fixture" \
+LANGFUSE_CONFIG_DIR="$opencode_then_home" \
+LANGFUSE_WORKSPACE_IDENTITY_DIR="$opencode_workspace" \
+  bash "$repo_root/scripts/agents/configure-langfuse-identity.sh"
+grep -Fq -- "- **Name:** Nikita Kabardin" "$opencode_workspace/me.md"
+if grep -Fq "stale home focus" "$opencode_workspace/me.md"; then
+  echo "Workspace identity was refilled from the home copy"
+  exit 1
+fi
+grep -Fq "stale home focus" "$opencode_then_home/me.md"
+
 # Redirected LANGFUSE_CONFIG_DIR still seeds an explicit workspace copy.
 PATH="$tmpdir/bin:$PATH" \
 LINEAR_API_KEY="test-secret-that-must-not-be-written" \

--- a/scripts/agents/configure-langfuse-identity.test.sh
+++ b/scripts/agents/configure-langfuse-identity.test.sh
@@ -205,6 +205,17 @@ LANGFUSE_WORKSPACE_IDENTITY_DIR="$opencode_workspace" \
 test ! -e "$opencode_home/.config/langfuse/me.md"
 grep -Fq -- "- **Name:** Nikita Kabardin" "$opencode_workspace/me.md"
 
+# OpenCode-first recovery leaves only the workspace file; a later normal
+# install with home access must seed the machine-level copy from it.
+opencode_then_home="$tmpdir/opencode-then-home"
+PATH="$tmpdir/bin:$PATH" \
+LINEAR_API_KEY="test-secret-that-must-not-be-written" \
+LINEAR_FIXTURE="$fixture" \
+LANGFUSE_CONFIG_DIR="$opencode_then_home" \
+LANGFUSE_WORKSPACE_IDENTITY_DIR="$opencode_workspace" \
+  bash "$repo_root/scripts/agents/configure-langfuse-identity.sh"
+grep -Fq -- "- **Name:** Nikita Kabardin" "$opencode_then_home/me.md"
+
 # Redirected LANGFUSE_CONFIG_DIR still seeds an explicit workspace copy.
 PATH="$tmpdir/bin:$PATH" \
 LINEAR_API_KEY="test-secret-that-must-not-be-written" \


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17246 app preview](https://pr-17246.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Workspace-scoped agent harnesses (OpenCode and similar) prompt on every path outside the project. The onboarding skill told agents to read and write `~/.config/langfuse/me.md` and to `ls` under `$HOME`, so a session spent its time asking for user-dir access.

Identity is optional in those harnesses. This change:

- Writes a gitignored workspace copy at `.langfuse/me.md` from postinstall / Cloud start
- Stops `whoami.sh` from stating `$HOME/.config` unless `LANGFUSE_ALLOW_HOME_IDENTITY=1`
- Skips the home-dir write when OpenCode env vars are set
- Tells agents to read the workspace file only — never `~/.config` or `~/code/...`

Cursor Cloud and Claude Code still recover a machine-level copy when the harness allows it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Impacted: `.agents/skills/langfuse-onboarding`, `.agents/AGENTS.md`, `scripts/agents/configure-langfuse-identity.sh`
- `bash scripts/agents/configure-langfuse-identity.test.sh` — `Langfuse identity recovery tests passed`
- `bash scripts/agents/start-cursor-cloud.test.sh` — `Cursor Cloud startup command regression test passed`
- `pnpm run agents:sync` then `pnpm run agents:check` — path check green after citing `.langfuse/` instead of a missing `me.md`
- Pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total` (`Cached: 6 cached, 7 total` on the follow-up commit)

## Test this

In OpenCode, run any task that would have loaded onboarding (or `whoami.sh` directly):

1. Confirm there is no permission prompt for `~/.config/langfuse` or `~/code`.
2. Confirm `.langfuse/me.md` is what the agent reads, if present.
3. Confirm a denied home path is treated as "identity absent" and the session continues from Linear / `gh` / Cloud run-info.

Demo project is not needed. No UI change.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-16120](https://linear.app/clickhouse/issue/LFE-16120/make-onboarding-skill-work-betterin-opencode)

<div><a href="https://cursor.com/agents/bc-0a69edd5-4ec2-485d-8de3-4348fcba1c98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a69edd5-4ec2-485d-8de3-4348fcba1c98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62077428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with a non-blocking identity-mirroring edge case that should be corrected to preserve documented cross-checkout recovery.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Machine Identity Is Skipped** <a href="https://github.com/langfuse/langfuse/pull/17246#discussion_r3968124157">▶</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/agents/configure-langfuse-identity.sh:72-75
When an OpenCode run creates only `.langfuse/me.md`, a later normal postinstall or Cloud start enables the machine-level identity path but exits here because the workspace file already exists. This leaves `~/.config/langfuse/me.md` absent, so other checkouts cannot be seeded from it as documented. Please populate the missing machine identity when home access is allowed and add coverage for an OpenCode-first run followed by a normal install.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Adds workspace identity recovery and restrictive file permissions.
- Updates onboarding and work-rhythm guidance to use `.langfuse/me.md`.
- Makes home identity probing opt-in and adds OpenCode-focused shell tests.
- Leaves one asymmetric mirroring case where a pre-existing workspace identity prevents later machine-level recovery.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Identity recovery starts] --> B{Machine identity exists?}
  B -->|Yes| C[Preserve machine identity]
  C --> D[Seed workspace identity if absent]
  B -->|No| E{Workspace identity exists?}
  E -->|Yes| F[Exit without machine identity]
  E -->|No| G[Recover identity from Linear]
  G --> H{Home access allowed?}
  H -->|Yes| I[Write machine identity]
  H -->|No| J[Skip machine identity]
  I --> K[Write workspace identity]
  J --> K
```
</details>

<!-- /greptile_comment -->