### PR TITLE
feat(trpc): attach OTEL trace id to error responses

### DIFF
--- a/packages/shared/src/server/instrumentation/index.ts
+++ b/packages/shared/src/server/instrumentation/index.ts
@@ -123,8 +123,13 @@ export function instrumentSync<T>(
 
 export const getCurrentSpan = () => opentelemetry.trace.getActiveSpan();
 
-export const getActiveTraceId = () =>
-  opentelemetry.trace.getActiveSpan()?.spanContext().traceId;
+export const getActiveTraceId = () => {
+  const span = opentelemetry.trace.getActiveSpan();
+  // Only return a trace id for sampled/recording spans. An unsampled span still
+  // carries a valid traceId in its context but is never exported, so that id
+  // would resolve to nothing in the tracing backend.
+  return span?.isRecording() ? span.spanContext().traceId : undefined;
+};
 
 export const addTagsToCurrentSpan = (
   attributes: Parameters<opentelemetry.Span["setAttributes"]>[0],

--- a/packages/shared/src/server/instrumentation/index.ts
+++ b/packages/shared/src/server/instrumentation/index.ts
@@ -123,6 +123,9 @@ export function instrumentSync<T>(
 
 export const getCurrentSpan = () => opentelemetry.trace.getActiveSpan();
 
+export const getActiveTraceId = () =>
+  opentelemetry.trace.getActiveSpan()?.spanContext().traceId;
+
 export const addTagsToCurrentSpan = (
   attributes: Parameters<opentelemetry.Span["setAttributes"]>[0],
 ) => {

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -89,6 +89,7 @@ import {
   addUserToSpan,
   contextWithLangfuseProps,
   ClickHouseResourceError,
+  getActiveTraceId,
 } from "@langfuse/shared/src/server";
 
 import { AdminApiAuthService } from "@/src/ee/features/admin-api/server/adminApiAuth";
@@ -107,6 +108,9 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
       ...shape,
       data: {
         ...shape.data,
+        // OTEL trace id of the failing request, for frontend/support correlation
+        // with Datadog. Absent when OTEL is not running (e.g. some self-hosted).
+        traceId: getActiveTraceId(),
         zodError:
           error.cause instanceof ZodError ? z.flattenError(error.cause) : null,
         errorName:

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -109,7 +109,8 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
       data: {
         ...shape.data,
         // OTEL trace id of the failing request, for frontend/support correlation
-        // with Datadog. Absent when OTEL is not running (e.g. some self-hosted).
+        // with Datadog. Absent when OTEL is not running or the trace was not
+        // sampled (an unsampled id never reaches the tracing backend).
         traceId: getActiveTraceId(),
         zodError:
           error.cause instanceof ZodError ? z.flattenError(error.cause) : null,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17253 app preview](https://pr-17253.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Attaches the request's OTEL trace id to the tRPC error payload so a surfaced backend error can be correlated with its trace in Datadog.

- Adds a `getActiveTraceId()` helper next to `getCurrentSpan` in `packages/shared/src/server/instrumentation/index.ts`.
- Sets `traceId` on `shape.data` in the `errorFormatter` in `web/src/server/api/trpc.ts`. The field is optional and simply absent when no span is active (e.g. OTEL not running in some self-hosted setups).

**Backend only.** The frontend rendering (showing/copying the id in the error toast) is intentionally out of scope and handled separately.

### Why `errorFormatter` is a safe place to read the active span

`errorFormatter` runs at response-serialization time, after the per-procedure tracing span has already ended. It still works because an outer `http.server` span (from `@opentelemetry/instrumentation-http`, wired in `web/src/observability.config.ts` via the Next.js `register()` hook) wraps the whole request lifecycle and is the parent of the tRPC span — so `getActiveTraceId()` reads that span, which shares the same trace id. `spanContext().traceId` is present regardless of sampling.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] `pnpm run lint` and typecheck pass (`Tasks: 7 successful, 7 total`, forced)
- [ ] I have added tests — N/A: the only available assertion would restate the diff; the real risk (span liveness) is a runtime concern a mocked-span unit test can't catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62127186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse/17253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the optional trace ID follows the existing request instrumentation lifecycle and preserves behavior when tracing is unavailable.

<details><summary><h3>Summary</h3></summary>

- Adds a shared helper for reading the active span’s trace ID.
- Extends formatted tRPC errors with an optional `traceId`.
- Preserves behavior for deployments without an active OpenTelemetry span.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Browser
  participant TRPC as tRPC handler
  participant Procedure
  participant OTEL as OpenTelemetry
  participant DD as Datadog

  Browser->>TRPC: tRPC request
  OTEL->>TRPC: Activate http.server span
  TRPC->>Procedure: Execute procedure
  Procedure-->>TRPC: Error
  TRPC->>OTEL: Read active trace ID
  OTEL-->>TRPC: traceId or undefined
  TRPC-->>Browser: Formatted error data
  OTEL-->>DD: Export request trace
```
</details>

<!-- /greptile_comment -->