### PR TITLE
feat(web): add source promt name to playground window content

### DIFF
--- a/web/src/features/playground/page/components/JumpToPlaygroundDropdownMenuController.tsx
+++ b/web/src/features/playground/page/components/JumpToPlaygroundDropdownMenuController.tsx
@@ -7,8 +7,10 @@ import { usePersistedWindowIds } from "@/src/features/playground/page/hooks/useP
 import {
   type PlaygroundCache,
   type PlaygroundSchema,
+  type PlaygroundSourcePrompt,
   type PlaygroundTool,
 } from "@/src/features/playground/page/types";
+import { getMessagesFingerprint } from "@/src/features/playground/page/utils/messagesFingerprint";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import {
@@ -207,6 +209,14 @@ export const JumpToPlaygroundDropdownMenuController = (
 const parsePrompt = (
   prompt: Prompt & { resolvedPrompt?: Prisma.JsonValue },
 ): PlaygroundCache => {
+  const asSourcePrompt = (
+    messages: (ChatMessage | PlaceholderMessage)[],
+  ): PlaygroundSourcePrompt => ({
+    name: prompt.name,
+    version: prompt.version,
+    initialMessagesFingerprint: getMessagesFingerprint(messages),
+  });
+
   if (prompt.type === PromptType.Chat) {
     try {
       const inResult = normalizeInput(prompt.resolvedPrompt);
@@ -221,23 +231,22 @@ const parsePrompt = (
 
       if (messages.length === 0) return null;
 
-      return { messages };
+      return { messages, sourcePrompt: asSourcePrompt(messages) };
     } catch {
       return null;
     }
   } else {
     // Text prompt
     const promptString = prompt.resolvedPrompt;
+    const messages = [
+      createEmptyMessage({
+        type: ChatMessageType.System,
+        role: ChatMessageRole.System,
+        content: typeof promptString === "string" ? promptString : "",
+      }),
+    ];
 
-    return {
-      messages: [
-        createEmptyMessage({
-          type: ChatMessageType.System,
-          role: ChatMessageRole.System,
-          content: typeof promptString === "string" ? promptString : "",
-        }),
-      ],
-    };
+    return { messages, sourcePrompt: asSourcePrompt(messages) };
   }
 };
 

--- a/web/src/features/playground/page/components/Messages.tsx
+++ b/web/src/features/playground/page/components/Messages.tsx
@@ -24,7 +24,7 @@ import {
 
 export const Messages: React.FC<MessagesContext> = (props) => {
   return (
-    <div className="flex h-full flex-col space-y-4 pt-2 pr-4">
+    <div className="flex h-full flex-col space-y-4 pt-2">
       <ResizablePanelGroup orientation="vertical">
         <ResizablePanel minSize="10%">
           <ChatMessages {...props} />

--- a/web/src/features/playground/page/components/MultiWindowPlayground.tsx
+++ b/web/src/features/playground/page/components/MultiWindowPlayground.tsx
@@ -161,9 +161,7 @@ function PlaygroundWindowContent({
   const windowContainerRef = useRef<HTMLDivElement | null>(null);
   const { messages, sourcePrompt } = playgroundContext;
 
-  // Whether this window still holds the prompt version it was opened from.
-  // Scoped to the messages because they are what a save back would write.
-  const isEdited = useMemo(
+  const isSourcePromtEdited = useMemo(
     () =>
       Boolean(sourcePrompt) &&
       getMessagesFingerprint(messages) !==
@@ -264,7 +262,7 @@ function PlaygroundWindowContent({
               <div className="absolute top-1 flex max-w-[calc(100%-4rem)] justify-end">
                 <SourcePromptHeading
                   sourcePrompt={playgroundContext.sourcePrompt}
-                  isEdited={isEdited}
+                  isEdited={isSourcePromtEdited}
                 />
               </div>
             )}

--- a/web/src/features/playground/page/components/MultiWindowPlayground.tsx
+++ b/web/src/features/playground/page/components/MultiWindowPlayground.tsx
@@ -2,6 +2,7 @@
 import React, { useMemo, useCallback, useRef, useEffect } from "react";
 import { PlaygroundProvider, usePlaygroundContext } from "../context";
 import { SaveToPromptButton } from "./SaveToPromptButton";
+import { SourcePromptHeading } from "./SourcePromptHeading";
 import { Button } from "@/src/components/ui/button";
 import { Plus, X } from "lucide-react";
 import { MULTI_WINDOW_CONFIG, type MultiWindowState } from "../types";
@@ -16,6 +17,7 @@ import {
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
 import { useIsMobile } from "@/src/hooks/use-mobile";
+import { getMessagesFingerprint } from "@/src/features/playground/page/utils/messagesFingerprint";
 
 /**
  * MultiWindowPlayground Component
@@ -157,6 +159,17 @@ function PlaygroundWindowContent({
   const { registerPageTarget, unregisterPageTarget } =
     useMessageSearchActions();
   const windowContainerRef = useRef<HTMLDivElement | null>(null);
+  const { messages, sourcePrompt } = playgroundContext;
+
+  // Whether this window still holds the prompt version it was opened from.
+  // Scoped to the messages because they are what a save back would write.
+  const isEdited = useMemo(
+    () =>
+      Boolean(sourcePrompt) &&
+      getMessagesFingerprint(messages) !==
+        sourcePrompt?.initialMessagesFingerprint,
+    [messages, sourcePrompt],
+  );
 
   const handleRemove = useCallback(() => {
     onRemove(windowId);
@@ -181,9 +194,8 @@ function PlaygroundWindowContent({
       ref={windowContainerRef}
       className="playground-window bg-background @container flex h-full min-w-0 flex-col rounded-lg border shadow-xs"
     >
-      {/* Window Header */}
-      <div className="bg-muted/50 relative shrink-0 border-b px-3 py-1">
-        <div className="flex items-center pr-32 @xl:pr-96">
+      <div className="bg-muted/50 shrink-0 border-b">
+        <div className="relative flex items-center py-1 pr-32 pl-3 @xl:pr-96">
           <div className="flex items-center gap-2">
             <ModelParameters {...playgroundContext} layout="compact" />
           </div>
@@ -247,7 +259,15 @@ function PlaygroundWindowContent({
         <div className="flex h-full flex-col">
           <ConfigurationDropdowns />
 
-          <div className="flex-1 overflow-auto p-4">
+          <div className="relative flex-1 overflow-auto p-4">
+            {playgroundContext.sourcePrompt && (
+              <div className="absolute top-1 right-8 flex max-w-[calc(100%-4rem)] justify-end">
+                <SourcePromptHeading
+                  sourcePrompt={playgroundContext.sourcePrompt}
+                  isEdited={isEdited}
+                />
+              </div>
+            )}
             <Messages {...playgroundContext} />
           </div>
         </div>

--- a/web/src/features/playground/page/components/MultiWindowPlayground.tsx
+++ b/web/src/features/playground/page/components/MultiWindowPlayground.tsx
@@ -261,7 +261,7 @@ function PlaygroundWindowContent({
 
           <div className="relative flex-1 overflow-auto p-4">
             {playgroundContext.sourcePrompt && (
-              <div className="absolute top-1 right-8 flex max-w-[calc(100%-4rem)] justify-end">
+              <div className="absolute top-1 flex max-w-[calc(100%-4rem)] justify-end">
                 <SourcePromptHeading
                   sourcePrompt={playgroundContext.sourcePrompt}
                   isEdited={isEdited}

--- a/web/src/features/playground/page/components/SourcePromptHeading.tsx
+++ b/web/src/features/playground/page/components/SourcePromptHeading.tsx
@@ -1,0 +1,30 @@
+import { Badge } from "@/src/components/design-system/Badge/Badge";
+import { Tooltip } from "@/src/components/ui/tooltip";
+import { type PlaygroundSourcePrompt } from "@/src/features/playground/page/types";
+
+type SourcePromptHeadingProps = {
+  sourcePrompt: PlaygroundSourcePrompt;
+  isEdited: boolean;
+};
+
+export const SourcePromptHeading: React.FC<SourcePromptHeadingProps> = ({
+  sourcePrompt,
+  isEdited,
+}) => {
+  const version = `v${sourcePrompt.version}`;
+
+  return (
+    <Tooltip>
+      <div className="text-muted-foreground flex min-w-0 items-center gap-1 text-xs leading-tight">
+        <span
+          className="min-w-0 truncate"
+          title={`${sourcePrompt.name} ${version}`}
+        >
+          {sourcePrompt.name}
+        </span>
+        <Badge size="sm" text={version} />
+        {isEdited && <span className="text-foreground shrink-0">· edited</span>}
+      </div>
+    </Tooltip>
+  );
+};

--- a/web/src/features/playground/page/components/SourcePromptHeading.tsx
+++ b/web/src/features/playground/page/components/SourcePromptHeading.tsx
@@ -1,5 +1,4 @@
 import { Badge } from "@/src/components/design-system/Badge/Badge";
-import { Tooltip } from "@/src/components/ui/tooltip";
 import { type PlaygroundSourcePrompt } from "@/src/features/playground/page/types";
 
 type SourcePromptHeadingProps = {
@@ -14,17 +13,15 @@ export const SourcePromptHeading: React.FC<SourcePromptHeadingProps> = ({
   const version = `v${sourcePrompt.version}`;
 
   return (
-    <Tooltip>
-      <div className="text-muted-foreground flex min-w-0 items-center gap-1 text-xs leading-tight">
-        <span
-          className="min-w-0 truncate"
-          title={`${sourcePrompt.name} ${version}`}
-        >
-          {sourcePrompt.name}
-        </span>
-        <Badge size="sm" text={version} />
-        {isEdited && <span className="text-foreground shrink-0">· edited</span>}
-      </div>
-    </Tooltip>
+    <div className="text-muted-foreground flex min-w-0 items-center gap-1 text-xs leading-tight">
+      <span
+        className="min-w-0 truncate"
+        title={`${sourcePrompt.name} ${version}`}
+      >
+        {sourcePrompt.name}
+      </span>
+      <Badge size="sm" text={version} />
+      {isEdited && <span className="text-foreground shrink-0">· edited</span>}
+    </div>
   );
 };

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -36,6 +36,7 @@ import type { ModelParamsContext } from "@/src/components/ModelParameters";
 import { env } from "@/src/env.mjs";
 import {
   type PlaygroundSchema,
+  type PlaygroundSourcePrompt,
   type PlaygroundTool,
   type PlaceholderMessageFillIn,
   type PlaygroundProviderProps,
@@ -67,6 +68,9 @@ type PlaygroundContextType = {
 
   structuredOutputSchema: PlaygroundSchema | null;
   setStructuredOutputSchema: (schema: PlaygroundSchema | null) => void;
+
+  /** The stored prompt this window was opened from, if any. */
+  sourcePrompt: PlaygroundSourcePrompt | null;
 
   output: string;
   outputReasoning: string;
@@ -113,6 +117,7 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
   const capture = usePostHogClientCapture();
   const projectId = useProjectIdFromURL();
   const { playgroundCache, setPlaygroundCache } = usePlaygroundCache(windowId);
+  const sourcePrompt = playgroundCache?.sourcePrompt ?? null;
   const [promptVariables, setPromptVariables] = useState<PromptVariable[]>([]);
   const [messagePlaceholders, setMessagePlaceholders] = useState<
     PlaceholderMessageFillIn[]
@@ -459,6 +464,7 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
           messagePlaceholders,
           tools,
           structuredOutputSchema,
+          sourcePrompt,
         });
         capture("playground:execute_button_click", {
           inputLength: finalMessages.length,
@@ -485,6 +491,7 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
       capture,
       setPlaygroundCache,
       structuredOutputSchema,
+      sourcePrompt,
       projectId,
     ],
   );
@@ -574,6 +581,7 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
         messagePlaceholders,
         tools,
         structuredOutputSchema,
+        sourcePrompt,
       });
     }
   }, [
@@ -584,6 +592,7 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
     messagePlaceholders,
     tools,
     structuredOutputSchema,
+    sourcePrompt,
     setPlaygroundCache,
     cacheLoaded,
   ]);
@@ -727,6 +736,8 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
 
         structuredOutputSchema,
         setStructuredOutputSchema,
+
+        sourcePrompt,
 
         messages,
         addMessage,

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -69,7 +69,6 @@ type PlaygroundContextType = {
   structuredOutputSchema: PlaygroundSchema | null;
   setStructuredOutputSchema: (schema: PlaygroundSchema | null) => void;
 
-  /** The stored prompt this window was opened from, if any. */
   sourcePrompt: PlaygroundSourcePrompt | null;
 
   output: string;

--- a/web/src/features/playground/page/types.ts
+++ b/web/src/features/playground/page/types.ts
@@ -28,6 +28,12 @@ export type PlaceholderMessageFillIn = {
   isUsed: boolean;
 };
 
+export type PlaygroundSourcePrompt = {
+  name: string;
+  version: number;
+  initialMessagesFingerprint: string;
+};
+
 export type PlaygroundCache = {
   messages: (ChatMessage | PlaceholderMessage)[];
   modelParams?: Partial<UIModelParams> &
@@ -37,6 +43,7 @@ export type PlaygroundCache = {
   messagePlaceholders?: PlaceholderMessageFillIn[];
   tools?: PlaygroundTool[];
   structuredOutputSchema?: PlaygroundSchema | null;
+  sourcePrompt?: PlaygroundSourcePrompt | null;
 } | null;
 
 // Multi-window types and interfaces

--- a/web/src/features/playground/page/utils/messagesFingerprint.ts
+++ b/web/src/features/playground/page/utils/messagesFingerprint.ts
@@ -1,4 +1,8 @@
-import { type ChatMessage, type PlaceholderMessage } from "@langfuse/shared";
+import {
+  type ChatMessageWithId,
+  type ChatMessage,
+  type PlaceholderMessage,
+} from "@langfuse/shared";
 
 /**
  * Stable string for a set of playground messages, used to tell whether a window
@@ -9,11 +13,11 @@ import { type ChatMessage, type PlaceholderMessage } from "@langfuse/shared";
  * depend on property order surviving a JSON round trip.
  */
 export const getMessagesFingerprint = (
-  messages: (ChatMessage | PlaceholderMessage | { id?: string })[],
+  messages: (ChatMessage | PlaceholderMessage | ChatMessageWithId)[],
 ): string =>
   JSON.stringify(
     messages.map((message) => {
-      const { id: _id, ...rest } = message as { id?: string };
+      const { id: _id, ...rest } = message as ChatMessageWithId;
 
       return Object.fromEntries(
         Object.entries(rest).sort(([a], [b]) => a.localeCompare(b)),

--- a/web/src/features/playground/page/utils/messagesFingerprint.ts
+++ b/web/src/features/playground/page/utils/messagesFingerprint.ts
@@ -1,0 +1,22 @@
+import { type ChatMessage, type PlaceholderMessage } from "@langfuse/shared";
+
+/**
+ * Stable string for a set of playground messages, used to tell whether a window
+ * still holds the prompt version it was opened from.
+ *
+ * `id` is dropped because the provider assigns one to every message while
+ * hydrating from the cache, and keys are sorted because equality here must not
+ * depend on property order surviving a JSON round trip.
+ */
+export const getMessagesFingerprint = (
+  messages: (ChatMessage | PlaceholderMessage | { id?: string })[],
+): string =>
+  JSON.stringify(
+    messages.map((message) => {
+      const { id: _id, ...rest } = message as { id?: string };
+
+      return Object.fromEntries(
+        Object.entries(rest).sort(([a], [b]) => a.localeCompare(b)),
+      );
+    }),
+  );


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17248 app preview](https://pr-17248.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<img width="1720" height="465" alt="Screenshot 2026-09-09 at 14 45 11" src="https://github.com/user-attachments/assets/33b3a78b-9377-48db-9471-f02fb58eb626" />

## Type of change


- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62103434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with a non-blocking correctness improvement recommended for nested message fingerprinting.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Nested keys affect fingerprints** <a href="https://github.com/langfuse/langfuse/pull/17248#discussion_r3968947699">▶</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/playground/page/utils/messagesFingerprint.ts:23-24
Only the top-level message properties are sorted before serialization, but messages can contain nested records such as `toolCalls[].args`. Reconstructing the same nested data with a different property order therefore produces a different fingerprint and incorrectly displays the prompt as edited. Please recursively canonicalize nested object keys before stringifying and add focused coverage for nested messages.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Adds source-prompt metadata to cached playground state.
- Computes a message fingerprint to identify subsequent edits.
- Adds a compact source heading to each applicable playground window.
- The fingerprint needs recursive canonicalization for nested message data.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Prompt selected] --> B[Parse prompt messages]
  B --> C[Compute initial fingerprint]
  C --> D[Persist playground cache]
  D --> E[Hydrate playground window]
  E --> F[Compute current fingerprint]
  F --> G{Fingerprints match?}
  G -->|Yes| H[Show prompt name and version]
  G -->|No| I[Show prompt name, version, and edited]
```
</details>

<!-- /greptile_comment -->