### PR TITLE
feat(worker): add sampled OTel trace activity map

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -108,10 +108,6 @@ LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE=true
 LANGFUSE_S3_MEDIA_UPLOAD_PREFIX=media/
 # Opt in to extracting and uploading media embedded in OTEL span attributes.
 LANGFUSE_OTEL_MEDIA_UPLOAD_ENABLED=false
-# OTel-only Redis activity map; each trace expires after two hours without updates.
-LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED=false
-# Deterministic percentage of project/trace pairs to track (0-100).
-LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT=100
 # Maximum encoded and decompressed OTLP request body size in bytes.
 # LANGFUSE_OTEL_INGESTION_MAX_BODY_BYTES=536870912
 

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -108,6 +108,10 @@ LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE=true
 LANGFUSE_S3_MEDIA_UPLOAD_PREFIX=media/
 # Opt in to extracting and uploading media embedded in OTEL span attributes.
 LANGFUSE_OTEL_MEDIA_UPLOAD_ENABLED=false
+# OTel-only Redis activity map; each trace expires after two hours without updates.
+LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED=false
+# Deterministic percentage of project/trace pairs to track (0-100).
+LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT=100
 # Maximum encoded and decompressed OTLP request body size in bytes.
 # LANGFUSE_OTEL_INGESTION_MAX_BODY_BYTES=536870912
 

--- a/worker/src/__tests__/traceActivityMap.test.ts
+++ b/worker/src/__tests__/traceActivityMap.test.ts
@@ -1,15 +1,23 @@
 import { randomUUID } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createNewRedisInstance, redis } from "@langfuse/shared/src/server";
+import {
+  createNewRedisInstance,
+  recordIncrement,
+  redis,
+} from "@langfuse/shared/src/server";
 import { env } from "../env";
-import { recordTraceActivity } from "../features/traces/traceActivityMap";
+import {
+  closeTraceActivityMap,
+  recordTraceActivity,
+} from "../features/traces/traceActivityMap";
 
 vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@langfuse/shared/src/server")>();
   return {
     ...actual,
-    createNewRedisInstance: vi.fn(() => actual.redis),
+    createNewRedisInstance: vi.fn(actual.createNewRedisInstance),
+    recordIncrement: vi.fn(),
   };
 });
 
@@ -34,9 +42,12 @@ describe("OTel trace activity map", () => {
     keys = [];
     env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED = "true";
     env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT = 100;
+    vi.mocked(recordIncrement).mockClear();
   });
 
   afterEach(async () => {
+    closeTraceActivityMap();
+    vi.useRealTimers();
     vi.restoreAllMocks();
     env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED = originalFlag;
     env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT = originalSamplePercent;
@@ -99,6 +110,9 @@ describe("OTel trace activity map", () => {
   it("does no Redis work when disabled and does not propagate write failures", async () => {
     const traceId = randomUUID();
     const traceKey = key(traceId);
+    vi.mocked(createNewRedisInstance).mockReturnValueOnce(redis);
+    // Keep the assertion client connected when the map closes its test client.
+    vi.spyOn(redis!, "disconnect").mockImplementation(() => {});
     const evalSpy = vi.spyOn(redis!, "eval");
     env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED = "false";
     await recordTraceActivity(projectId, [traceId]);
@@ -114,6 +128,8 @@ describe("OTel trace activity map", () => {
   });
 
   it("selects stable trace samples across batches and expands them when the percentage increases", async () => {
+    vi.mocked(createNewRedisInstance).mockReturnValueOnce(redis);
+    vi.spyOn(redis!, "disconnect").mockImplementation(() => {});
     const evalSpy = vi.spyOn(redis!, "eval").mockResolvedValue(1);
     const traceIds = Array.from({ length: 1000 }, (_, i) => `trace-${i}`);
     const sampledIds = async (
@@ -159,6 +175,8 @@ describe("OTel trace activity map", () => {
   });
 
   it("does no Redis work at zero percent and includes every distinct trace at 100 percent", async () => {
+    vi.mocked(createNewRedisInstance).mockReturnValueOnce(redis);
+    vi.spyOn(redis!, "disconnect").mockImplementation(() => {});
     const evalSpy = vi.spyOn(redis!, "eval").mockResolvedValue(1);
     vi.mocked(createNewRedisInstance).mockClear();
     env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT = 0;
@@ -172,5 +190,50 @@ describe("OTel trace activity map", () => {
       `langfuse:otel:activity:{${projectId}}:trace-a`,
       `langfuse:otel:activity:{${projectId}}:trace-b`,
     ]);
+  });
+
+  it("writes the first batch on a fresh connection and distinguishes creation from repeated updates", async () => {
+    const traceId = randomUUID();
+    const traceKey = key(traceId);
+    await recordTraceActivity(projectId, [traceId, traceId]);
+    expect(await redis!.exists(traceKey)).toBe(1);
+    await recordTraceActivity(projectId, [traceId]);
+    const total = (name: string) =>
+      vi
+        .mocked(recordIncrement)
+        .mock.calls.filter(
+          ([metric]) =>
+            metric === `langfuse.ingestion.otel.activity_map.${name}`,
+        )
+        .reduce((sum, [, value]) => sum + (value ?? 1), 0);
+    expect(total("eligible_trace_updates")).toBe(2);
+    expect(total("sampled_trace_updates")).toBe(2);
+    expect(total("trace_updates")).toBe(2);
+    expect(total("trace_creations")).toBe(1);
+    expect(total("skipped_batches")).toBe(0);
+  });
+
+  it("bounds startup waiting and records a skipped batch if the connection never becomes ready", async () => {
+    const actual = await vi.importActual<
+      typeof import("@langfuse/shared/src/server")
+    >("@langfuse/shared/src/server");
+    const waitingClient = actual.createNewRedisInstance({ lazyConnect: true });
+    if (!waitingClient) throw new Error("Redis must be configured");
+    const readyListeners = waitingClient.listenerCount("ready");
+    vi.mocked(createNewRedisInstance).mockReturnValueOnce(waitingClient);
+    const evalSpy = vi.spyOn(waitingClient, "eval");
+    vi.useFakeTimers();
+    const write = recordTraceActivity(projectId, ["trace-startup-timeout"]);
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(write).resolves.toBeUndefined();
+    expect(evalSpy).not.toHaveBeenCalled();
+    expect(waitingClient.listenerCount("ready")).toBe(readyListeners);
+    expect(recordIncrement).toHaveBeenCalledWith(
+      "langfuse.ingestion.otel.activity_map.skipped_batches",
+    );
+    expect(recordIncrement).not.toHaveBeenCalledWith(
+      "langfuse.ingestion.otel.activity_map.trace_updates",
+      expect.any(Number),
+    );
   });
 });

--- a/worker/src/__tests__/traceActivityMap.test.ts
+++ b/worker/src/__tests__/traceActivityMap.test.ts
@@ -1,0 +1,176 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createNewRedisInstance, redis } from "@langfuse/shared/src/server";
+import { env } from "../env";
+import { recordTraceActivity } from "../features/traces/traceActivityMap";
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@langfuse/shared/src/server")>();
+  return {
+    ...actual,
+    createNewRedisInstance: vi.fn(() => actual.redis),
+  };
+});
+
+describe("OTel trace activity map", () => {
+  const originalFlag = env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED;
+  const originalSamplePercent =
+    env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT;
+  let projectId: string;
+  let keys: string[];
+
+  const key = (traceId: string, project = projectId) => {
+    const value = `langfuse:otel:activity:{${project}}:${traceId}`;
+    keys.push(value);
+    return value;
+  };
+
+  beforeEach(async () => {
+    if (!redis)
+      throw new Error("Redis must be configured for integration tests");
+    await redis.ping();
+    projectId = randomUUID();
+    keys = [];
+    env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED = "true";
+    env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT = 100;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED = originalFlag;
+    env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT = originalSamplePercent;
+    // Delete only keys owned by this test, one at a time for cluster support.
+    for (const ownedKey of new Set(keys)) await redis?.del(ownedKey);
+  });
+
+  it("atomically preserves first arrival under concurrency, batches distinct traces, and isolates projects", async () => {
+    const traceId = randomUUID();
+    const traceKey = key(traceId);
+    const firstSeen = await Promise.all(
+      Array.from({ length: 20 }, async () => {
+        await recordTraceActivity(projectId, [traceId]);
+        return redis!.hget(traceKey, "first_seen");
+      }),
+    );
+    expect(firstSeen[0]).not.toBeNull();
+    expect(new Set(firstSeen).size).toBe(1);
+
+    // Pin an existing timestamp to prove later arrivals don't reinitialize it.
+    await redis!.hset(traceKey, "first_seen", "1", "last_seen", "2");
+    const otherTraces = Array.from({ length: 101 }, () => randomUUID());
+    otherTraces.forEach((id) => key(id));
+    await recordTraceActivity(projectId, [traceId, traceId, ...otherTraces]);
+    const activity = await redis!.hgetall(traceKey);
+    expect(activity.first_seen).toBe("1");
+    expect(Number(activity.last_seen)).toBeGreaterThan(2);
+    expect(await redis!.exists(key(otherTraces[100]))).toBe(1);
+
+    const otherProject = randomUUID();
+    const otherKey = key(traceId, otherProject);
+    await recordTraceActivity(otherProject, [traceId]);
+    expect(Number(await redis!.hget(otherKey, "first_seen"))).toBeGreaterThan(
+      1,
+    );
+    expect(await redis!.hget(traceKey, "first_seen")).toBe("1");
+  });
+
+  it("refreshes the two-hour TTL and starts a new activity window after expiry", async () => {
+    const traceId = randomUUID();
+    const traceKey = key(traceId);
+    await recordTraceActivity(projectId, [traceId]);
+    expect(await redis!.ttl(traceKey)).toBeGreaterThan(7190);
+
+    await redis!.hset(traceKey, "first_seen", "1");
+    await redis!.expire(traceKey, 60);
+    await recordTraceActivity(projectId, [traceId]);
+    expect(await redis!.ttl(traceKey)).toBeGreaterThan(7190);
+    expect(await redis!.hget(traceKey, "first_seen")).toBe("1");
+
+    await redis!.pexpireat(traceKey, 1);
+    expect(await redis!.exists(traceKey)).toBe(0);
+    await recordTraceActivity(projectId, [traceId]);
+    const activity = await redis!.hgetall(traceKey);
+    expect(Number(activity.first_seen)).toBeGreaterThan(1);
+    expect(activity.first_seen).toBe(activity.last_seen);
+    expect(await redis!.ttl(traceKey)).toBeGreaterThan(7190);
+  });
+
+  it("does no Redis work when disabled and does not propagate write failures", async () => {
+    const traceId = randomUUID();
+    const traceKey = key(traceId);
+    const evalSpy = vi.spyOn(redis!, "eval");
+    env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED = "false";
+    await recordTraceActivity(projectId, [traceId]);
+    expect(evalSpy).not.toHaveBeenCalled();
+    expect(await redis!.exists(traceKey)).toBe(0);
+
+    env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED = "true";
+    evalSpy.mockRejectedValueOnce(new Error("Redis unavailable"));
+    await expect(
+      recordTraceActivity(projectId, [traceId]),
+    ).resolves.toBeUndefined();
+    expect(await redis!.exists(traceKey)).toBe(0);
+  });
+
+  it("selects stable trace samples across batches and expands them when the percentage increases", async () => {
+    const evalSpy = vi.spyOn(redis!, "eval").mockResolvedValue(1);
+    const traceIds = Array.from({ length: 1000 }, (_, i) => `trace-${i}`);
+    const sampledIds = async (
+      project: string,
+      percent: number,
+      ids = traceIds,
+    ) => {
+      evalSpy.mockClear();
+      env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT = percent;
+      await recordTraceActivity(project, ids);
+      const prefix = `langfuse:otel:activity:{${project}}:`;
+      return evalSpy.mock.calls
+        .flatMap((call) =>
+          call.slice(2).map((value) => String(value).slice(prefix.length)),
+        )
+        .sort();
+    };
+
+    const tenPercent = await sampledIds("sampling-project", 10);
+    expect(tenPercent.length).toBeGreaterThan(50);
+    expect(tenPercent.length).toBeLessThan(150);
+    expect(
+      await sampledIds("sampling-project", 10, [...traceIds].reverse()),
+    ).toEqual(tenPercent);
+    // Splitting the batch or repeating observations must not change selection.
+    const splitSample = [
+      ...(await sampledIds("sampling-project", 10, traceIds.slice(0, 500))),
+      ...(await sampledIds("sampling-project", 10, traceIds.slice(500))),
+    ].sort();
+    expect(splitSample).toEqual(tenPercent);
+    expect(
+      await sampledIds("sampling-project", 10, [...traceIds, ...traceIds]),
+    ).toEqual(tenPercent);
+
+    const fiftyPercent = await sampledIds("sampling-project", 50);
+    expect(fiftyPercent.length).toBeGreaterThan(400);
+    expect(fiftyPercent.length).toBeLessThan(600);
+    expect(tenPercent.every((id) => fiftyPercent.includes(id))).toBe(true);
+    expect(await sampledIds("sampling-project", 10)).toEqual(tenPercent);
+    expect(await sampledIds("other-sampling-project", 10)).not.toEqual(
+      tenPercent,
+    );
+  });
+
+  it("does no Redis work at zero percent and includes every distinct trace at 100 percent", async () => {
+    const evalSpy = vi.spyOn(redis!, "eval").mockResolvedValue(1);
+    vi.mocked(createNewRedisInstance).mockClear();
+    env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT = 0;
+    await recordTraceActivity(projectId, ["trace-a", "trace-b"]);
+    expect(evalSpy).not.toHaveBeenCalled();
+    expect(createNewRedisInstance).not.toHaveBeenCalled();
+
+    env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT = 100;
+    await recordTraceActivity(projectId, ["trace-a", "trace-b", "trace-a"]);
+    expect(evalSpy.mock.calls.flatMap((call) => call.slice(2))).toEqual([
+      `langfuse:otel:activity:{${projectId}}:trace-a`,
+      `langfuse:otel:activity:{${projectId}}:trace-b`,
+    ]);
+  });
+});

--- a/worker/src/__tests__/traceActivityMap.test.ts
+++ b/worker/src/__tests__/traceActivityMap.test.ts
@@ -1,10 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  createNewRedisInstance,
-  recordIncrement,
-  redis,
-} from "@langfuse/shared/src/server";
+import { createNewRedisInstance, redis } from "@langfuse/shared/src/server";
 import { env } from "../env";
 import {
   closeTraceActivityMap,
@@ -17,7 +13,6 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
   return {
     ...actual,
     createNewRedisInstance: vi.fn(actual.createNewRedisInstance),
-    recordIncrement: vi.fn(),
   };
 });
 
@@ -42,7 +37,9 @@ describe("OTel trace activity map", () => {
     keys = [];
     env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED = "true";
     env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT = 100;
-    vi.mocked(recordIncrement).mockClear();
+    vi.mocked(createNewRedisInstance).mockReturnValueOnce(redis);
+    // Use the ready assertion client; keep it connected when the map closes.
+    vi.spyOn(redis!, "disconnect").mockImplementation(() => {});
   });
 
   afterEach(async () => {
@@ -107,12 +104,9 @@ describe("OTel trace activity map", () => {
     expect(await redis!.ttl(traceKey)).toBeGreaterThan(7190);
   });
 
-  it("does no Redis work when disabled and does not propagate write failures", async () => {
+  it("skips disabled/unavailable writes and does not propagate Redis failures", async () => {
     const traceId = randomUUID();
     const traceKey = key(traceId);
-    vi.mocked(createNewRedisInstance).mockReturnValueOnce(redis);
-    // Keep the assertion client connected when the map closes its test client.
-    vi.spyOn(redis!, "disconnect").mockImplementation(() => {});
     const evalSpy = vi.spyOn(redis!, "eval");
     env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED = "false";
     await recordTraceActivity(projectId, [traceId]);
@@ -125,11 +119,22 @@ describe("OTel trace activity map", () => {
       recordTraceActivity(projectId, [traceId]),
     ).resolves.toBeUndefined();
     expect(await redis!.exists(traceKey)).toBe(0);
+
+    closeTraceActivityMap();
+    const actual = await vi.importActual<
+      typeof import("@langfuse/shared/src/server")
+    >("@langfuse/shared/src/server");
+    const waitingClient = actual.createNewRedisInstance({ lazyConnect: true });
+    if (!waitingClient) throw new Error("Redis must be configured");
+    vi.mocked(createNewRedisInstance).mockReturnValueOnce(waitingClient);
+    const waitingEval = vi.spyOn(waitingClient, "eval");
+    vi.useFakeTimers();
+    await recordTraceActivity(projectId, [traceId]);
+    expect(waitingEval).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("selects stable trace samples across batches and expands them when the percentage increases", async () => {
-    vi.mocked(createNewRedisInstance).mockReturnValueOnce(redis);
-    vi.spyOn(redis!, "disconnect").mockImplementation(() => {});
     const evalSpy = vi.spyOn(redis!, "eval").mockResolvedValue(1);
     const traceIds = Array.from({ length: 1000 }, (_, i) => `trace-${i}`);
     const sampledIds = async (
@@ -172,17 +177,11 @@ describe("OTel trace activity map", () => {
     expect(await sampledIds("other-sampling-project", 10)).not.toEqual(
       tenPercent,
     );
-  });
 
-  it("does no Redis work at zero percent and includes every distinct trace at 100 percent", async () => {
-    vi.mocked(createNewRedisInstance).mockReturnValueOnce(redis);
-    vi.spyOn(redis!, "disconnect").mockImplementation(() => {});
-    const evalSpy = vi.spyOn(redis!, "eval").mockResolvedValue(1);
-    vi.mocked(createNewRedisInstance).mockClear();
+    evalSpy.mockClear();
     env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT = 0;
     await recordTraceActivity(projectId, ["trace-a", "trace-b"]);
     expect(evalSpy).not.toHaveBeenCalled();
-    expect(createNewRedisInstance).not.toHaveBeenCalled();
 
     env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT = 100;
     await recordTraceActivity(projectId, ["trace-a", "trace-b", "trace-a"]);
@@ -192,48 +191,35 @@ describe("OTel trace activity map", () => {
     ]);
   });
 
-  it("writes the first batch on a fresh connection and distinguishes creation from repeated updates", async () => {
-    const traceId = randomUUID();
-    const traceKey = key(traceId);
-    await recordTraceActivity(projectId, [traceId, traceId]);
-    expect(await redis!.exists(traceKey)).toBe(1);
-    await recordTraceActivity(projectId, [traceId]);
-    const total = (name: string) =>
-      vi
-        .mocked(recordIncrement)
-        .mock.calls.filter(
-          ([metric]) =>
-            metric === `langfuse.ingestion.otel.activity_map.${name}`,
-        )
-        .reduce((sum, [, value]) => sum + (value ?? 1), 0);
-    expect(total("eligible_trace_updates")).toBe(2);
-    expect(total("sampled_trace_updates")).toBe(2);
-    expect(total("trace_updates")).toBe(2);
-    expect(total("trace_creations")).toBe(1);
-    expect(total("skipped_batches")).toBe(0);
-  });
-
-  it("bounds startup waiting and records a skipped batch if the connection never becomes ready", async () => {
-    const actual = await vi.importActual<
-      typeof import("@langfuse/shared/src/server")
-    >("@langfuse/shared/src/server");
-    const waitingClient = actual.createNewRedisInstance({ lazyConnect: true });
-    if (!waitingClient) throw new Error("Redis must be configured");
-    const readyListeners = waitingClient.listenerCount("ready");
-    vi.mocked(createNewRedisInstance).mockReturnValueOnce(waitingClient);
-    const evalSpy = vi.spyOn(waitingClient, "eval");
-    vi.useFakeTimers();
-    const write = recordTraceActivity(projectId, ["trace-startup-timeout"]);
+  it("stops waiting at the batch deadline and never submits remaining chunks after a late response", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
+    let finishCommand!: (value: number) => void;
+    const evalSpy = vi
+      .spyOn(redis!, "eval")
+      .mockImplementationOnce(
+        () => new Promise((resolve) => setTimeout(() => resolve(0), 60)),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishCommand = resolve;
+          }),
+      );
+    let finished = false;
+    const write = recordTraceActivity(
+      projectId,
+      Array.from({ length: 301 }, (_, i) => `trace-${i}`),
+    ).then(() => {
+      finished = true;
+    });
+    await vi.advanceTimersByTimeAsync(99);
+    expect(evalSpy).toHaveBeenCalledTimes(2);
+    expect(finished).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(finished).toBe(true);
+    finishCommand(0);
+    await write;
     await vi.advanceTimersByTimeAsync(1000);
-    await expect(write).resolves.toBeUndefined();
-    expect(evalSpy).not.toHaveBeenCalled();
-    expect(waitingClient.listenerCount("ready")).toBe(readyListeners);
-    expect(recordIncrement).toHaveBeenCalledWith(
-      "langfuse.ingestion.otel.activity_map.skipped_batches",
-    );
-    expect(recordIncrement).not.toHaveBeenCalledWith(
-      "langfuse.ingestion.otel.activity_map.trace_updates",
-      expect.any(Number),
-    );
+    expect(evalSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -113,7 +113,7 @@ const EnvSchema = z.object({
     .number()
     .min(0)
     .max(100)
-    .default(100),
+    .default(10),
   LANGFUSE_SECONDARY_OTEL_INGESTION_QUEUE_ENABLED_PROJECT_IDS: z
     .string()
     .optional(),

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -106,6 +106,14 @@ const EnvSchema = z.object({
   LANGFUSE_OTEL_MEDIA_UPLOAD_ENABLED: z
     .enum(["true", "false"])
     .default("false"),
+  LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED: z
+    .enum(["true", "false"])
+    .default("false"),
+  LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT: z.coerce
+    .number()
+    .min(0)
+    .max(100)
+    .default(100),
   LANGFUSE_SECONDARY_OTEL_INGESTION_QUEUE_ENABLED_PROJECT_IDS: z
     .string()
     .optional(),

--- a/worker/src/features/traces/traceActivityMap.md
+++ b/worker/src/features/traces/traceActivityMap.md
@@ -37,17 +37,63 @@ event time or ClickHouse visibility. **Do not use `first_seen` as a lower bound
 for loading the complete trace from ClickHouse.**
 
 Writes are best-effort on a separate connection with a one-second command
-timeout. Batches encountered while that connection is starting or reconnecting
-are skipped. Errors stop the remaining updates for that batch without failing
+timeout. Concurrent first batches share a startup wait of at most one second,
+so a healthy new connection can write its first batch. If startup times out or
+the connection is reconnecting, batches are skipped. Startup waiting and a
+subsequent command timeout are separate budgets, not a one-second whole-batch
+deadline. Errors stop the remaining updates for that batch without failing
 ingestion. Consequently, this is an approximate activity map, not a completeness
 guarantee. Disabling the flag stops updates; existing keys expire naturally.
 
-Metrics use the `langfuse.ingestion.otel.activity_map` prefix:
-`trace_updates`, `skipped_batches`, `errors`, and `duration_ms`. Counts cover
-OTel only; updates are deduplicated within a batch but count again on retries.
+## Experiment measurements
+
+Metrics use the `langfuse.ingestion.otel.activity_map` prefix, without
+project/trace ID tags. Group by the deployment's region/service tags when
+comparing rollout stages. Metrics are emitted only when enabled with a nonzero
+sampling percentage and a nonempty input batch.
+
+| Suffix                   | Type         | Meaning                                                                                                        |
+| ------------------------ | ------------ | -------------------------------------------------------------------------------------------------------------- |
+| `eligible_trace_updates` | Counter      | Distinct traces per input batch, before sampling.                                                              |
+| `sampled_trace_updates`  | Counter      | Selected trace updates, before connecting or writing.                                                          |
+| `trace_updates`          | Counter      | Updates in scripts acknowledged as successful.                                                                 |
+| `trace_creations`        | Counter      | Hash initializations reported by successful scripts; obtained atomically with `HSETNX`, without an extra read. |
+| `skipped_batches`        | Counter      | Batches with selected traces skipped entirely or partly because the connection is unavailable.                 |
+| `errors`                 | Counter      | Failed map calls; may follow successful chunks in the same batch.                                              |
+| `duration_ms`            | Distribution | Map-call duration including sampling, startup waiting, and writes.                                             |
+
+Counts cover OTel only. Updates are deduplicated within a batch but count again
+on retries. Creations include recreation after expiry/eviction, so their sum is
+neither the current map size nor a globally unique trace count. A timeout can
+occur after Redis applied a script: success/creation counters reflect confirmed
+responses, not a complete ledger of writes.
+
+For each stable sampling stage, compare:
+
+- `sampled_trace_updates / eligible_trace_updates`: observed selection fraction
+  of trace updates (not necessarily the configured percentage of unique traces,
+  because traces have different batch frequencies).
+- `trace_updates / sampled_trace_updates`, plus skips/errors: confirmed write
+  coverage. The difference includes unconfirmed writes, not just lost updates.
+- Rates of `trace_creations` and `trace_updates`: new-entry churn vs write load.
+- p50/p95/p99 of `duration_ms`: added worker latency, including startup.
+
 There is no automatic storage scan in the ingestion path. For a regional
 storage experiment, sample matching keys with incremental `SCAN` and
 `MEMORY USAGE`, and compare Redis memory, CPU, eviction counts, and ingestion
 latency before/after enablement. On a cluster, sample each primary. Include
 key/index overhead, replication, and allocator overhead when estimating total
 capacity; `MEMORY USAGE` samples alone are not total Redis memory.
+
+The application counters do **not** automatically publish map bytes, active-key
+count, Redis CPU, evictions, or BullMQ latency. Use a separately scoped key-count
+and memory sample plus the existing infrastructure/queue telemetry for those.
+Redis metrics must be checked per shard, since the current project hash tag can
+concentrate writes. Whole-cluster averages can hide that pressure.
+
+Capture a baseline, enable 10% in one region, and observe at least the two-hour
+retention window and representative peak traffic. Record the actual sampling
+configuration and time of each rollout. Increase to 50% only within operator-
+agreed memory/CPU and ingestion/queue latency limits; disable on breaches.
+Do not extrapolate write-only measurements as the cost of a future sorted-set
+index or readiness scheduler: those are separate experiments.

--- a/worker/src/features/traces/traceActivityMap.md
+++ b/worker/src/features/traces/traceActivityMap.md
@@ -1,99 +1,53 @@
 # OTel trace activity map
 
-Set `LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED=true` on the region's OTel
-workers to enable this experiment. It defaults to false. It does not run for
-legacy JSON ingestion or schedule evaluations.
+Write-only, best-effort experiment in the OTel batch worker. Enable per region:
 
-Use `LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT=10` to start with an
-approximately 10% trace sample, then raise it to `50` or `100`. This setting
-accepts numbers from 0 to 100 (including fractional percentages), defaulting to 100. Zero performs no map writes. Apply env changes by restarting/redeploying
-the region's workers, using the same value across them for consistent coverage.
+```env
+LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED=true
+LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT=10
+```
 
-Sampling hashes the `(project_id, trace_id)` pair, so a trace is consistently
-included or excluded across batches and retries. Increasing the percentage
-keeps the existing sample and adds traces; newly included traces start their
-activity window on their next processed batch. Decreasing it stops refreshing
-excluded keys, which expire according to their existing TTL. Selection happens
-before Redis connection creation or commands. This controls expected trace
-volume, not an exact count, traffic percentage, or hard memory limit.
+The feature defaults to disabled; sampling defaults to **10%**. Percentages
+from 0 to 100 (including fractions) are supported; zero skips all map work.
+Restart/redeploy workers with consistent regional settings to change sampling.
 
-Each distinct trace in a converted OTel batch updates a Redis hash:
+Sampling hashes the project/trace pair, so selection is stable across batches
+and retries. Increasing to 50% retains the original sample. Newly selected
+traces start on their next update; deselected traces expire naturally.
+Sampling controls expected trace volume, not exact traffic or a hard memory cap.
 
-`<REDIS_KEY_PREFIX>langfuse:otel:activity:{<project_id>}:<trace_id>`
+## Stored state
 
-- `first_seen`: Redis server time in Unix milliseconds when the key was created.
-- `last_seen`: Redis server time of the latest update, never decreasing.
-- TTL: two hours, refreshed on every update. No explicit drainage.
+Each trace uses a hash at
+`<REDIS_KEY_PREFIX>langfuse:otel:activity:{<project_id>}:<trace_id>`:
 
-A Lua script performs initialization, update, and expiry without another
-worker interleaving. Calls contain at most 100 trace keys, sharing a project
-hash tag for Redis Cluster. This places a project's activity keys on one shard.
-The script is atomic with respect to concurrent commands, not a durable queue
-or a rollback transaction.
+- `first_seen`: Redis arrival time in Unix milliseconds when the key is created.
+- `last_seen`: Redis arrival time of the latest update, never decreasing.
+- TTL: two hours, refreshed on every update; no explicit drainage.
 
-After expiration or eviction, another observation creates a fresh window.
-These timestamps measure worker processing activity, including retries, not
-event time or ClickHouse visibility. **Do not use `first_seen` as a lower bound
-for loading the complete trace from ClickHouse.**
+Lua atomically initializes the first timestamp, updates the last, and refreshes
+expiry. Scripts contain at most 100 keys with the same project hash tag for
+Redis Cluster. A project's keys concentrate on one shard.
 
-Writes are best-effort on a separate connection with a one-second command
-timeout. Concurrent first batches share a startup wait of at most one second,
-so a healthy new connection can write its first batch. If startup times out or
-the connection is reconnecting, batches are skipped. Startup waiting and a
-subsequent command timeout are separate budgets, not a one-second whole-batch
-deadline. Errors stop the remaining updates for that batch without failing
-ingestion. Consequently, this is an approximate activity map, not a completeness
-guarantee. Disabling the flag stops updates; existing keys expire naturally.
+Expiry/eviction resets the window. These are worker-arrival timestamps, not
+observation timestamps or ClickHouse visibility guarantees. **Do not use
+`first_seen` as a lower bound for loading complete traces.**
 
-## Experiment measurements
+## Ingestion safety and rollout
 
-Metrics use the `langfuse.ingestion.otel.activity_map` prefix, without
-project/trace ID tags. Group by the deployment's region/service tags when
-comparing rollout stages. Metrics are emitted only when enabled with a nonzero
-sampling percentage and a nonempty input batch.
+The helper has a fixed 100ms budget covering sampling and Redis waits, using a
+dedicated connection. Startup/reconnect batches are skipped immediately.
+Errors or deadline expiry stop further chunks without failing ingestion.
+An already-sent script may still apply after the deadline; timing out does not
+cancel Redis work. JavaScript event-loop delays can delay timeout handling.
 
-| Suffix                   | Type         | Meaning                                                                                                        |
-| ------------------------ | ------------ | -------------------------------------------------------------------------------------------------------------- |
-| `eligible_trace_updates` | Counter      | Distinct traces per input batch, before sampling.                                                              |
-| `sampled_trace_updates`  | Counter      | Selected trace updates, before connecting or writing.                                                          |
-| `trace_updates`          | Counter      | Updates in scripts acknowledged as successful.                                                                 |
-| `trace_creations`        | Counter      | Hash initializations reported by successful scripts; obtained atomically with `HSETNX`, without an extra read. |
-| `skipped_batches`        | Counter      | Batches with selected traces skipped entirely or partly because the connection is unavailable.                 |
-| `errors`                 | Counter      | Failed map calls; may follow successful chunks in the same batch.                                              |
-| `duration_ms`            | Distribution | Map-call duration including sampling, startup waiting, and writes.                                             |
+There are no custom experiment metrics or ingestion-path storage scans.
+Use existing Redis and queue monitoring: compare per-shard memory, CPU,
+evictions, and ingestion/queue latency against a baseline. Begin at 10% in one
+region; observe at least two hours and representative peak traffic before
+considering 50%. Disable if operator-agreed headroom is exceeded.
 
-Counts cover OTel only. Updates are deduplicated within a batch but count again
-on retries. Creations include recreation after expiry/eviction, so their sum is
-neither the current map size nor a globally unique trace count. A timeout can
-occur after Redis applied a script: success/creation counters reflect confirmed
-responses, not a complete ledger of writes.
-
-For each stable sampling stage, compare:
-
-- `sampled_trace_updates / eligible_trace_updates`: observed selection fraction
-  of trace updates (not necessarily the configured percentage of unique traces,
-  because traces have different batch frequencies).
-- `trace_updates / sampled_trace_updates`, plus skips/errors: confirmed write
-  coverage. The difference includes unconfirmed writes, not just lost updates.
-- Rates of `trace_creations` and `trace_updates`: new-entry churn vs write load.
-- p50/p95/p99 of `duration_ms`: added worker latency, including startup.
-
-There is no automatic storage scan in the ingestion path. For a regional
-storage experiment, sample matching keys with incremental `SCAN` and
-`MEMORY USAGE`, and compare Redis memory, CPU, eviction counts, and ingestion
-latency before/after enablement. On a cluster, sample each primary. Include
-key/index overhead, replication, and allocator overhead when estimating total
-capacity; `MEMORY USAGE` samples alone are not total Redis memory.
-
-The application counters do **not** automatically publish map bytes, active-key
-count, Redis CPU, evictions, or BullMQ latency. Use a separately scoped key-count
-and memory sample plus the existing infrastructure/queue telemetry for those.
-Redis metrics must be checked per shard, since the current project hash tag can
-concentrate writes. Whole-cluster averages can hide that pressure.
-
-Capture a baseline, enable 10% in one region, and observe at least the two-hour
-retention window and representative peak traffic. Record the actual sampling
-configuration and time of each rollout. Increase to 50% only within operator-
-agreed memory/CPU and ingestion/queue latency limits; disable on breaches.
-Do not extrapolate write-only measurements as the cost of a future sorted-set
-index or readiness scheduler: those are separate experiments.
+Budget/connection skips make actual coverage lower than the selected sample.
+Infrastructure metrics do not measure that coverage, so do not blindly scale
+observed storage by 10 to predict a complete map. This experiment does not
+estimate the cost of a future index, scheduler, or drainage mechanism.

--- a/worker/src/features/traces/traceActivityMap.md
+++ b/worker/src/features/traces/traceActivityMap.md
@@ -1,0 +1,53 @@
+# OTel trace activity map
+
+Set `LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED=true` on the region's OTel
+workers to enable this experiment. It defaults to false. It does not run for
+legacy JSON ingestion or schedule evaluations.
+
+Use `LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT=10` to start with an
+approximately 10% trace sample, then raise it to `50` or `100`. This setting
+accepts numbers from 0 to 100 (including fractional percentages), defaulting to 100. Zero performs no map writes. Apply env changes by restarting/redeploying
+the region's workers, using the same value across them for consistent coverage.
+
+Sampling hashes the `(project_id, trace_id)` pair, so a trace is consistently
+included or excluded across batches and retries. Increasing the percentage
+keeps the existing sample and adds traces; newly included traces start their
+activity window on their next processed batch. Decreasing it stops refreshing
+excluded keys, which expire according to their existing TTL. Selection happens
+before Redis connection creation or commands. This controls expected trace
+volume, not an exact count, traffic percentage, or hard memory limit.
+
+Each distinct trace in a converted OTel batch updates a Redis hash:
+
+`<REDIS_KEY_PREFIX>langfuse:otel:activity:{<project_id>}:<trace_id>`
+
+- `first_seen`: Redis server time in Unix milliseconds when the key was created.
+- `last_seen`: Redis server time of the latest update, never decreasing.
+- TTL: two hours, refreshed on every update. No explicit drainage.
+
+A Lua script performs initialization, update, and expiry without another
+worker interleaving. Calls contain at most 100 trace keys, sharing a project
+hash tag for Redis Cluster. This places a project's activity keys on one shard.
+The script is atomic with respect to concurrent commands, not a durable queue
+or a rollback transaction.
+
+After expiration or eviction, another observation creates a fresh window.
+These timestamps measure worker processing activity, including retries, not
+event time or ClickHouse visibility. **Do not use `first_seen` as a lower bound
+for loading the complete trace from ClickHouse.**
+
+Writes are best-effort on a separate connection with a one-second command
+timeout. Batches encountered while that connection is starting or reconnecting
+are skipped. Errors stop the remaining updates for that batch without failing
+ingestion. Consequently, this is an approximate activity map, not a completeness
+guarantee. Disabling the flag stops updates; existing keys expire naturally.
+
+Metrics use the `langfuse.ingestion.otel.activity_map` prefix:
+`trace_updates`, `skipped_batches`, `errors`, and `duration_ms`. Counts cover
+OTel only; updates are deduplicated within a batch but count again on retries.
+There is no automatic storage scan in the ingestion path. For a regional
+storage experiment, sample matching keys with incremental `SCAN` and
+`MEMORY USAGE`, and compare Redis memory, CPU, eviction counts, and ingestion
+latency before/after enablement. On a cluster, sample each primary. Include
+key/index overhead, replication, and allocator overhead when estimating total
+capacity; `MEMORY USAGE` samples alone are not total Redis memory.

--- a/worker/src/features/traces/traceActivityMap.ts
+++ b/worker/src/features/traces/traceActivityMap.ts
@@ -13,20 +13,25 @@ import { env } from "../../env";
 const touchTracesScript = `
 local time = redis.call('TIME')
 local now = tonumber(time[1]) * 1000 + math.floor(tonumber(time[2]) / 1000)
+local created = 0
 for _, key in ipairs(KEYS) do
-  redis.call('HSETNX', key, 'first_seen', now)
+  created = created + redis.call('HSETNX', key, 'first_seen', now)
   local last = tonumber(redis.call('HGET', key, 'last_seen')) or 0
   redis.call('HSET', key, 'last_seen', math.max(now, last))
   redis.call('EXPIRE', key, 7200)
 end
-return #KEYS
+return created
 `;
 
 let client: ReturnType<typeof createNewRedisInstance> | undefined;
+let startupReady: Promise<void> | undefined;
+let finishStartupWait: (() => void) | undefined;
 
 export function closeTraceActivityMap(): void {
+  finishStartupWait?.();
   client?.disconnect();
   client = undefined;
+  startupReady = undefined;
 }
 
 /** Best-effort OTel activity measurement; never gates ingestion on Redis health. */
@@ -45,7 +50,12 @@ export async function recordTraceActivity(
   const startedAt = performance.now();
   try {
     const samplePercent = env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT;
-    const distinctTraceIds = [...new Set(traceIds)].filter((traceId) => {
+    const eligibleTraceIds = [...new Set(traceIds)];
+    recordIncrement(
+      "langfuse.ingestion.otel.activity_map.eligible_trace_updates",
+      eligibleTraceIds.length,
+    );
+    const distinctTraceIds = eligibleTraceIds.filter((traceId) => {
       if (samplePercent === 100) return true;
       // Stable across workers, retries, and batches. Increasing the threshold
       // retains the existing sample. JSON encoding keeps the pair unambiguous.
@@ -56,14 +66,37 @@ export async function recordTraceActivity(
       return hash / 2 ** 32 < samplePercent / 100;
     });
     if (distinctTraceIds.length === 0) return;
+    recordIncrement(
+      "langfuse.ingestion.otel.activity_map.sampled_trace_updates",
+      distinctTraceIds.length,
+    );
 
     // A separate connection bounds failures without changing BullMQ's retries.
-    client ??= createNewRedisInstance({
-      keyPrefix: sharedEnv.REDIS_KEY_PREFIX ?? undefined,
-      enableOfflineQueue: false,
-      maxRetriesPerRequest: 1,
-      commandTimeout: 1000,
-    });
+    if (client === undefined) {
+      client = createNewRedisInstance({
+        keyPrefix: sharedEnv.REDIS_KEY_PREFIX ?? undefined,
+        enableOfflineQueue: false,
+        maxRetriesPerRequest: 1,
+        commandTimeout: 1000,
+      });
+      if (client && client.status !== "ready") {
+        const connection = client;
+        // Concurrent first batches share one bounded wait, not one listener
+        // each. After startup, unavailable connections fail open immediately.
+        startupReady = new Promise<void>((resolve) => {
+          const finish = () => {
+            clearTimeout(timeout);
+            connection.removeListener("ready", finish);
+            finishStartupWait = undefined;
+            resolve();
+          };
+          const timeout = setTimeout(finish, 1000);
+          finishStartupWait = finish;
+          connection.once("ready", finish);
+        });
+      }
+    }
+    if (client?.status !== "ready") await startupReady;
     // Also avoid the cluster-level offline queue during startup/reconnect.
     if (!client || client.status !== "ready") {
       recordIncrement("langfuse.ingestion.otel.activity_map.skipped_batches");
@@ -80,10 +113,18 @@ export async function recordTraceActivity(
       const keys = distinctTraceIds
         .slice(offset, offset + 100)
         .map((traceId) => `langfuse:otel:activity:{${projectId}}:${traceId}`);
-      await client.eval(touchTracesScript, keys.length, ...keys);
+      const created = await client.eval(
+        touchTracesScript,
+        keys.length,
+        ...keys,
+      );
       recordIncrement(
         "langfuse.ingestion.otel.activity_map.trace_updates",
         keys.length,
+      );
+      recordIncrement(
+        "langfuse.ingestion.otel.activity_map.trace_creations",
+        Number(created),
       );
     }
   } catch (error) {

--- a/worker/src/features/traces/traceActivityMap.ts
+++ b/worker/src/features/traces/traceActivityMap.ts
@@ -1,139 +1,97 @@
 import { createHash } from "node:crypto";
 import { env as sharedEnv } from "@langfuse/shared/src/env";
-import {
-  createNewRedisInstance,
-  logger,
-  recordDistribution,
-  recordIncrement,
-} from "@langfuse/shared/src/server";
+import { createNewRedisInstance, logger } from "@langfuse/shared/src/server";
 import { env } from "../../env";
 
-// Redis serializes the entire script, including initialization and expiry.
-// These are Redis arrival times, not observation timestamps or query bounds.
+// Redis serializes initialization, update, and expiry. These are arrival
+// timestamps, not observation timestamps or ClickHouse query bounds.
 const touchTracesScript = `
 local time = redis.call('TIME')
 local now = tonumber(time[1]) * 1000 + math.floor(tonumber(time[2]) / 1000)
-local created = 0
 for _, key in ipairs(KEYS) do
-  created = created + redis.call('HSETNX', key, 'first_seen', now)
+  redis.call('HSETNX', key, 'first_seen', now)
   local last = tonumber(redis.call('HGET', key, 'last_seen')) or 0
   redis.call('HSET', key, 'last_seen', math.max(now, last))
   redis.call('EXPIRE', key, 7200)
 end
-return created
+return 1
 `;
 
 let client: ReturnType<typeof createNewRedisInstance> | undefined;
-let startupReady: Promise<void> | undefined;
-let finishStartupWait: (() => void) | undefined;
 
 export function closeTraceActivityMap(): void {
-  finishStartupWait?.();
   client?.disconnect();
   client = undefined;
-  startupReady = undefined;
 }
 
-/** Best-effort OTel activity measurement; never gates ingestion on Redis health. */
+/** Best-effort OTel activity sampling with a 100ms budget per call. */
 export async function recordTraceActivity(
   projectId: string,
   traceIds: string[],
 ): Promise<void> {
+  const samplePercent = env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT;
   if (
     env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED !== "true" ||
-    env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT === 0 ||
+    samplePercent === 0 ||
     traceIds.length === 0
   ) {
     return;
   }
 
-  const startedAt = performance.now();
+  const deadline = performance.now() + 100;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
-    const samplePercent = env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT;
-    const eligibleTraceIds = [...new Set(traceIds)];
-    recordIncrement(
-      "langfuse.ingestion.otel.activity_map.eligible_trace_updates",
-      eligibleTraceIds.length,
-    );
-    const distinctTraceIds = eligibleTraceIds.filter((traceId) => {
-      if (samplePercent === 100) return true;
-      // Stable across workers, retries, and batches. Increasing the threshold
-      // retains the existing sample. JSON encoding keeps the pair unambiguous.
-      const hash = createHash("sha256")
-        .update(JSON.stringify([projectId, traceId]))
-        .digest()
-        .readUInt32BE(0);
-      return hash / 2 ** 32 < samplePercent / 100;
-    });
-    if (distinctTraceIds.length === 0) return;
-    recordIncrement(
-      "langfuse.ingestion.otel.activity_map.sampled_trace_updates",
-      distinctTraceIds.length,
-    );
-
-    // A separate connection bounds failures without changing BullMQ's retries.
+    // Separate from BullMQ; skip startup/reconnect rather than queueing writes.
     if (client === undefined) {
       client = createNewRedisInstance({
         keyPrefix: sharedEnv.REDIS_KEY_PREFIX ?? undefined,
         enableOfflineQueue: false,
         maxRetriesPerRequest: 1,
-        commandTimeout: 1000,
+        commandTimeout: 100,
       });
-      if (client && client.status !== "ready") {
-        const connection = client;
-        // Concurrent first batches share one bounded wait, not one listener
-        // each. After startup, unavailable connections fail open immediately.
-        startupReady = new Promise<void>((resolve) => {
-          const finish = () => {
-            clearTimeout(timeout);
-            connection.removeListener("ready", finish);
-            finishStartupWait = undefined;
-            resolve();
-          };
-          const timeout = setTimeout(finish, 1000);
-          finishStartupWait = finish;
-          connection.once("ready", finish);
-        });
-      }
     }
-    if (client?.status !== "ready") await startupReady;
-    // Also avoid the cluster-level offline queue during startup/reconnect.
-    if (!client || client.status !== "ready") {
-      recordIncrement("langfuse.ingestion.otel.activity_map.skipped_batches");
-      return;
-    }
+    if (!client || client.status !== "ready") return;
 
-    // All keys in a call share a project hash tag for Redis Cluster. Bound
-    // script work to avoid blocking Redis for a large OTel batch.
-    for (let offset = 0; offset < distinctTraceIds.length; offset += 100) {
-      if (client.status !== "ready") {
-        recordIncrement("langfuse.ingestion.otel.activity_map.skipped_batches");
-        return;
+    const budgetExpired = new Promise<never>((_, reject) => {
+      timeout = setTimeout(
+        () => reject(new Error("OTel trace activity map deadline exceeded")),
+        Math.max(0, deadline - performance.now()),
+      );
+    });
+    const seen = new Set<string>();
+    let offset = 0;
+    while (offset < traceIds.length) {
+      const keys: string[] = [];
+      while (offset < traceIds.length && keys.length < 100) {
+        // Bound sampling too, without first copying/deduplicating a huge batch.
+        if (performance.now() >= deadline) return;
+        const traceId = traceIds[offset++];
+        if (seen.has(traceId)) continue;
+        seen.add(traceId);
+        if (samplePercent < 100) {
+          // Stable across batches/retries; increasing the threshold retains
+          // existing traces. JSON encoding keeps the project/trace unambiguous.
+          const hash = createHash("sha256")
+            .update(JSON.stringify([projectId, traceId]))
+            .digest()
+            .readUInt32BE(0);
+          if (hash / 2 ** 32 >= samplePercent / 100) continue;
+        }
+        keys.push(`langfuse:otel:activity:{${projectId}}:${traceId}`);
       }
-      const keys = distinctTraceIds
-        .slice(offset, offset + 100)
-        .map((traceId) => `langfuse:otel:activity:{${projectId}}:${traceId}`);
-      const created = await client.eval(
-        touchTracesScript,
-        keys.length,
-        ...keys,
-      );
-      recordIncrement(
-        "langfuse.ingestion.otel.activity_map.trace_updates",
-        keys.length,
-      );
-      recordIncrement(
-        "langfuse.ingestion.otel.activity_map.trace_creations",
-        Number(created),
-      );
+      if (performance.now() >= deadline || client.status !== "ready") return;
+      if (keys.length === 0) continue;
+      // Each script is bounded and all keys share a Redis Cluster slot.
+      // Race only this command: on timeout no remaining chunks are submitted.
+      // A command already sent to Redis may still apply after we stop waiting.
+      await Promise.race([
+        client.eval(touchTracesScript, keys.length, ...keys),
+        budgetExpired,
+      ]);
     }
   } catch (error) {
-    recordIncrement("langfuse.ingestion.otel.activity_map.errors");
     logger.warn("Failed to record OTel trace activity", { projectId, error });
   } finally {
-    recordDistribution(
-      "langfuse.ingestion.otel.activity_map.duration_ms",
-      performance.now() - startedAt,
-    );
+    clearTimeout(timeout);
   }
 }

--- a/worker/src/features/traces/traceActivityMap.ts
+++ b/worker/src/features/traces/traceActivityMap.ts
@@ -1,0 +1,98 @@
+import { createHash } from "node:crypto";
+import { env as sharedEnv } from "@langfuse/shared/src/env";
+import {
+  createNewRedisInstance,
+  logger,
+  recordDistribution,
+  recordIncrement,
+} from "@langfuse/shared/src/server";
+import { env } from "../../env";
+
+// Redis serializes the entire script, including initialization and expiry.
+// These are Redis arrival times, not observation timestamps or query bounds.
+const touchTracesScript = `
+local time = redis.call('TIME')
+local now = tonumber(time[1]) * 1000 + math.floor(tonumber(time[2]) / 1000)
+for _, key in ipairs(KEYS) do
+  redis.call('HSETNX', key, 'first_seen', now)
+  local last = tonumber(redis.call('HGET', key, 'last_seen')) or 0
+  redis.call('HSET', key, 'last_seen', math.max(now, last))
+  redis.call('EXPIRE', key, 7200)
+end
+return #KEYS
+`;
+
+let client: ReturnType<typeof createNewRedisInstance> | undefined;
+
+export function closeTraceActivityMap(): void {
+  client?.disconnect();
+  client = undefined;
+}
+
+/** Best-effort OTel activity measurement; never gates ingestion on Redis health. */
+export async function recordTraceActivity(
+  projectId: string,
+  traceIds: string[],
+): Promise<void> {
+  if (
+    env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED !== "true" ||
+    env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT === 0 ||
+    traceIds.length === 0
+  ) {
+    return;
+  }
+
+  const startedAt = performance.now();
+  try {
+    const samplePercent = env.LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT;
+    const distinctTraceIds = [...new Set(traceIds)].filter((traceId) => {
+      if (samplePercent === 100) return true;
+      // Stable across workers, retries, and batches. Increasing the threshold
+      // retains the existing sample. JSON encoding keeps the pair unambiguous.
+      const hash = createHash("sha256")
+        .update(JSON.stringify([projectId, traceId]))
+        .digest()
+        .readUInt32BE(0);
+      return hash / 2 ** 32 < samplePercent / 100;
+    });
+    if (distinctTraceIds.length === 0) return;
+
+    // A separate connection bounds failures without changing BullMQ's retries.
+    client ??= createNewRedisInstance({
+      keyPrefix: sharedEnv.REDIS_KEY_PREFIX ?? undefined,
+      enableOfflineQueue: false,
+      maxRetriesPerRequest: 1,
+      commandTimeout: 1000,
+    });
+    // Also avoid the cluster-level offline queue during startup/reconnect.
+    if (!client || client.status !== "ready") {
+      recordIncrement("langfuse.ingestion.otel.activity_map.skipped_batches");
+      return;
+    }
+
+    // All keys in a call share a project hash tag for Redis Cluster. Bound
+    // script work to avoid blocking Redis for a large OTel batch.
+    for (let offset = 0; offset < distinctTraceIds.length; offset += 100) {
+      if (client.status !== "ready") {
+        recordIncrement("langfuse.ingestion.otel.activity_map.skipped_batches");
+        return;
+      }
+      const keys = distinctTraceIds
+        .slice(offset, offset + 100)
+        .map((traceId) => `langfuse:otel:activity:{${projectId}}:${traceId}`);
+      await client.eval(touchTracesScript, keys.length, ...keys);
+      recordIncrement(
+        "langfuse.ingestion.otel.activity_map.trace_updates",
+        keys.length,
+      );
+    }
+  } catch (error) {
+    recordIncrement("langfuse.ingestion.otel.activity_map.errors");
+    logger.warn("Failed to record OTel trace activity", { projectId, error });
+  } finally {
+    recordDistribution(
+      "langfuse.ingestion.otel.activity_map.duration_ms",
+      performance.now() - startedAt,
+    );
+  }
+}

--- a/worker/src/queues/otelIngestionQueue.ts
+++ b/worker/src/queues/otelIngestionQueue.ts
@@ -37,6 +37,7 @@ import {
 import { IngestionService } from "../services/IngestionService";
 import { prisma } from "@langfuse/shared/src/db";
 import { ClickhouseWriter } from "../services/ClickhouseWriter";
+import { recordTraceActivity } from "../features/traces/traceActivityMap";
 import {
   ForbiddenError,
   convertEventRecordToObservationForEval,
@@ -770,6 +771,11 @@ export const otelIngestionQueueProcessorBuilder = (
       if (eventInputs.length === 0) {
         return;
       }
+
+      await recordTraceActivity(
+        projectId,
+        eventInputs.map((event) => event.traceId),
+      );
 
       // Determine what processing is needed
       const shouldWriteToEventsTable =

--- a/worker/src/utils/shutdown.ts
+++ b/worker/src/utils/shutdown.ts
@@ -10,6 +10,7 @@ import { WorkerManager } from "../queues/workerManager";
 import { logInFlightBlobExportsOnShutdown } from "../features/blobstorage/inFlightExports";
 import { abortActiveInAppAgentRuns } from "../features/in-app-agent/executeInAppAgentRun";
 import { prisma } from "@langfuse/shared/src/db";
+import { closeTraceActivityMap } from "../features/traces/traceActivityMap";
 import { BackgroundMigrationManager } from "../backgroundMigrations/backgroundMigrationManager";
 import {
   batchProjectCleaners,
@@ -109,6 +110,7 @@ const runDrainAndClose = async () => {
   logger.info("Clickhouse writer has been shut down.");
 
   redis?.disconnect();
+  closeTraceActivityMap();
   logger.info("Redis connection has been closed.");
 
   await prisma.$disconnect();


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17284 app preview](https://pr-17284.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Adds a small opt-in, OTel-only Redis activity map for a write-only storage/load experiment.

- One hash per project/trace containing Redis-arrival `first_seen` and monotonic `last_seen`.
- Atomic Lua initialization/update and rolling two-hour TTL; no drainage.
- Stable, nested trace sampling: **10% by default**, feature disabled by default.
- Dedicated fail-fast connection, immediate startup/reconnect skips, and a **100ms helper-call budget** across incremental sampling and Redis waits.
- At most 100 keys per Lua invocation, sharing the project hash tag for Redis Cluster.
- No custom counters, creation-count bookkeeping, or duration metrics. Use existing infrastructure monitoring and failure logs.
- No ZSET, scheduler, ClickHouse query changes, or changes to `.env.dev.example`.

Impacted package: `worker`.

### Regional rollout

```env
LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_ENABLED=true
LANGFUSE_OTEL_TRACE_ACTIVITY_MAP_SAMPLE_PERCENT=10
```

Sampling accepts 0–100 including fractions; zero skips all map work. Restart/redeploy workers with consistent regional settings. Increasing to 50 retains the original sample; lowering it lets excluded keys expire naturally.

Compare per-shard Redis memory, CPU, evictions, and ingestion/queue latency with a baseline. Observe at least two hours and representative peak traffic before increasing the percentage.

### Review considerations

- One deadline applies to the entire helper call, not a fresh budget per chunk. On expiry, ingestion continues and no remaining chunks are submitted. A command already sent may still apply; timeout does not cancel Redis work. Event-loop delays can delay timeout handling.
- Startup/reconnect skips are deliberate for this best-effort experiment. Sampling and deadline skips mean actual coverage is approximate; infrastructure monitoring alone cannot measure coverage or justify extrapolating storage directly from 10% to 100%.
- Expiration/eviction resets `first_seen`; arrival timestamps are not safe ClickHouse bounds for loading complete traces.
- Project hash tags concentrate a project's keys on one shard. Sampling is not a hard memory cap.
- No production enablement, load benchmark, Redis Cluster/failover test, or full end-to-end OTel ingestion test performed.

## Verification

Executed on feature commit `9c68feaef`:

- `mise exec -- pnpm --filter worker run test traceActivityMap.test.ts otelDirectEventWrite.test.ts`: `Test Files 2 passed (2)`; `Tests 74 passed (74)`.
- `mise exec -- pnpm run lint`: `Tasks: 7 successful, 7 total`; `Cached: 5 cached, 7 total`.
- `mise exec -- pnpm run typecheck`: `Tasks: 8 successful, 8 total`; `Cached: 6 cached, 8 total`.
- Targeted Prettier formatting and `git diff --check` passed.
- `mise exec -- pnpm exec knip`: `Unused files (2)`, both unrelated local research files excluded from this PR.
- Repository-wide `format:check` reports those same two unrelated files. The scoped commit bypassed the hook after targeted formatting and the checks above; unrelated files were not changed.

The existing remote merge from `main` was preserved via a conflict-free isolated integration. All six feature source/test/documentation files are unchanged by that integration; the full merged dependency/base update was not reinstalled or revalidated locally.

Tests added: 5 total in `worker/src/__tests__/traceActivityMap.test.ts` (reduced from 7): atomic concurrent updates/project isolation, TTL refresh/recreation, disabled/unavailable/failing Redis isolation, stable nested sampling including 0/100%, and a whole-call deadline regression with a late Redis response. The deadline regression was confirmed failing against the previous implementation. Metrics/startup-wait tests were removed with those behaviors.

## Type of change

- [x] New feature (non-breaking)

## Mandatory Tasks

- [x] Self-reviewed the scoped diff; unrelated local files excluded.
- [x] Focused tests and operational notes updated.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62532498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until total activity-map work per OTel job is bounded so high-cardinality batches cannot substantially delay ingestion.

<details open><summary><h3>Summary</h3></summary>

- Stores project-scoped trace activity timestamps with a rolling two-hour TTL through bounded Lua invocations.
- Adds sampling and enablement configuration, focused Redis/sampling tests, and operational documentation.
- Adds activity-map update, skip, failure, and duration telemetry.
- The per-command timeout does not currently bound total work for a high-cardinality OTel job.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  OTLP[OTLP request] --> Queue[OTel ingestion queue]
  Queue --> Convert[Convert spans to events]
  Convert --> Sample[Deterministically sample trace IDs]
  Sample --> Batch[Split IDs into groups of 100]
  Batch --> Redis[(Redis activity hashes)]
  Redis --> Persist[Continue ingestion persistence]
  Redis -. failure is swallowed .-> Persist
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat(worker): add sampled OTel trace act..."](https://github.com/langfuse/langfuse/commit/9e46fe69a138cba9c7c70adf35cf95e132ba2829)</sub>

<!-- /greptile_comment -->
