### PR TITLE
feat(api): say legacy endpoints delay data by about 10 minutes

### DIFF
--- a/web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
+++ b/web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
@@ -12,6 +12,14 @@ import {
   stampDeprecations,
 } from "../../../../scripts/openapi/stamp-deprecations";
 import {
+  DATASET_RUN_ITEMS_DEPRECATION,
+  DATASET_RUNS_DEPRECATION,
+  METRICS_DEPRECATION,
+  OBSERVATIONS_V1_DEPRECATION,
+  SCORES_DEPRECATION,
+  SESSIONS_DEPRECATION,
+  TRACES_DEPRECATION,
+  V3_DELAY_NOTICE,
   V3_SUNSET_DATE,
   V3_SUNSET_HUMAN,
 } from "@/src/features/public-api/server/deprecations";
@@ -156,6 +164,24 @@ describe("OpenAPI deprecations", () => {
         timeZone: "UTC",
       }),
     ).toBe(V3_SUNSET_HUMAN);
+  });
+
+  // Every family that already stamps `_deprecation` shares V3_NOTICE, so a new
+  // family that forgets it would ship without the delay warning.
+  it("puts the 10-minute delay on every legacy `_deprecation.message`", () => {
+    const families = [
+      OBSERVATIONS_V1_DEPRECATION,
+      TRACES_DEPRECATION,
+      SESSIONS_DEPRECATION,
+      SCORES_DEPRECATION,
+      METRICS_DEPRECATION,
+      DATASET_RUN_ITEMS_DEPRECATION,
+      DATASET_RUNS_DEPRECATION,
+    ];
+
+    for (const family of families) {
+      expect(family.message).toContain(V3_DELAY_NOTICE);
+    }
   });
 
   it("supports deprecated endpoints at a service base path", () => {

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -13,7 +13,10 @@ export const V3_SUNSET_HUMAN = "November 16, 2026";
 
 // Shared deprecation reason — references the deprecated Langfuse v3 system
 // version (not an API version). Customer-facing wording lives here — edit once.
-const V3_NOTICE = `On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on ${V3_SUNSET_HUMAN}.`;
+export const V3_DELAY_NOTICE =
+  "Data on this API is delayed by about 10 minutes. Real-time is only OpenTelemetry writes plus v2 observations and v2 metrics reads.";
+
+const V3_NOTICE = `On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on ${V3_SUNSET_HUMAN}. ${V3_DELAY_NOTICE}`;
 
 // v4 replacement endpoints, referenced by both the message and `replacement`.
 // Placeholder style matches rateLimitUpgradePaths (<from>, <to>, filters).


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17260 app preview](https://pr-17260.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Every Cloud `_deprecation.message` on a legacy (v3) public API now says that data on this API is delayed by about 10 minutes, and that real-time is only OpenTelemetry writes plus v2 observations and v2 metrics reads.

The sentence lives on the shared notice all families already interpolate, so traces, observations v1, sessions, scores, metrics, dataset runs, and dataset-run-items stay in lockstep. Fern `availability.message` is unchanged on purpose: this is the request-time body field, not the OpenAPI deprecation banner.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Impacted packages

- `web` (runtime deprecation copy + unit test)

## Verification

- `pnpm --filter web run test src/__tests__/server/unit/openapi-deprecations.servertest.ts` — Test Files 1 passed (1), Tests 16 passed (16)
- Pre-commit: `turbo run lint` — Tasks: 7 successful, 7 total, Cached: 0 cached, 7 total

Skipped `openapi:check` / Fern regen: no Fern or generated spec edits.
Skipped the HTTP `deprecation-signal.servertest.ts` suite: it needs a web server on port 3000 against the test database; the unit test already asserts every family message contains the delay sentence.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- I have read the contributing guide
- Code follows the style guidelines of this project
- I have checked if this PR needs documentation changes (no docs page; agents read the response field)
- I have not added new lint warnings
- I have added tests that prove the delay sentence is on every family that stamps `_deprecation`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-16135](https://linear.app/clickhouse/issue/LFE-16135/say-on-legacy-deprecation-that-this-api-is-delayed-10-minutes)

<div><a href="https://cursor.com/agents/bc-a4e2e1b9-cc3a-4050-8488-27fa30e8874c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4e2e1b9-cc3a-4050-8488-27fa30e8874c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a shared customer-facing notice that legacy API reads may be delayed by approximately ten minutes and identifies the supported real-time interfaces.

- Applies the notice consistently to all seven current runtime deprecation families.
- Adds a unit assertion covering every currently defined family.
- Leaves Fern/OpenAPI availability messages unchanged.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking gap in the future completeness guarantee of the new test.

The production wording is consistently applied to all current legacy read families, and no behavioral failure was found; only the test’s manually maintained enumeration weakens its promised regression protection.

**Files Needing Attention:** web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/unit/openapi-deprecations.servertest.ts:172-180
**Family List Can Drift**

This test manually lists the seven current deprecation constants. If another deprecation family is added without updating this array, the test will still pass even when its message omits the delay notice. Consider exporting or deriving a canonical collection so this test can enforce its stated guarantee for future families.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api): say legacy endpoints delay da..."](https://github.com/langfuse/langfuse/commit/ec61fadf7c4fc551ef68efc28051c4b31f976730) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62318125)</sub>

<!-- /greptile_comment -->