### PR TITLE
fix(scores): bound scored-traces filter-option subquery to the view window

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/event-filter-options.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-filter-options.ts
@@ -238,8 +238,8 @@ export type EventFilterOptionRow = {
 // scanning all history).
 export type EventFilterOptionScope = {
   type: "scoredTraces";
-  fromTime?: Date;
-  toTime?: Date;
+  fromTime?: { operator: ">=" | ">"; value: Date };
+  toTime?: { operator: "<=" | "<"; value: Date };
 };
 
 const EVENTS_FILTER_OPTION_COLUMN_IDENTIFIER_PATTERN = /^[A-Za-z]+$/;
@@ -392,16 +392,18 @@ const eventFilterOptionScopeCondition = (
       const params: Record<string, unknown> = {};
       if (scope.fromTime) {
         clauses.push(
-          "timestamp >= {scoredTracesFromTime: DateTime64(3, 'UTC')}",
+          `timestamp ${scope.fromTime.operator} {scoredTracesFromTime: DateTime64(3, 'UTC')}`,
         );
         params.scoredTracesFromTime = convertDateToClickhouseDateTime(
-          scope.fromTime,
+          scope.fromTime.value,
         );
       }
       if (scope.toTime) {
-        clauses.push("timestamp <= {scoredTracesToTime: DateTime64(3, 'UTC')}");
+        clauses.push(
+          `timestamp ${scope.toTime.operator} {scoredTracesToTime: DateTime64(3, 'UTC')}`,
+        );
         params.scoredTracesToTime = convertDateToClickhouseDateTime(
-          scope.toTime,
+          scope.toTime.value,
         );
       }
       return {

--- a/packages/shared/src/server/queries/clickhouse-sql/event-filter-options.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-filter-options.ts
@@ -7,6 +7,7 @@ import {
   eventsTableTraceNameSql,
 } from "../../../eventsTable";
 import type { FilterState } from "../../../types";
+import { convertDateToClickhouseDateTime } from "../../clickhouse/client";
 import { eventsTableUiColumnDefinitions } from "../../tableMappings/mapEventsTable";
 import { FilterList } from "./clickhouse-filter";
 import { EventsAggQueryBuilder } from "./event-query-builder";
@@ -230,7 +231,16 @@ export type EventFilterOptionRow = {
   displayValue?: string;
 };
 
-export type EventFilterOptionScope = "scoredTraces";
+// scoredTraces restricts events to traces that carry a score. The optional
+// time bounds mirror the scores list view's both-sided window on
+// scores.timestamp, so offered options match what the windowed view can
+// actually display (and the subquery prunes by partition/PK instead of
+// scanning all history).
+export type EventFilterOptionScope = {
+  type: "scoredTraces";
+  fromTime?: Date;
+  toTime?: Date;
+};
 
 const EVENTS_FILTER_OPTION_COLUMN_IDENTIFIER_PATTERN = /^[A-Za-z]+$/;
 
@@ -375,10 +385,30 @@ const optionRowsArrayExpression = (column: EventFilterOptionColumn) => {
 
 const eventFilterOptionScopeCondition = (
   scope: EventFilterOptionScope,
-): string => {
-  switch (scope) {
-    case "scoredTraces":
-      return "e.trace_id IN (SELECT DISTINCT trace_id FROM scores WHERE project_id = {projectId: String})";
+): { condition: string; params: Record<string, unknown> } => {
+  switch (scope.type) {
+    case "scoredTraces": {
+      const clauses = ["project_id = {projectId: String}"];
+      const params: Record<string, unknown> = {};
+      if (scope.fromTime) {
+        clauses.push(
+          "timestamp >= {scoredTracesFromTime: DateTime64(3, 'UTC')}",
+        );
+        params.scoredTracesFromTime = convertDateToClickhouseDateTime(
+          scope.fromTime,
+        );
+      }
+      if (scope.toTime) {
+        clauses.push("timestamp <= {scoredTracesToTime: DateTime64(3, 'UTC')}");
+        params.scoredTracesToTime = convertDateToClickhouseDateTime(
+          scope.toTime,
+        );
+      }
+      return {
+        condition: `e.trace_id IN (SELECT DISTINCT trace_id FROM scores WHERE ${clauses.join(" AND ")})`,
+        params,
+      };
+    }
   }
 };
 
@@ -426,7 +456,8 @@ export const buildEventsFilterOptionColumnQuery = (params: {
     .sampleRows(sampleRows);
 
   if (params.scope) {
-    queryBuilder.whereRaw(eventFilterOptionScopeCondition(params.scope));
+    const scopeCondition = eventFilterOptionScopeCondition(params.scope);
+    queryBuilder.whereRaw(scopeCondition.condition, scopeCondition.params);
   }
 
   return queryBuilder.buildWithParams();
@@ -466,8 +497,10 @@ export const buildEventsFilterOptionsForColumnsQuery = (params: {
   aggregatedOptionsBuilder.sampleRows(sampleRows);
 
   if (params.scope) {
+    const scopeCondition = eventFilterOptionScopeCondition(params.scope);
     aggregatedOptionsBuilder.whereRaw(
-      eventFilterOptionScopeCondition(params.scope),
+      scopeCondition.condition,
+      scopeCondition.params,
     );
   }
 

--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -271,20 +271,22 @@ describe("buildEventsFilterOptionsForColumnsQuery", () => {
     expect(Object.values(built.params)).toContain("quality");
   });
 
-  it("applies the scored traces scope without caller-provided raw SQL", () => {
+  it("bounds the scored traces scope by the view's both-sided window", () => {
+    const fromTime = new Date("2026-01-01T00:00:00.000Z");
+    const toTime = new Date("2026-01-01T00:30:00.000Z");
     const built = buildEventsFilterOptionColumnQuery({
       projectId: "test-project",
       filter: [],
       column: "traceName",
       limit: 100,
-      scope: "scoredTraces",
+      scope: { type: "scoredTraces", fromTime, toTime },
     });
 
     expect(built).not.toBeNull();
     if (!built) throw new Error("expected query");
 
     expect(built.query).toContain(
-      "e.trace_id IN (SELECT DISTINCT trace_id FROM scores WHERE project_id = {projectId: String})",
+      "e.trace_id IN (SELECT DISTINCT trace_id FROM scores WHERE project_id = {projectId: String} AND timestamp >= {scoredTracesFromTime: DateTime64(3, 'UTC')} AND timestamp <= {scoredTracesToTime: DateTime64(3, 'UTC')})",
     );
     expect(built.query).toContain(
       "COALESCE(nullIf(e.trace_name, ''), if((e.parent_span_id = '' OR e.is_app_root = true), nullIf(e.name, ''), NULL))",
@@ -293,7 +295,28 @@ describe("buildEventsFilterOptionsForColumnsQuery", () => {
     expect(built.params).toMatchObject({
       projectId: "test-project",
       limit: 100,
+      scoredTracesFromTime: "2026-01-01 00:00:00.000",
+      scoredTracesToTime: "2026-01-01 00:30:00.000",
     });
+  });
+
+  it("omits scores timestamp bounds the view did not supply", () => {
+    const built = buildEventsFilterOptionColumnQuery({
+      projectId: "test-project",
+      filter: [],
+      column: "traceName",
+      limit: 100,
+      scope: { type: "scoredTraces" },
+    });
+
+    expect(built).not.toBeNull();
+    if (!built) throw new Error("expected query");
+
+    expect(built.query).toContain(
+      "e.trace_id IN (SELECT DISTINCT trace_id FROM scores WHERE project_id = {projectId: String})",
+    );
+    expect(built.query).not.toContain("scoredTracesFromTime");
+    expect(built.query).not.toContain("scoredTracesToTime");
   });
 
   it("builds a direct grouped query for one scalar filter option column", () => {

--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -279,7 +279,11 @@ describe("buildEventsFilterOptionsForColumnsQuery", () => {
       filter: [],
       column: "traceName",
       limit: 100,
-      scope: { type: "scoredTraces", fromTime, toTime },
+      scope: {
+        type: "scoredTraces",
+        fromTime: { operator: ">=", value: fromTime },
+        toTime: { operator: "<=", value: toTime },
+      },
     });
 
     expect(built).not.toBeNull();
@@ -298,6 +302,30 @@ describe("buildEventsFilterOptionsForColumnsQuery", () => {
       scoredTracesFromTime: "2026-01-01 00:00:00.000",
       scoredTracesToTime: "2026-01-01 00:30:00.000",
     });
+  });
+
+  it("preserves strict scores timestamp operators", () => {
+    const built = buildEventsFilterOptionColumnQuery({
+      projectId: "test-project",
+      filter: [],
+      column: "traceName",
+      limit: 100,
+      scope: {
+        type: "scoredTraces",
+        fromTime: {
+          operator: ">",
+          value: new Date("2026-01-01T00:00:00.000Z"),
+        },
+        toTime: { operator: "<", value: new Date("2026-01-01T00:30:00.000Z") },
+      },
+    });
+
+    expect(built).not.toBeNull();
+    if (!built) throw new Error("expected query");
+
+    expect(built.query).toContain(
+      "AND timestamp > {scoredTracesFromTime: DateTime64(3, 'UTC')} AND timestamp < {scoredTracesToTime: DateTime64(3, 'UTC')}",
+    );
   });
 
   it("omits scores timestamp bounds the view did not supply", () => {

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -381,26 +381,49 @@ export const scoresRouter = createTRPCRouter({
         );
       }
 
-      // Bound the scored-traces semi-join by the same both-sided window the
-      // scores list view applies on scores.timestamp, so the offered options
-      // match what the windowed view can actually display. The UI sends `>=`
-      // for the lower bound and `<=` for the upper; take the tightest of each.
-      const lowerBounds = (timestampFilter ?? [])
+      // Bound the scored-traces semi-join by the same window the scores list
+      // view applies on scores.timestamp, so the offered options match what the
+      // windowed view can actually display. Preserve the caller's operator (not
+      // just the instant) so a score exactly on a strict boundary is offered iff
+      // the view would show it. Take the tightest bound on each side; on a tie
+      // the strict operator wins because it excludes the boundary instant.
+      const timestamps = timestampFilter ?? [];
+      const lowerBound = timestamps
         .filter((tf) => tf.operator === ">=" || tf.operator === ">")
-        .map((tf) => tf.value);
-      const upperBounds = (timestampFilter ?? [])
+        .reduce<{ operator: ">=" | ">"; value: Date } | undefined>(
+          (tightest, tf) => {
+            const candidate = {
+              operator: tf.operator as ">=" | ">",
+              value: tf.value,
+            };
+            if (!tightest) return candidate;
+            const diff = candidate.value.getTime() - tightest.value.getTime();
+            if (diff > 0) return candidate;
+            if (diff === 0 && candidate.operator === ">") return candidate;
+            return tightest;
+          },
+          undefined,
+        );
+      const upperBound = timestamps
         .filter((tf) => tf.operator === "<=" || tf.operator === "<")
-        .map((tf) => tf.value);
+        .reduce<{ operator: "<=" | "<"; value: Date } | undefined>(
+          (tightest, tf) => {
+            const candidate = {
+              operator: tf.operator as "<=" | "<",
+              value: tf.value,
+            };
+            if (!tightest) return candidate;
+            const diff = candidate.value.getTime() - tightest.value.getTime();
+            if (diff < 0) return candidate;
+            if (diff === 0 && candidate.operator === "<") return candidate;
+            return tightest;
+          },
+          undefined,
+        );
       const scope = {
         type: "scoredTraces" as const,
-        fromTime:
-          lowerBounds.length > 0
-            ? new Date(Math.max(...lowerBounds.map((d) => d.getTime())))
-            : undefined,
-        toTime:
-          upperBounds.length > 0
-            ? new Date(Math.min(...upperBounds.map((d) => d.getTime())))
-            : undefined,
+        fromTime: lowerBound,
+        toTime: upperBound,
       };
 
       const [names, tags, traceNames, userIds, stringValues] =

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -381,17 +381,39 @@ export const scoresRouter = createTRPCRouter({
         );
       }
 
+      // Bound the scored-traces semi-join by the same both-sided window the
+      // scores list view applies on scores.timestamp, so the offered options
+      // match what the windowed view can actually display. The UI sends `>=`
+      // for the lower bound and `<=` for the upper; take the tightest of each.
+      const lowerBounds = (timestampFilter ?? [])
+        .filter((tf) => tf.operator === ">=" || tf.operator === ">")
+        .map((tf) => tf.value);
+      const upperBounds = (timestampFilter ?? [])
+        .filter((tf) => tf.operator === "<=" || tf.operator === "<")
+        .map((tf) => tf.value);
+      const scope = {
+        type: "scoredTraces" as const,
+        fromTime:
+          lowerBounds.length > 0
+            ? new Date(Math.max(...lowerBounds.map((d) => d.getTime())))
+            : undefined,
+        toTime:
+          upperBounds.length > 0
+            ? new Date(Math.min(...upperBounds.map((d) => d.getTime())))
+            : undefined,
+      };
+
       const [names, tags, traceNames, userIds, stringValues] =
         await Promise.all([
           getScoreNames(input.projectId, timestampFilter ?? []),
           getEventsGroupedByTraceTags(input.projectId, eventsFilter, {
-            scope: "scoredTraces",
+            scope,
           }),
           getEventsGroupedByTraceName(input.projectId, eventsFilter, {
-            scope: "scoredTraces",
+            scope,
           }),
           getEventsGroupedByUserId(input.projectId, eventsFilter, {
-            scope: "scoredTraces",
+            scope,
           }),
           getScoreStringValues(input.projectId, timestampFilter ?? []),
         ]);


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17257 app preview](https://pr-17257.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

The scores list view's filter-option queries (trace name / trace tags / user id facets) restricted events to traces that carry a score via an **unbounded** semi-join:

```sql
e.trace_id IN (SELECT DISTINCT trace_id FROM scores WHERE project_id = {projectId})
```

With no time bound, this subquery scanned the project's **entire** scores history and materialised it as a `CreatingSets` set before the outer scan could probe — timing out (>30s) even on a 30-minute window. It also offered facet values whose scores fall **entirely outside** the selected window; picking one filtered the windowed view down to zero rows.

This bounds the subquery by the **same both-sided window the list view already applies** on `scores.timestamp`:

```sql
e.trace_id IN (
  SELECT DISTINCT trace_id FROM scores
  WHERE project_id = {projectId}
    AND timestamp >= {fromTime}
    AND timestamp <= {toTime}
)
```

- **Correctness:** offered options now match what the windowed view can actually display.
- **Performance:** the subquery prunes by partition/PK instead of scanning all history.

**Deliberate semantics change:** filter options move from *"traces ever scored"* → *"traces with a score in the selected window."* This is the intended behavior for a time-windowed view.

The bounds are optional: an open-ended (all-time) view supplies no upper bound and keeps the corresponding side unbounded, matching what it can show. The window is derived in the `filterOptionsFromEvents` router from the same `timestampFilter` the view uses, and threaded through the `scoredTraces` scope.

Out of scope (unchanged, pre-existing): the trace *name* is derived from `events_core` bounded by `start_time`, so an in-window score whose trace's naming event is out-of-window can still miss its name.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor / performance improvement

## Checklist

- [x] Unit tests updated (scope SQL: bounded both-sides, and bounds omitted when the view supplies none)
- [x] `lint` and `typecheck` pass

---

🤖 Written by Claude (an AI agent) on behalf of Niklas



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bounds scored-trace filter-option subqueries to the score view’s effective timestamp window while preserving strict and inclusive boundary semantics.
- Replaces the string scope with a typed scored-traces scope carrying optional lower and upper bounds.
- Adds parameterized ClickHouse timestamp predicates to both filter-option query shapes.
- Derives the tightest timestamp bounds from the score filters and preserves their comparison operators.
- Adds coverage for bounded, strict-boundary, and unbounded query generation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no actionable correctness, security, or repository-rule issues remain.

The scored-traces query now mirrors the score view’s effective timestamp predicates, including strict boundaries, while keeping project and timestamp values parameterized. The previous boundary-semantics thread was manually resolved without explanation, and the current implementation fully addresses its concern.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Score timestamp filters] --> B[Select tightest lower and upper bounds]
    B --> C[Preserve strict or inclusive operators]
    C --> D[Scored-traces scope]
    D --> E[Parameterized scores subquery]
    E --> F[Trace name, tag, and user ID options]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into perf/lfe-16128\_..."](https://github.com/langfuse/langfuse/commit/39d0daf44eefe981f0a0710ec6660783a6e8ac6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62242785)</sub>

**Context used:**

- Knowledge Base — [Observability data platform](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/observability-data-platform.md)

<!-- /greptile_comment -->