### PR TITLE
docs(agents): qualify Cursor Cloud script paths for multi-repo workspaces

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -219,11 +219,17 @@ langfuse/
 - Cursor Cloud starts the complete source-built stack through
   `scripts/agents/start-cursor-cloud.sh`; do not start a second web or worker
   process on ports 3000 or 3030.
+- Both `scripts/agents/*-cursor-cloud.sh` paths are relative to this repo, but a
+  multi-repo Cloud workspace runs commands from the workspace root rather than
+  from a checkout. Qualify them there
+  (`bash repos/langfuse/scripts/agents/start-cursor-cloud.sh`), and do the same
+  in the `install` and `start` entries of a multi-repo environment, or the
+  command exits 127 before any of it runs.
 - Use that script for the Cloud stack rather than invoking Compose directly:
   the workspace `.env` contains host-facing `localhost` service URLs and must
   not be used to interpolate container service configuration.
-- After changing web or worker production code, rerun
-  `bash scripts/agents/start-cursor-cloud.sh` before browser signoff.
+- After changing web or worker production code, rerun that start script before
+  browser signoff.
 - Open a same-repo reviewable PR after local verification (not a draft) and
   test the resulting `pr-<N>.preview.langfuse.com` deployment with synthetic
   data. Previews normally run Mon-Fri 08:00-24:00 Europe/Berlin.


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17278 app preview](https://pr-17278.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The Cursor Cloud section of `.agents/AGENTS.md` tells agents to run
`bash scripts/agents/start-cursor-cloud.sh`. That path is relative to this
repository, which is correct for a single-repo Cloud environment where the
working directory *is* the checkout.

In a multi-repo Cloud workspace the working directory is the workspace root and
the checkouts live one level down (`repos/langfuse/…`), so the documented
command cannot resolve the script and `bash` exits 127 before any of the script
runs. The same string is easy to copy into a multi-repo environment's `install`
and `start` entries, where it fails identically and takes every environment
build with it.

This adds one bullet naming the multi-repo form and drops the now-redundant
repetition of the bare path from the following bullet. Documentation only — no
behavior change, and the tracked `.cursor/environment.json` is deliberately left
alone because its relative paths are correct for the repo-managed single-repo
environment it configures.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

Both commands run from the multi-repo workspace root on a Cursor Cloud VM:

- Bare documented path (before): `bash: scripts/agents/start-cursor-cloud.sh: No such file or directory`, exit `127`
- Qualified path (after): install exits `0` (twice, confirming idempotence) and the start script reports `Cursor Cloud Langfuse stack is healthy: 6 services, web :3000, worker :3030` with `START_EXIT=0`

Repo checks: `pnpm run agents:check` exits 0; `pnpm run lint` → `Tasks: 7 successful, 7 total`, `Cached: 0 cached, 7 total`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a8256c1-66f1-4b9d-8480-8b2be59b953d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a8256c1-66f1-4b9d-8480-8b2be59b953d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62504519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation-only change appears safe to merge.

<details open><summary><h3>Summary</h3></summary>

- Provides the qualified start-script path for the `repos/langfuse` checkout.
- Extends the qualification guidance to multi-repository `install` and `start` entries.
- Removes a redundant repetition of the unqualified start-script command.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(agents): qualify Cursor Cloud scrip..."](https://github.com/langfuse/langfuse/commit/5af7aa8bf38fc1b7726d71f3a39b93c3402f18b4)</sub>

<!-- /greptile_comment -->