### PR TITLE
feat(worker): env-gated benchmark for trace observation I/O lookup

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -151,6 +151,11 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(25),
+  // Enables a read-only benchmark of observation I/O retrieval for each
+  // trace-upsert job. Keep disabled unless actively measuring the query.
+  LANGFUSE_TRACE_UPSERT_OBSERVATION_IO_BENCHMARK_ENABLED: z
+    .enum(["true", "false"])
+    .default("false"),
   LANGFUSE_TRACE_DELETE_CONCURRENCY: z.coerce.number().positive().default(1),
   LANGFUSE_SCORE_DELETE_CONCURRENCY: z.coerce.number().positive().default(1),
   // Delay (ms) inserted after each Mixpanel flush to throttle analytics exports

--- a/worker/src/features/traces/observationIoBenchmark.ts
+++ b/worker/src/features/traces/observationIoBenchmark.ts
@@ -1,0 +1,56 @@
+import {
+  getObservationsForTraceFromEventsTable,
+  logger,
+  recordDistribution,
+  recordIncrement,
+} from "@langfuse/shared/src/server";
+
+const METRIC = "langfuse.trace_upsert.observation_io_benchmark";
+
+/**
+ * Reads every observation for one trace with its input/output and reports how
+ * long that took and how many rows carried I/O. Read-only, and swallows its own
+ * failures: it sizes the lookup rather than feeding a caller.
+ */
+export const runTraceObservationIoBenchmark = async (params: {
+  projectId: string;
+  traceId: string;
+  timestamp: Date;
+}): Promise<void> => {
+  const { projectId, traceId, timestamp } = params;
+  const startedAt = performance.now();
+
+  try {
+    const { observations, totalCount } =
+      await getObservationsForTraceFromEventsTable({
+        projectId,
+        traceId,
+        timestamp,
+        selectIOAndMetadata: true,
+        selectToolData: true,
+      });
+
+    const observationsWithIo = observations.filter(
+      ({ input, output }) => input !== null || output !== null,
+    ).length;
+
+    recordIncrement(`${METRIC}.read`);
+    recordDistribution(`${METRIC}.observation_count`, totalCount);
+    recordDistribution(
+      `${METRIC}.observation_with_io_count`,
+      observationsWithIo,
+    );
+  } catch (error) {
+    logger.warn("Failed trace observation I/O benchmark", {
+      error,
+      projectId,
+      traceId,
+    });
+    recordIncrement(`${METRIC}.failure`);
+  } finally {
+    recordDistribution(
+      `${METRIC}.duration_ms`,
+      Math.round(performance.now() - startedAt),
+    );
+  }
+};

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -14,6 +14,7 @@ import {
   classifyEvaluatorLlmError,
 } from "@langfuse/shared/src/server";
 import { createEvalJobs, evaluate } from "../features/evaluation/evalService";
+import { runTraceObservationIoBenchmark } from "../features/traces/observationIoBenchmark";
 import { processObservationEval } from "../features/evaluation/observationEval";
 import { createW3CTraceId, retryLLMRateLimitError } from "../features/utils";
 import { isUnrecoverableError } from "../errors/UnrecoverableError";
@@ -30,6 +31,16 @@ export const evalJobTraceCreatorQueueProcessor = async (
   job: Job<TQueueJobTypes[QueueName.TraceUpsert]>,
 ) => {
   try {
+    if (env.LANGFUSE_TRACE_UPSERT_OBSERVATION_IO_BENCHMARK_ENABLED === "true") {
+      await runTraceObservationIoBenchmark({
+        projectId: job.data.payload.projectId,
+        traceId: job.data.payload.traceId,
+        timestamp: new Date(
+          job.data.payload.exactTimestamp ?? job.data.timestamp,
+        ),
+      });
+    }
+
     await createEvalJobs({
       sourceEventType: "trace-upsert",
       event: job.data.payload,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17247 app preview](https://pr-17247.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What

Adds an env-gated, read-only benchmark to the trace-upsert queue processor that fetches every observation for the incoming trace **with its input/output** and emits timing metrics.

The goal is to measure how expensive that lookup actually is under production trace-upsert volume, before deciding whether any feature can rely on it.

## How

- New `worker/src/features/traces/observationIoBenchmark.ts` calls the existing `getObservationsForTraceFromEventsTable` with `selectIOAndMetadata: true` and `selectToolData: true`. Both are already-optional parameters, so no shared code changes: `git diff --stat -- packages/shared` is empty.
  - `selectIOAndMetadata: true` is what makes the read hit `events_full` rather than `events_core`: it sets `ioFields.mode = "full"` (rendering props default to `truncated: false`), and `needsFullTable()` is true for any mode other than `"truncated"`.
  - `selectToolData` defaults to `false` in that function, which selects the `baseWithoutTools` field set — leaving it off would understate the row width.
- One env var, off by default: `LANGFUSE_TRACE_UPSERT_OBSERVATION_IO_BENCHMARK_ENABLED`.
- Metrics under `langfuse.trace_upsert.observation_io_benchmark`: `duration_ms`, `observation_count`, `observation_with_io_count`, `read`, `failure`.
- Failures are caught and logged, so the benchmark can never fail or retry eval-job creation.

## What a reviewer should doubt

- The `await` sits inline before `createEvalJobs`, so a slow read delays eval-job creation even though errors are swallowed. There is no query timeout. Enabling this deliberately accepts that.
- `duration_ms` covers more than the ClickHouse query — `enrichObservationsWithModelData` and `enrichObservationsWithTraceFields` are inside the timing. That is intentional (it is the cost a real caller would pay), but it is not a pure query measurement.
- The lookback window is whatever the existing function does, `timestamp - INTERVAL 1 HOUR`. An earlier revision made this configurable; that was dropped rather than change a signature prod features use.
- Row count is bounded by the function's existing `MAX_OBSERVATIONS_PER_TRACE + 1` cap, so memory is capped, but I/O payloads for a wide trace are still large.

## Verification

- `pnpm exec turbo run lint typecheck --force --filter=worker --filter=@langfuse/shared --filter=web` — `Tasks: 9 successful, 9 total`, `Cached: 0 cached, 9 total`
- `pnpm exec knip` — clean

No tests: nothing ships enabled, and the only new logic is a flag check plus timing around an existing repository call. A test would restate the flag gate rather than pin behavior that could regress.

The `events_full` claims above are a static read of the query builder, not runtime-verified against a live ClickHouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
