### PR TITLE
fix(billing): clarify graduated usage pricing

### DIFF
--- a/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
+++ b/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
@@ -153,12 +153,15 @@ export const BillingSwitchPlanDialog = ({
                         )}
                       </ul>
                     </div>
+                    <p className="text-muted-foreground mt-auto pt-4 text-xs">
+                      *price per 100k drops with increasing usage
+                    </p>
                     <Link
                       href="https://langfuse.com/pricing"
                       target="_blank"
-                      className="text-muted-foreground hover:text-foreground mt-auto block py-4 text-sm"
+                      className="text-muted-foreground hover:text-foreground block py-4 text-sm"
                     >
-                      Learn more about plan →
+                      Learn more about this plan →
                     </Link>
                     {/* The default behavior the user is on a paid plan.*/}
                     {currentProductId ? (

--- a/web/src/ee/features/billing/utils/stripeCatalogue.ts
+++ b/web/src/ee/features/billing/utils/stripeCatalogue.ts
@@ -36,7 +36,7 @@ export const stripeProducts: StripeProduct[] = [
       description:
         "Great to get started for most projects with unlimited users and 90 days data access.",
       price: "$29 / month",
-      usagePrice: "$8-6/100k units (100k included, graduated pricing)",
+      usagePrice: "$8-6* per 100k units",
       mainFeatures: [
         "90 days data access",
         "Unlimited users",
@@ -56,7 +56,7 @@ export const stripeProducts: StripeProduct[] = [
       description:
         "For projects that scale and need unlimited data access, high rate limits, and Slack support.",
       price: "$199 / month",
-      usagePrice: "$8-6/100k units (100k included, graduated pricing)",
+      usagePrice: "$8-6* per 100k units",
       mainFeatures: [
         "Everything in Core",
         "3 years data access",
@@ -77,7 +77,7 @@ export const stripeProducts: StripeProduct[] = [
       title: "Pro + Teams Add-on",
       description: "Organizational and security controls for larger teams.",
       price: "$499 / month",
-      usagePrice: "$8-6/100k units (100k included, graduated pricing)",
+      usagePrice: "$8-6* per 100k units",
       mainFeatures: [
         "Everything in Pro",
         "Enterprise SSO (e.g. Okta)",
@@ -98,7 +98,7 @@ export const stripeProducts: StripeProduct[] = [
       description:
         "For large scale teams. Enterprise-grade support and security.",
       price: "$2499 / month",
-      usagePrice: "$8-6/100k units (100k included, graduated pricing)",
+      usagePrice: "$8-6* per 100k units",
       mainFeatures: [
         "Everything in Pro + Teams",
         "Audit Logs",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17285 app preview](https://pr-17285.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Clarifies graduated usage pricing in all four plan cards: `+ $8-6* per 100k units`, with `*price per 100k drops with increasing usage` above the renamed “Learn more about this plan” link.

Impacted package: `web`. Billing calculations and link destinations are unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the code.

## Validation

- `pnpm run lint` — `Tasks: 7 successful, 7 total`.
- `pnpm exec prettier --check web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx web/src/ee/features/billing/utils/stripeCatalogue.ts` — `All matched files use Prettier code style!`.
- `git diff --check` — passed.
- Playwright component preview at desktop and mobile widths: verified all four pricing labels, footnotes above their links, link destinations, and no footnote overlap or horizontal overflow. Billing services were mocked.
- Unit tests and full billing integration testing were skipped for this copy-only change.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62540607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable correctness, security, or repository-rule issues identified.

<details open><summary><h3>Summary</h3></summary>

- Rewords each usage-price label as “$8-6* per 100k units.”
- Adds a matching explanation that unit pricing decreases as usage grows.
- Renames the pricing link to “Learn more about this plan” without changing its destination.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(billing): clarify graduated usage pr..."](https://github.com/langfuse/langfuse/commit/acbadbae013447acc4f3e29b2ccd0b2c003c7a0e)</sub>

<!-- /greptile_comment -->