### PR TITLE
chore(ci): don't write next build cache always

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -776,6 +776,7 @@ jobs:
       - name: Build
         run: pnpm turbo run build:test
         env:
+          NEXT_DISABLE_BUILD_CACHE: "true"
           NODE_OPTIONS: --max_old_space_size=8192
           # TypeScript is checked explicitly in the lint job; skip duplicate
           # Next.js type checks in test builds to reduce CI runtime.
@@ -785,6 +786,7 @@ jobs:
           cp .env.runtime .env
           pnpm --filter web exec dotenv -e ../.env -- next build --experimental-build-mode generate
         env:
+          NEXT_DISABLE_BUILD_CACHE: "true"
           NODE_OPTIONS: --max_old_space_size=8192
           NEXT_IGNORE_BUILD_ERRORS: "true"
       - name: Wait for dev containers

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -96,7 +96,7 @@ jobs:
         # depends on db:generate, which is offline.
         run: |
           if [ "${{ matrix.env_profile }}" = "tests-web" ]; then
-            pnpm turbo run build:test
+            NEXT_DISABLE_BUILD_CACHE=true pnpm turbo run build:test
           else
             pnpm run build --filter=!ai-gateway
           fi

--- a/turbo.json
+++ b/turbo.json
@@ -22,7 +22,7 @@
     },
     "build:test": {
       "dependsOn": ["db:generate", "^build"],
-      "env": ["NEXT_IGNORE_BUILD_ERRORS"],
+      "env": ["NEXT_IGNORE_BUILD_ERRORS", "NEXT_DISABLE_BUILD_CACHE"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
       "cache": true,
       "outputLogs": "errors-only"

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -150,6 +150,10 @@ const nextConfig = {
     browserToTerminal: true,
   },
   experimental: {
+    // Ephemeral CI builds can skip writing compiler state they never restore.
+    ...(process.env.NEXT_DISABLE_BUILD_CACHE === "true"
+      ? { turbopackFileSystemCacheForBuild: false }
+      : {}),
     // Use the Rust port instead of the Babel transform
     // turbopackRustReactCompiler: true,
     // Keep `new Worker(new URL(..., import.meta.url))` on the app origin when


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17292 app preview](https://pr-17292.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62614239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the cache-control setting is supported and consistently applied without removing artifacts required by the split build.

<details open><summary><h3>Summary</h3></summary>

- Conditionally disables the Next.js build filesystem cache through `NEXT_DISABLE_BUILD_CACHE`.
- Applies the flag consistently to test-build compilation, runtime-environment generation, and cache warming.
- Includes the flag in Turbo’s `build:test` environment inputs so cache keys reflect the changed build behavior.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  W[Warm-cache workflow] -->|NEXT_DISABLE_BUILD_CACHE=true| B[Turbo build:test]
  P[Tests-web pipeline] -->|same environment input| B
  B --> C[Next.js compile phase]
  C -->|compiled .next artifacts| G[Next.js generate phase]
  C -. no incremental cache writes .-> X[.next/cache/turbopack]
  B --> T[Reusable Turbo task output]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["chore(ci): don&#39;t write next build cache ..."](https://github.com/langfuse/langfuse/commit/7c6b4a642147ad802645adb260094880cc59cd94)</sub>

<!-- /greptile_comment -->