### PR TITLE
feat(audit-logs): add ClickHouse audit_logs table, queue and backfill

### DIFF
--- a/packages/shared/clickhouse/migrations/canonical/0049_create_audit_logs.down.sql
+++ b/packages/shared/clickhouse/migrations/canonical/0049_create_audit_logs.down.sql
@@ -1,0 +1,3 @@
+-- WARNING: destructive rollback. Drops every audit log row stored in
+-- ClickHouse, including access events that have no Postgres copy.
+DROP TABLE IF EXISTS audit_logs {CLICKHOUSE_CLUSTER_CLAUSE};

--- a/packages/shared/clickhouse/migrations/canonical/0049_create_audit_logs.up.sql
+++ b/packages/shared/clickhouse/migrations/canonical/0049_create_audit_logs.up.sql
@@ -1,0 +1,38 @@
+-- Audit log storage for change events (create/update/delete of settings and
+-- data) and access events (reads, lists, exports, downloads). Rows are
+-- append-only. ReplacingMergeTree collapses exact duplicates from queue
+-- retries and backfill re-runs, which is why `id` ends the sorting key.
+-- `project_id = ''` marks organisation-level events.
+-- Note for authors: golang-migrate splits this file on semicolons, so comments
+-- must not contain one.
+CREATE TABLE IF NOT EXISTS audit_logs {CLICKHOUSE_CLUSTER_CLAUSE}
+(
+    id                String,
+    timestamp         DateTime64(3),
+    org_id            String,
+    project_id        String DEFAULT '',
+    event_kind        LowCardinality(String),
+    actor_type        LowCardinality(String),
+    user_id           String DEFAULT '',
+    api_key_id        String DEFAULT '',
+    user_org_role     LowCardinality(String) DEFAULT '',
+    user_project_role LowCardinality(String) DEFAULT '',
+    resource_type     LowCardinality(String),
+    resource_id       String DEFAULT '',
+    action            LowCardinality(String),
+    surface           LowCardinality(String) DEFAULT '',
+    route             String DEFAULT '',
+    params            String DEFAULT '' CODEC(ZSTD(3)),
+    result_count      UInt32 DEFAULT 0,
+    before            String DEFAULT '' CODEC(ZSTD(3)),
+    after             String DEFAULT '' CODEC(ZSTD(3)),
+    created_at        DateTime64(3) DEFAULT now(),
+
+    INDEX idx_resource_id resource_id TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_user_id     user_id     TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_api_key_id  api_key_id  TYPE bloom_filter(0.01) GRANULARITY 1
+)
+ENGINE = {CLICKHOUSE_REPLICATION_PREFIX}ReplacingMergeTree
+PARTITION BY toYYYYMM(timestamp)
+PRIMARY KEY (org_id, project_id, toStartOfMinute(timestamp))
+ORDER BY (org_id, project_id, toStartOfMinute(timestamp), id);

--- a/packages/shared/prisma/migrations/20260910130000_add_backfill_audit_logs_to_clickhouse_background_migration/migration.sql
+++ b/packages/shared/prisma/migrations/20260910130000_add_backfill_audit_logs_to_clickhouse_background_migration/migration.sql
@@ -1,0 +1,11 @@
+-- Copies the Postgres audit_logs table into the ClickHouse audit_logs table,
+-- which serves the audit log read path from this release on. Resumable via the
+-- (created_at, id) cursor kept in `state`; safe to re-run because the
+-- ClickHouse table dedupes on the row id.
+INSERT INTO background_migrations (id, name, script, args)
+VALUES (
+  'b1f3c7a0-6d2e-4f9b-9c41-7a8e5d2b3c60',
+  '20260910_backfill_audit_logs_to_clickhouse',
+  'backfillAuditLogsToClickhouse',
+  '{}'::jsonb
+);

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -125,6 +125,7 @@ export * from "./webhooks/validation";
 export * from "./webhooks/ipBlocking";
 export * from "./redis/experimentCreateQueue";
 export * from "./redis/dlqRetryQueue";
+export * from "./redis/auditLogQueue";
 export * from "./redis/entityChangeQueue";
 export * from "./redis/eventPropagationQueue";
 export * from "./redis/otelProjectTracking";

--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -21,6 +21,7 @@ import {
   MonitorWebhookQueueEventSchema,
 } from "../features/monitors/scheduler/types";
 import { ProjectNotificationWebhookQueueEventSchema } from "./notifications/types";
+import type { AuditLogRecordInsertType } from "./repositories/definitions";
 
 export type { MonitorQueueEvent, MonitorQueueEventInput };
 
@@ -443,6 +444,7 @@ export enum QueueName {
   MonitorQueue = "monitor-queue",
   InAppAgentRunQueue = "in-app-agent-run-queue",
   V4LegacyApiUsageQueue = "v4-legacy-api-usage-queue",
+  AuditLogQueue = "audit-log-queue", // Buffers audit log rows on their way into ClickHouse
 }
 
 export enum QueueJobs {
@@ -482,6 +484,7 @@ export enum QueueJobs {
   MonitorJob = "monitor-job",
   InAppAgentRunJob = "in-app-agent-run-job",
   V4LegacyApiUsageJob = "v4-legacy-api-usage-job",
+  AuditLogJob = "audit-log-job",
 }
 
 export type TQueueJobTypes = {
@@ -674,5 +677,11 @@ export type TQueueJobTypes = {
     id: string;
     payload: InAppAgentRunQueueEventType;
     name: QueueJobs.InAppAgentRunJob;
+  };
+  [QueueName.AuditLogQueue]: {
+    timestamp: Date;
+    id: string;
+    payload: AuditLogRecordInsertType;
+    name: QueueJobs.AuditLogJob;
   };
 };

--- a/packages/shared/src/server/redis/auditLogQueue.ts
+++ b/packages/shared/src/server/redis/auditLogQueue.ts
@@ -1,0 +1,48 @@
+import { Queue } from "bullmq";
+import { logger } from "../logger";
+import { TQueueJobTypes, QueueName } from "../queues";
+import { createBullMQQueueOptionsWithRedis } from "./redis";
+
+/**
+ * Carries one audit log row per job from web to the worker, which batches the
+ * rows into ClickHouse. Retries are safe: the destination table collapses
+ * duplicate rows by id.
+ */
+export class AuditLogQueue {
+  private static instance: Queue<
+    TQueueJobTypes[QueueName.AuditLogQueue]
+  > | null = null;
+
+  public static getInstance(): Queue<
+    TQueueJobTypes[QueueName.AuditLogQueue]
+  > | null {
+    if (AuditLogQueue.instance) return AuditLogQueue.instance;
+
+    const queueOptionsWithRedis = createBullMQQueueOptionsWithRedis(
+      QueueName.AuditLogQueue,
+    );
+    AuditLogQueue.instance = queueOptionsWithRedis
+      ? new Queue<TQueueJobTypes[QueueName.AuditLogQueue]>(
+          QueueName.AuditLogQueue,
+          {
+            ...queueOptionsWithRedis,
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: 10_000,
+              attempts: 5,
+              backoff: {
+                type: "exponential",
+                delay: 5_000,
+              },
+            },
+          },
+        )
+      : null;
+
+    AuditLogQueue.instance?.on("error", (err) => {
+      logger.error("AuditLogQueue error", err);
+    });
+
+    return AuditLogQueue.instance;
+  }
+}

--- a/packages/shared/src/server/redis/getQueue.ts
+++ b/packages/shared/src/server/redis/getQueue.ts
@@ -30,6 +30,7 @@ import { NotificationQueue } from "./notificationQueue";
 import { MonitorQueue } from "./monitorQueue";
 import { InAppAgentRunQueue } from "./inAppAgentRunQueue";
 import { V4LegacyApiUsageQueue } from "./v4LegacyApiUsageQueue";
+import { AuditLogQueue } from "./auditLogQueue";
 
 // Sharded queues require a sharding key.
 // Use the queue class directly, for example IngestionQueue.getInstance({ shardingKey }).
@@ -108,6 +109,8 @@ export function getQueue(
       return InAppAgentRunQueue.getInstance();
     case QueueName.V4LegacyApiUsageQueue:
       return V4LegacyApiUsageQueue.getInstance();
+    case QueueName.AuditLogQueue:
+      return AuditLogQueue.getInstance();
     default: {
       const _exhaustiveCheckDefault: never = queueName;
       throw new Error(`Queue ${queueName} not found`);

--- a/packages/shared/src/server/repositories/auditLogs.ts
+++ b/packages/shared/src/server/repositories/auditLogs.ts
@@ -1,0 +1,34 @@
+import type { AuditLog } from "../../db";
+import { convertDateToClickhouseDateTime } from "../clickhouse/client";
+import type { AuditLogRecordInsertType } from "./definitions";
+
+/**
+ * Maps a Postgres audit log row to its ClickHouse change-event twin. The web
+ * dual-write and the backfill both go through here so both produce byte-equal
+ * rows and ReplacingMergeTree collapses them into one.
+ */
+export function convertPostgresAuditLogToClickhouse(
+  row: AuditLog,
+): AuditLogRecordInsertType {
+  return {
+    id: row.id,
+    timestamp: convertDateToClickhouseDateTime(row.createdAt),
+    org_id: row.orgId,
+    project_id: row.projectId ?? "",
+    event_kind: "change",
+    actor_type: row.type,
+    user_id: row.userId ?? "",
+    api_key_id: row.apiKeyId ?? "",
+    user_org_role: row.userOrgRole ?? "",
+    user_project_role: row.userProjectRole ?? "",
+    resource_type: row.resourceType,
+    resource_id: row.resourceId,
+    action: row.action,
+    surface: "",
+    route: "",
+    params: "",
+    result_count: 0,
+    before: row.before ?? "",
+    after: row.after ?? "",
+  };
+}

--- a/packages/shared/src/server/repositories/auditLogs.ts
+++ b/packages/shared/src/server/repositories/auditLogs.ts
@@ -3,12 +3,37 @@ import { convertDateToClickhouseDateTime } from "../clickhouse/client";
 import type { AuditLogRecordInsertType } from "./definitions";
 
 /**
+ * The fields of a Postgres audit log row that the ClickHouse twin is built
+ * from. A stored `AuditLog` satisfies it, and so does the row the web dual
+ * write assembles before it inserts, which is why nullable columns may also be
+ * `undefined` here.
+ */
+export type AuditLogChangeRow = Pick<
+  AuditLog,
+  | "id"
+  | "createdAt"
+  | "orgId"
+  | "type"
+  | "resourceType"
+  | "resourceId"
+  | "action"
+> & {
+  projectId?: string | null;
+  userId?: string | null;
+  apiKeyId?: string | null;
+  userOrgRole?: string | null;
+  userProjectRole?: string | null;
+  before?: string | null;
+  after?: string | null;
+};
+
+/**
  * Maps a Postgres audit log row to its ClickHouse change-event twin. The web
  * dual-write and the backfill both go through here so both produce byte-equal
  * rows and ReplacingMergeTree collapses them into one.
  */
 export function convertPostgresAuditLogToClickhouse(
-  row: AuditLog,
+  row: AuditLogChangeRow,
 ): AuditLogRecordInsertType {
   return {
     id: row.id,

--- a/packages/shared/src/server/repositories/definitions.ts
+++ b/packages/shared/src/server/repositories/definitions.ts
@@ -581,3 +581,38 @@ export const eventRecordInsertSchema = eventRecordBaseSchema.extend({
   event_ts: z.string(),
 });
 export type EventRecordInsertType = z.infer<typeof eventRecordInsertSchema>;
+
+// Audit logs: one row per change (create/update/delete) or access (read,
+// list, export, download) event. `project_id = ''` marks org-level events;
+// empty strings replace nulls so the row matches the ClickHouse defaults.
+const auditLogEventKindSchema = z.enum(["change", "access"]);
+export type AuditLogEventKind = z.infer<typeof auditLogEventKindSchema>;
+const auditLogActorTypeSchema = z.enum(["USER", "API_KEY"]);
+export type AuditLogActorType = z.infer<typeof auditLogActorTypeSchema>;
+
+const auditLogRecordBaseSchema = z.object({
+  id: z.string(),
+  org_id: z.string(),
+  project_id: z.string(),
+  event_kind: auditLogEventKindSchema,
+  actor_type: auditLogActorTypeSchema,
+  user_id: z.string(),
+  api_key_id: z.string(),
+  user_org_role: z.string(),
+  user_project_role: z.string(),
+  resource_type: z.string(),
+  resource_id: z.string(),
+  action: z.string(),
+  surface: z.string(),
+  route: z.string(),
+  params: z.string(),
+  result_count: z.number().int().nonnegative(),
+  before: z.string(),
+  after: z.string(),
+});
+export const auditLogRecordInsertSchema = auditLogRecordBaseSchema.extend({
+  timestamp: z.string(),
+});
+export type AuditLogRecordInsertType = z.infer<
+  typeof auditLogRecordInsertSchema
+>;

--- a/packages/shared/src/server/repositories/index.ts
+++ b/packages/shared/src/server/repositories/index.ts
@@ -13,6 +13,7 @@ export * from "./constants";
 export * from "./trace-sessions";
 export * from "./scores-utils";
 export * from "./blobStorageLog";
+export * from "./auditLogs";
 export * from "./environments";
 export * from "./automation-repository";
 export * from "./dataset-run-items-converters";

--- a/web/src/__tests__/server/audit-log-clickhouse-dual-write.servertest.ts
+++ b/web/src/__tests__/server/audit-log-clickhouse-dual-write.servertest.ts
@@ -82,8 +82,9 @@ describe("auditLog dual write", () => {
     );
   });
 
-  it("surfaces queue failures so a change event is never silently dropped", async () => {
+  it("keeps the Postgres row and does not fail the caller when the queue is down", async () => {
     const { orgId, projectId } = await createOrgProjectAndApiKey();
+    const resourceId = randomUUID();
     mockAdd.mockRejectedValueOnce(new Error("redis down"));
 
     await expect(
@@ -92,9 +93,14 @@ describe("auditLog dual write", () => {
         orgId,
         projectId,
         resourceType: "dataset",
-        resourceId: randomUUID(),
+        resourceId,
         action: "delete",
       }),
-    ).rejects.toThrow("redis down");
+    ).resolves.toBeUndefined();
+
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+    await expect(
+      prisma.auditLog.count({ where: { orgId, resourceId } }),
+    ).resolves.toBe(1);
   });
 });

--- a/web/src/__tests__/server/audit-log-clickhouse-dual-write.servertest.ts
+++ b/web/src/__tests__/server/audit-log-clickhouse-dual-write.servertest.ts
@@ -1,0 +1,100 @@
+import { randomUUID } from "crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { prisma } from "@langfuse/shared/src/db";
+import {
+  convertDateToClickhouseDateTime,
+  createOrgProjectAndApiKey,
+  QueueJobs,
+} from "@langfuse/shared/src/server";
+
+const mockAdd = vi.fn();
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const originalModule = await importOriginal<Record<string, unknown>>();
+  return {
+    ...originalModule,
+    AuditLogQueue: {
+      getInstance: vi.fn(() => ({ add: mockAdd })),
+    },
+  };
+});
+
+import { auditLog } from "@/src/features/audit-logs/auditLog";
+
+describe("auditLog dual write", () => {
+  beforeEach(() => {
+    mockAdd.mockReset();
+    mockAdd.mockResolvedValue(undefined);
+  });
+
+  it("queues the Postgres change row for ClickHouse with the same id and timestamp", async () => {
+    const { orgId, projectId } = await createOrgProjectAndApiKey();
+    const userId = randomUUID();
+    const resourceId = randomUUID();
+
+    await auditLog({
+      session: {
+        user: { id: userId },
+        orgId,
+        orgRole: "OWNER",
+        projectId,
+        projectRole: "ADMIN",
+      },
+      resourceType: "prompt",
+      resourceId,
+      action: "update",
+      before: { name: "old" },
+      after: { name: "new" },
+    });
+
+    const persisted = await prisma.auditLog.findFirstOrThrow({
+      where: { orgId, resourceId },
+    });
+
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+    expect(mockAdd).toHaveBeenCalledWith(
+      QueueJobs.AuditLogJob,
+      expect.objectContaining({
+        id: persisted.id,
+        name: QueueJobs.AuditLogJob,
+        payload: {
+          id: persisted.id,
+          timestamp: convertDateToClickhouseDateTime(persisted.createdAt),
+          org_id: orgId,
+          project_id: projectId,
+          event_kind: "change",
+          actor_type: "USER",
+          user_id: userId,
+          api_key_id: "",
+          user_org_role: "OWNER",
+          user_project_role: "ADMIN",
+          resource_type: "prompt",
+          resource_id: resourceId,
+          action: "update",
+          surface: "",
+          route: "",
+          params: "",
+          result_count: 0,
+          before: JSON.stringify({ name: "old" }),
+          after: JSON.stringify({ name: "new" }),
+        },
+      }),
+    );
+  });
+
+  it("surfaces queue failures so a change event is never silently dropped", async () => {
+    const { orgId, projectId } = await createOrgProjectAndApiKey();
+    mockAdd.mockRejectedValueOnce(new Error("redis down"));
+
+    await expect(
+      auditLog({
+        userId: randomUUID(),
+        orgId,
+        projectId,
+        resourceType: "dataset",
+        resourceId: randomUUID(),
+        action: "delete",
+      }),
+    ).rejects.toThrow("redis down");
+  });
+});

--- a/web/src/__tests__/server/web-callouts-trpc.servertest.ts
+++ b/web/src/__tests__/server/web-callouts-trpc.servertest.ts
@@ -45,6 +45,9 @@ vi.mock("@langfuse/shared/src/server", async () => {
   const actual = await vi.importActual("@langfuse/shared/src/server");
   return {
     ...actual,
+    // Audit persistence is stubbed like prisma.auditLog below; the real queue
+    // talks to Redis, which never resolves under fake timers.
+    AuditLogQueue: { getInstance: () => ({ add: vi.fn() }) },
     fetchWithSecureRedirects: vi.fn(),
     getObservationById: vi.fn(),
     getObservationByIdFromEventsTable: vi.fn(),

--- a/web/src/features/audit-logs/auditLog.ts
+++ b/web/src/features/audit-logs/auditLog.ts
@@ -3,6 +3,12 @@ import {
   type Role,
   AuditLogRecordType,
 } from "@langfuse/shared/src/db";
+import {
+  AuditLogQueue,
+  convertPostgresAuditLogToClickhouse,
+  QueueJobs,
+  type AuditLogRecordInsertType,
+} from "@langfuse/shared/src/server";
 
 type AuditableResource =
   | "annotationQueue"
@@ -83,6 +89,37 @@ type AuditLog = {
     }
 );
 
+/**
+ * Queues an audit log row for ClickHouse. Throws when Redis is unavailable so
+ * a change event is never silently lost.
+ */
+async function enqueueAuditLogRecord(
+  record: AuditLogRecordInsertType,
+): Promise<void> {
+  const queue = AuditLogQueue.getInstance();
+  if (!queue) {
+    throw new Error("AuditLogQueue is not available, Redis is not configured");
+  }
+  await queue.add(QueueJobs.AuditLogJob, {
+    id: record.id,
+    timestamp: new Date(),
+    name: QueueJobs.AuditLogJob,
+    payload: record,
+  });
+}
+
+/**
+ * Writes the change event to Postgres and queues the same row (same id and
+ * created_at) for ClickHouse, where the read path lives.
+ */
+async function writeChangeEvent(
+  db: typeof _prisma,
+  data: Parameters<typeof db.auditLog.create>[0]["data"],
+) {
+  const created = await db.auditLog.create({ data });
+  await enqueueAuditLogRecord(convertPostgresAuditLogToClickhouse(created));
+}
+
 export async function auditLog(log: AuditLog, prisma?: typeof _prisma) {
   const db = prisma ?? _prisma;
   const shared = {
@@ -105,50 +142,44 @@ export async function auditLog(log: AuditLog, prisma?: typeof _prisma) {
       },
     });
 
-    await db.auditLog.create({
-      data: {
-        apiKeyId: log.apiKeyId,
-        userId:
-          apiKey?.isInAppAgentKey === true
-            ? (apiKey.createdByUserId ?? undefined)
-            : undefined,
-        orgId: log.orgId,
-        projectId: log.projectId,
-        type: AuditLogRecordType.API_KEY,
-        ...shared,
-      },
+    await writeChangeEvent(db, {
+      apiKeyId: log.apiKeyId,
+      userId:
+        apiKey?.isInAppAgentKey === true
+          ? (apiKey.createdByUserId ?? undefined)
+          : undefined,
+      orgId: log.orgId,
+      projectId: log.projectId,
+      type: AuditLogRecordType.API_KEY,
+      ...shared,
     });
 
     return;
   }
 
   if ("session" in log) {
-    await db.auditLog.create({
-      data: {
-        userId: log.session.user.id,
-        orgId: log.session.orgId,
-        userOrgRole: log.session.orgRole,
-        projectId: log.session.projectId,
-        userProjectRole: log.session.projectRole,
-        type: AuditLogRecordType.USER,
-        ...shared,
-      },
+    await writeChangeEvent(db, {
+      userId: log.session.user.id,
+      orgId: log.session.orgId,
+      userOrgRole: log.session.orgRole,
+      projectId: log.session.projectId,
+      userProjectRole: log.session.projectRole,
+      type: AuditLogRecordType.USER,
+      ...shared,
     });
 
     return;
   }
 
   if ("userId" in log) {
-    await db.auditLog.create({
-      data: {
-        userId: log.userId,
-        orgId: log.orgId,
-        userOrgRole: log.orgRole,
-        projectId: log.projectId,
-        userProjectRole: log.projectRole,
-        type: AuditLogRecordType.USER,
-        ...shared,
-      },
+    await writeChangeEvent(db, {
+      userId: log.userId,
+      orgId: log.orgId,
+      userOrgRole: log.orgRole,
+      projectId: log.projectId,
+      userProjectRole: log.projectRole,
+      type: AuditLogRecordType.USER,
+      ...shared,
     });
 
     return;

--- a/web/src/features/audit-logs/auditLog.ts
+++ b/web/src/features/audit-logs/auditLog.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import {
   prisma as _prisma,
   type Role,
@@ -7,6 +8,7 @@ import {
   AuditLogQueue,
   convertPostgresAuditLogToClickhouse,
   QueueJobs,
+  type AuditLogChangeRow,
   type AuditLogRecordInsertType,
 } from "@langfuse/shared/src/server";
 
@@ -108,16 +110,22 @@ async function enqueueAuditLogRecord(
   });
 }
 
+type ChangeEventData = Omit<AuditLogChangeRow, "id" | "createdAt">;
+
 /**
  * Writes the change event to Postgres and queues the same row (same id and
- * created_at) for ClickHouse, where the read path lives.
+ * created_at) for ClickHouse, where the read path lives. The id and timestamp
+ * are assigned here rather than read back from Postgres so both stores receive
+ * the identical row regardless of what the insert returns.
  */
-async function writeChangeEvent(
-  db: typeof _prisma,
-  data: Parameters<typeof db.auditLog.create>[0]["data"],
-) {
-  const created = await db.auditLog.create({ data });
-  await enqueueAuditLogRecord(convertPostgresAuditLogToClickhouse(created));
+async function writeChangeEvent(db: typeof _prisma, data: ChangeEventData) {
+  const row: AuditLogChangeRow = {
+    id: randomUUID(),
+    createdAt: new Date(),
+    ...data,
+  };
+  await db.auditLog.create({ data: row });
+  await enqueueAuditLogRecord(convertPostgresAuditLogToClickhouse(row));
 }
 
 export async function auditLog(log: AuditLog, prisma?: typeof _prisma) {

--- a/web/src/features/audit-logs/auditLog.ts
+++ b/web/src/features/audit-logs/auditLog.ts
@@ -7,7 +7,9 @@ import {
 import {
   AuditLogQueue,
   convertPostgresAuditLogToClickhouse,
+  logger,
   QueueJobs,
+  recordIncrement,
   type AuditLogChangeRow,
   type AuditLogRecordInsertType,
 } from "@langfuse/shared/src/server";
@@ -92,22 +94,37 @@ type AuditLog = {
 );
 
 /**
- * Queues an audit log row for ClickHouse. Throws when Redis is unavailable so
- * a change event is never silently lost.
+ * Queues an audit log row for ClickHouse. Fails open: the row is already
+ * committed to Postgres, which stays the durable copy while the backfill runs
+ * (a re-run copies anything the queue missed), and the caller's mutation has
+ * already succeeded, so a Redis problem is logged and counted, not thrown.
  */
 async function enqueueAuditLogRecord(
   record: AuditLogRecordInsertType,
 ): Promise<void> {
-  const queue = AuditLogQueue.getInstance();
-  if (!queue) {
-    throw new Error("AuditLogQueue is not available, Redis is not configured");
+  try {
+    const queue = AuditLogQueue.getInstance();
+    if (!queue) {
+      recordIncrement("langfuse.audit_log.change_event_dropped", 1, {
+        reason: "queue_unavailable",
+      });
+      return;
+    }
+    await queue.add(QueueJobs.AuditLogJob, {
+      id: record.id,
+      timestamp: new Date(),
+      name: QueueJobs.AuditLogJob,
+      payload: record,
+    });
+  } catch (error) {
+    logger.error("Failed to enqueue audit log change event", {
+      error,
+      auditLogId: record.id,
+    });
+    recordIncrement("langfuse.audit_log.change_event_dropped", 1, {
+      reason: "enqueue_failed",
+    });
   }
-  await queue.add(QueueJobs.AuditLogJob, {
-    id: record.id,
-    timestamp: new Date(),
-    name: QueueJobs.AuditLogJob,
-    payload: record,
-  });
 }
 
 type ChangeEventData = Omit<AuditLogChangeRow, "id" | "createdAt">;

--- a/worker/src/__tests__/backfillAuditLogsToClickhouse.test.ts
+++ b/worker/src/__tests__/backfillAuditLogsToClickhouse.test.ts
@@ -55,7 +55,8 @@ describe("BackfillAuditLogsToClickhouse", () => {
   });
 
   it("copies rows in batches, persists a resumable cursor and stays idempotent", async () => {
-    const base = Date.now() - 60_000;
+    // Older than the default settle window so the first run picks them up.
+    const base = Date.now() - 10 * 60_000;
     const rows = [0, 1, 2].map((i) => ({
       id: `row-${i}-${uuidv4()}`,
       createdAt: new Date(base + i * 1000),
@@ -70,7 +71,23 @@ describe("BackfillAuditLogsToClickhouse", () => {
       before: i === 0 ? JSON.stringify({ name: "a" }) : null,
       after: JSON.stringify({ name: "b" }),
     }));
-    await prisma.auditLog.createMany({ data: rows });
+    // Inside the settle window: left to the dual-write, so the first run
+    // must stop short of it.
+    const lateRow = {
+      id: `row-late-${uuidv4()}`,
+      createdAt: new Date(),
+      orgId,
+      projectId,
+      type: "USER" as const,
+      userId: "user-late",
+      apiKeyId: null,
+      resourceType: "prompt",
+      resourceId: "prompt-late",
+      action: "delete",
+      before: null,
+      after: null,
+    };
+    await prisma.auditLog.createMany({ data: [...rows, lateRow] });
 
     const migration = new BackfillAuditLogsToClickhouse(migrationId);
     await expect(migration.validate()).resolves.toEqual({
@@ -110,30 +127,17 @@ describe("BackfillAuditLogsToClickhouse", () => {
         })
       ).state,
     );
-    expect(new Date(state.cursorCreatedAt).getTime()).toBeGreaterThanOrEqual(
-      rows[2].createdAt.getTime(),
-    );
+    const cursorAt = new Date(state.cursorCreatedAt).getTime();
+    expect(cursorAt).toBeGreaterThanOrEqual(rows[2].createdAt.getTime());
+    expect(cursorAt).toBeLessThan(lateRow.createdAt.getTime());
     expect(state.processedRows).toBeGreaterThanOrEqual(3);
 
-    // A later row appears after the cursor: a re-run copies only that one and
-    // re-inserting nothing else keeps the row count stable.
-    const lateRow = {
-      id: `row-late-${uuidv4()}`,
-      createdAt: new Date(),
-      orgId,
-      projectId,
-      type: "USER" as const,
-      userId: "user-late",
-      apiKeyId: null,
-      resourceType: "prompt",
-      resourceId: "prompt-late",
-      action: "delete",
-      before: null,
-      after: null,
-    };
-    await prisma.auditLog.create({ data: lateRow });
-
-    await new BackfillAuditLogsToClickhouse(migrationId).run({ batchSize: 2 });
+    // Once the row has settled, a re-run resumes from the cursor and copies
+    // only what is new; re-inserting nothing else keeps the row set stable.
+    await new BackfillAuditLogsToClickhouse(migrationId).run({
+      batchSize: 2,
+      settleMs: 0,
+    });
 
     const afterRerun = await readClickhouseRows(orgId);
     expect(afterRerun.map((r) => r.id)).toEqual([

--- a/worker/src/__tests__/backfillAuditLogsToClickhouse.test.ts
+++ b/worker/src/__tests__/backfillAuditLogsToClickhouse.test.ts
@@ -27,6 +27,9 @@ const readClickhouseRows = (orgId: string) =>
     params: { orgId },
   });
 
+const readState = (state: unknown) =>
+  state as { cursorCreatedAt: string; cursorId: string; processedRows: number };
+
 describe("BackfillAuditLogsToClickhouse", () => {
   let migrationId: string;
   let orgId: string;
@@ -97,21 +100,26 @@ describe("BackfillAuditLogsToClickhouse", () => {
     });
     expect(copied[2].project_id).toBe("");
 
-    const state = await prisma.backgroundMigration.findUniqueOrThrow({
-      where: { id: migrationId },
-      select: { state: true },
-    });
-    expect(state.state).toEqual({
-      cursorCreatedAt: rows[2].createdAt.toISOString(),
-      cursorId: rows[2].id,
-      processedRows: 3,
-    });
+    // Other tests write audit logs concurrently, so the cursor is asserted
+    // relative to our rows rather than as an exact value.
+    const state = readState(
+      (
+        await prisma.backgroundMigration.findUniqueOrThrow({
+          where: { id: migrationId },
+          select: { state: true },
+        })
+      ).state,
+    );
+    expect(new Date(state.cursorCreatedAt).getTime()).toBeGreaterThanOrEqual(
+      rows[2].createdAt.getTime(),
+    );
+    expect(state.processedRows).toBeGreaterThanOrEqual(3);
 
     // A later row appears after the cursor: a re-run copies only that one and
     // re-inserting nothing else keeps the row count stable.
     const lateRow = {
       id: `row-late-${uuidv4()}`,
-      createdAt: new Date(base + 10_000),
+      createdAt: new Date(),
       orgId,
       projectId,
       type: "USER" as const,
@@ -132,13 +140,17 @@ describe("BackfillAuditLogsToClickhouse", () => {
       ...rows.map((r) => r.id),
       lateRow.id,
     ]);
-    const stateAfter = await prisma.backgroundMigration.findUniqueOrThrow({
-      where: { id: migrationId },
-      select: { state: true },
-    });
-    expect(stateAfter.state).toMatchObject({
-      cursorId: lateRow.id,
-      processedRows: 4,
-    });
+    const stateAfter = readState(
+      (
+        await prisma.backgroundMigration.findUniqueOrThrow({
+          where: { id: migrationId },
+          select: { state: true },
+        })
+      ).state,
+    );
+    expect(
+      new Date(stateAfter.cursorCreatedAt).getTime(),
+    ).toBeGreaterThanOrEqual(lateRow.createdAt.getTime());
+    expect(stateAfter.processedRows).toBeGreaterThan(state.processedRows);
   });
 });

--- a/worker/src/__tests__/backfillAuditLogsToClickhouse.test.ts
+++ b/worker/src/__tests__/backfillAuditLogsToClickhouse.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { v4 as uuidv4 } from "uuid";
+import { prisma } from "@langfuse/shared/src/db";
+import { queryClickhouse } from "@langfuse/shared/src/server";
+import BackfillAuditLogsToClickhouse from "../backgroundMigrations/backfillAuditLogsToClickhouse";
+
+const readClickhouseRows = (orgId: string) =>
+  queryClickhouse<{
+    id: string;
+    project_id: string;
+    event_kind: string;
+    actor_type: string;
+    user_id: string;
+    api_key_id: string;
+    resource_type: string;
+    action: string;
+    before: string;
+    after: string;
+  }>({
+    query: `
+      SELECT id, project_id, event_kind, actor_type, user_id, api_key_id,
+             resource_type, action, before, after
+      FROM audit_logs FINAL
+      WHERE org_id = {orgId: String}
+      ORDER BY timestamp ASC, id ASC
+    `,
+    params: { orgId },
+  });
+
+describe("BackfillAuditLogsToClickhouse", () => {
+  let migrationId: string;
+  let orgId: string;
+  let projectId: string;
+
+  beforeEach(async () => {
+    migrationId = uuidv4();
+    orgId = uuidv4();
+    projectId = uuidv4();
+    await prisma.backgroundMigration.create({
+      data: {
+        id: migrationId,
+        name: `test_backfill_audit_logs_${migrationId}`,
+        script: "backfillAuditLogsToClickhouse",
+        args: {},
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await prisma.backgroundMigration.deleteMany({ where: { id: migrationId } });
+    await prisma.auditLog.deleteMany({ where: { orgId } });
+  });
+
+  it("copies rows in batches, persists a resumable cursor and stays idempotent", async () => {
+    const base = Date.now() - 60_000;
+    const rows = [0, 1, 2].map((i) => ({
+      id: `row-${i}-${uuidv4()}`,
+      createdAt: new Date(base + i * 1000),
+      orgId,
+      projectId: i === 2 ? null : projectId,
+      type: i === 1 ? ("API_KEY" as const) : ("USER" as const),
+      userId: i === 1 ? null : `user-${i}`,
+      apiKeyId: i === 1 ? "api-key-1" : null,
+      resourceType: "prompt",
+      resourceId: `prompt-${i}`,
+      action: "update",
+      before: i === 0 ? JSON.stringify({ name: "a" }) : null,
+      after: JSON.stringify({ name: "b" }),
+    }));
+    await prisma.auditLog.createMany({ data: rows });
+
+    const migration = new BackfillAuditLogsToClickhouse(migrationId);
+    await expect(migration.validate()).resolves.toEqual({
+      valid: true,
+      invalidReason: undefined,
+    });
+    await migration.run({ batchSize: 2 });
+
+    const copied = await readClickhouseRows(orgId);
+    expect(copied.map((r) => r.id)).toEqual(rows.map((r) => r.id));
+    expect(copied[0]).toMatchObject({
+      project_id: projectId,
+      event_kind: "change",
+      actor_type: "USER",
+      user_id: "user-0",
+      api_key_id: "",
+      resource_type: "prompt",
+      action: "update",
+      before: JSON.stringify({ name: "a" }),
+      after: JSON.stringify({ name: "b" }),
+    });
+    expect(copied[1]).toMatchObject({
+      actor_type: "API_KEY",
+      user_id: "",
+      api_key_id: "api-key-1",
+      before: "",
+    });
+    expect(copied[2].project_id).toBe("");
+
+    const state = await prisma.backgroundMigration.findUniqueOrThrow({
+      where: { id: migrationId },
+      select: { state: true },
+    });
+    expect(state.state).toEqual({
+      cursorCreatedAt: rows[2].createdAt.toISOString(),
+      cursorId: rows[2].id,
+      processedRows: 3,
+    });
+
+    // A later row appears after the cursor: a re-run copies only that one and
+    // re-inserting nothing else keeps the row count stable.
+    const lateRow = {
+      id: `row-late-${uuidv4()}`,
+      createdAt: new Date(base + 10_000),
+      orgId,
+      projectId,
+      type: "USER" as const,
+      userId: "user-late",
+      apiKeyId: null,
+      resourceType: "prompt",
+      resourceId: "prompt-late",
+      action: "delete",
+      before: null,
+      after: null,
+    };
+    await prisma.auditLog.create({ data: lateRow });
+
+    await new BackfillAuditLogsToClickhouse(migrationId).run({ batchSize: 2 });
+
+    const afterRerun = await readClickhouseRows(orgId);
+    expect(afterRerun.map((r) => r.id)).toEqual([
+      ...rows.map((r) => r.id),
+      lateRow.id,
+    ]);
+    const stateAfter = await prisma.backgroundMigration.findUniqueOrThrow({
+      where: { id: migrationId },
+      select: { state: true },
+    });
+    expect(stateAfter.state).toMatchObject({
+      cursorId: lateRow.id,
+      processedRows: 4,
+    });
+  });
+});

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -64,6 +64,7 @@ import {
   postHogIntegrationProcessor,
 } from "./queues/postHogIntegrationQueue";
 import { v4LegacyApiUsageProcessor } from "./queues/v4LegacyApiUsageQueue";
+import { auditLogQueueProcessor } from "./queues/auditLogQueue";
 import {
   mixpanelIntegrationProcessingProcessor,
   mixpanelIntegrationProcessor,
@@ -653,6 +654,12 @@ if (env.QUEUE_CONSUMER_DEAD_LETTER_RETRY_QUEUE_IS_ENABLED === "true") {
       concurrency: 1,
     },
   );
+}
+
+if (env.QUEUE_CONSUMER_AUDIT_LOG_QUEUE_IS_ENABLED === "true") {
+  WorkerManager.register(QueueName.AuditLogQueue, auditLogQueueProcessor, {
+    concurrency: env.LANGFUSE_AUDIT_LOG_QUEUE_PROCESSING_CONCURRENCY,
+  });
 }
 
 if (env.QUEUE_CONSUMER_WEBHOOK_QUEUE_IS_ENABLED === "true") {

--- a/worker/src/backgroundMigrations/backfillAuditLogsToClickhouse.ts
+++ b/worker/src/backgroundMigrations/backfillAuditLogsToClickhouse.ts
@@ -7,6 +7,11 @@
  * run resumes where it stopped. Inserts are idempotent: the ClickHouse table is
  * a ReplacingMergeTree keyed on the row id, and the web dual-write produces
  * byte-equal rows, so re-inserting a row it already wrote is a no-op.
+ *
+ * Rows younger than the settle window are left to the dual-write. A row whose
+ * created_at precedes the cursor can still be committing while the cursor
+ * passes it, and a cursor-only walk would never see it; staying well behind
+ * the present keeps that race out of the backfill's range.
  */
 
 import { IBackgroundMigration } from "./IBackgroundMigration";
@@ -25,6 +30,7 @@ export const BACKFILL_AUDIT_LOGS_MIGRATION_ID =
 
 const LOG_PREFIX = "[Background Migration] backfillAuditLogsToClickhouse:";
 const DEFAULT_BATCH_SIZE = 1000;
+const DEFAULT_SETTLE_MS = 5 * 60 * 1000;
 
 type BackfillState = {
   cursorCreatedAt?: string;
@@ -77,6 +83,10 @@ export default class BackfillAuditLogsToClickhouse implements IBackgroundMigrati
       typeof args.batchSize === "number" && args.batchSize > 0
         ? args.batchSize
         : DEFAULT_BATCH_SIZE;
+    const settleMs =
+      typeof args.settleMs === "number" && args.settleMs >= 0
+        ? args.settleMs
+        : DEFAULT_SETTLE_MS;
 
     const state = await this.loadState();
     let processedRows = state.processedRows ?? 0;
@@ -90,22 +100,26 @@ export default class BackfillAuditLogsToClickhouse implements IBackgroundMigrati
     );
 
     while (!this.isAborted) {
+      const horizon = new Date(Date.now() - settleMs);
       const rows = await prisma.auditLog.findMany({
-        where: cursor
-          ? {
-              OR: [
-                { createdAt: { gt: cursor.createdAt } },
-                { createdAt: cursor.createdAt, id: { gt: cursor.id } },
-              ],
-            }
-          : undefined,
+        where: {
+          createdAt: { lte: horizon },
+          ...(cursor
+            ? {
+                OR: [
+                  { createdAt: { gt: cursor.createdAt } },
+                  { createdAt: cursor.createdAt, id: { gt: cursor.id } },
+                ],
+              }
+            : {}),
+        },
         orderBy: [{ createdAt: "asc" }, { id: "asc" }],
         take: batchSize,
       });
 
       if (rows.length === 0) {
         logger.info(
-          `${LOG_PREFIX} finished in ${Date.now() - start}ms, ${processedRows} rows copied`,
+          `${LOG_PREFIX} finished in ${Date.now() - start}ms, ${processedRows} rows copied up to ${horizon.toISOString()}`,
         );
         return;
       }

--- a/worker/src/backgroundMigrations/backfillAuditLogsToClickhouse.ts
+++ b/worker/src/backgroundMigrations/backfillAuditLogsToClickhouse.ts
@@ -1,0 +1,175 @@
+/**
+ * Copies every Postgres `audit_logs` row into the ClickHouse `audit_logs`
+ * table, which owns the read path from this release on.
+ *
+ * The migration walks Postgres in (created_at, id) order and persists that
+ * cursor in `background_migrations.state` after each batch, so an interrupted
+ * run resumes where it stopped. Inserts are idempotent: the ClickHouse table is
+ * a ReplacingMergeTree keyed on the row id, and the web dual-write produces
+ * byte-equal rows, so re-inserting a row it already wrote is a no-op.
+ */
+
+import { IBackgroundMigration } from "./IBackgroundMigration";
+import {
+  clickhouseClient,
+  convertPostgresAuditLogToClickhouse,
+  logger,
+  queryClickhouse,
+} from "@langfuse/shared/src/server";
+import { prisma } from "@langfuse/shared/src/db";
+import { detectTableEngine } from "./utils/backfillBase";
+
+// Hard-coded in the Prisma migration that registers this background migration.
+export const BACKFILL_AUDIT_LOGS_MIGRATION_ID =
+  "b1f3c7a0-6d2e-4f9b-9c41-7a8e5d2b3c60";
+
+const LOG_PREFIX = "[Background Migration] backfillAuditLogsToClickhouse:";
+const DEFAULT_BATCH_SIZE = 1000;
+
+type BackfillState = {
+  cursorCreatedAt?: string;
+  cursorId?: string;
+  processedRows?: number;
+};
+
+export default class BackfillAuditLogsToClickhouse implements IBackgroundMigration {
+  private isAborted = false;
+
+  constructor(
+    private readonly migrationId: string = BACKFILL_AUDIT_LOGS_MIGRATION_ID,
+  ) {}
+
+  async validate(): Promise<{
+    valid: boolean;
+    invalidReason: string | undefined;
+  }> {
+    const engine = await detectTableEngine("audit_logs");
+    if (!engine) {
+      return {
+        valid: false,
+        invalidReason: "ClickHouse audit_logs table does not exist",
+      };
+    }
+    return { valid: true, invalidReason: undefined };
+  }
+
+  private async loadState(): Promise<BackfillState> {
+    const migration = await prisma.backgroundMigration.findUnique({
+      where: { id: this.migrationId },
+      select: { state: true },
+    });
+    const state = migration?.state;
+    return state && typeof state === "object" && !Array.isArray(state)
+      ? (state as BackfillState)
+      : {};
+  }
+
+  private async saveState(state: BackfillState): Promise<void> {
+    await prisma.backgroundMigration.updateMany({
+      where: { id: this.migrationId },
+      data: { state },
+    });
+  }
+
+  async run(args: Record<string, unknown>): Promise<void> {
+    const start = Date.now();
+    const batchSize =
+      typeof args.batchSize === "number" && args.batchSize > 0
+        ? args.batchSize
+        : DEFAULT_BATCH_SIZE;
+
+    const state = await this.loadState();
+    let processedRows = state.processedRows ?? 0;
+    let cursor =
+      state.cursorCreatedAt && state.cursorId
+        ? { createdAt: new Date(state.cursorCreatedAt), id: state.cursorId }
+        : null;
+
+    logger.info(
+      `${LOG_PREFIX} starting${cursor ? ` from cursor ${cursor.createdAt.toISOString()}/${cursor.id}` : ""}, ${processedRows} rows already copied`,
+    );
+
+    while (!this.isAborted) {
+      const rows = await prisma.auditLog.findMany({
+        where: cursor
+          ? {
+              OR: [
+                { createdAt: { gt: cursor.createdAt } },
+                { createdAt: cursor.createdAt, id: { gt: cursor.id } },
+              ],
+            }
+          : undefined,
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+        take: batchSize,
+      });
+
+      if (rows.length === 0) {
+        logger.info(
+          `${LOG_PREFIX} finished in ${Date.now() - start}ms, ${processedRows} rows copied`,
+        );
+        return;
+      }
+
+      await clickhouseClient().insert({
+        table: "audit_logs",
+        format: "JSONEachRow",
+        values: rows.map(convertPostgresAuditLogToClickhouse),
+        clickhouse_settings: {
+          log_comment: JSON.stringify({
+            surface: "worker",
+            route: "background-migration.backfillAuditLogsToClickhouse",
+          }),
+        },
+      });
+
+      const last = rows[rows.length - 1];
+      cursor = { createdAt: last.createdAt, id: last.id };
+      processedRows += rows.length;
+      await this.saveState({
+        cursorCreatedAt: last.createdAt.toISOString(),
+        cursorId: last.id,
+        processedRows,
+      });
+
+      logger.debug(`${LOG_PREFIX} copied ${processedRows} rows so far`);
+    }
+
+    logger.info(
+      `${LOG_PREFIX} aborted after ${processedRows} rows, will resume from the saved cursor`,
+    );
+  }
+
+  async abort(): Promise<void> {
+    logger.info(`${LOG_PREFIX} aborting`);
+    this.isAborted = true;
+  }
+}
+
+async function main() {
+  const migration = new BackfillAuditLogsToClickhouse();
+  const validation = await migration.validate();
+  if (!validation.valid) {
+    throw new Error(validation.invalidReason);
+  }
+  await migration.run({});
+  const count = await queryClickhouse<{ count: string }>({
+    query: "SELECT count() AS count FROM audit_logs",
+    tags: {
+      surface: "worker",
+      route: "background-migration.backfillAuditLogsToClickhouse",
+    },
+  });
+  logger.info(`${LOG_PREFIX} ClickHouse now holds ${count[0]?.count} rows`);
+}
+
+// If the script is being executed directly (not imported), run the main function
+if (require.main === module) {
+  main()
+    .then(() => {
+      process.exit(0);
+    })
+    .catch((error) => {
+      logger.error(`Migration execution failed: ${error}`, error);
+      process.exit(1);
+    });
+}

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -346,6 +346,13 @@ const EnvSchema = z.object({
   QUEUE_CONSUMER_DEAD_LETTER_RETRY_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("false"),
+  QUEUE_CONSUMER_AUDIT_LOG_QUEUE_IS_ENABLED: z
+    .enum(["true", "false"])
+    .default("true"),
+  LANGFUSE_AUDIT_LOG_QUEUE_PROCESSING_CONCURRENCY: z.coerce
+    .number()
+    .positive()
+    .default(10),
   QUEUE_CONSUMER_WEBHOOK_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("true"),

--- a/worker/src/queues/__tests__/auditLogQueueProcessor.test.ts
+++ b/worker/src/queues/__tests__/auditLogQueueProcessor.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Job } from "bullmq";
+import {
+  QueueJobs,
+  QueueName,
+  TQueueJobTypes,
+} from "@langfuse/shared/src/server";
+
+const addToQueue = vi.fn();
+
+vi.mock("../../services/ClickhouseWriter", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../services/ClickhouseWriter")
+  >("../../services/ClickhouseWriter");
+  return {
+    ...actual,
+    ClickhouseWriter: {
+      getInstance: vi.fn(() => ({ addToQueue })),
+    },
+  };
+});
+
+import { auditLogQueueProcessor } from "../auditLogQueue";
+import { TableName } from "../../services/ClickhouseWriter";
+
+const validRow = {
+  id: "row-1",
+  timestamp: "2026-09-10 12:00:00.000",
+  org_id: "org-1",
+  project_id: "project-1",
+  event_kind: "access" as const,
+  actor_type: "USER" as const,
+  user_id: "user-1",
+  api_key_id: "",
+  user_org_role: "OWNER",
+  user_project_role: "OWNER",
+  resource_type: "trace",
+  resource_id: "trace-1",
+  action: "read",
+  surface: "trpc",
+  route: "traces.byId",
+  params: '{"traceId":"trace-1"}',
+  result_count: 1,
+  before: "",
+  after: "",
+};
+
+const createJob = (payload: unknown) =>
+  ({
+    id: "job-1",
+    data: {
+      id: "row-1",
+      timestamp: new Date(),
+      name: QueueJobs.AuditLogJob,
+      payload,
+    },
+  }) as unknown as Job<TQueueJobTypes[QueueName.AuditLogQueue]>;
+
+describe("auditLogQueueProcessor", () => {
+  beforeEach(() => {
+    addToQueue.mockClear();
+  });
+
+  it("hands a valid row to the ClickHouse writer", async () => {
+    await auditLogQueueProcessor(createJob(validRow));
+
+    expect(addToQueue).toHaveBeenCalledTimes(1);
+    expect(addToQueue).toHaveBeenCalledWith(TableName.AuditLogs, validRow);
+  });
+
+  it("drops a malformed row without failing the job", async () => {
+    await expect(
+      auditLogQueueProcessor(
+        createJob({ ...validRow, event_kind: "unknown", result_count: -1 }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(addToQueue).not.toHaveBeenCalled();
+  });
+});

--- a/worker/src/queues/auditLogQueue.ts
+++ b/worker/src/queues/auditLogQueue.ts
@@ -1,0 +1,30 @@
+import { Job } from "bullmq";
+import {
+  auditLogRecordInsertSchema,
+  logger,
+  QueueName,
+  recordIncrement,
+  TQueueJobTypes,
+} from "@langfuse/shared/src/server";
+import { ClickhouseWriter, TableName } from "../services/ClickhouseWriter";
+
+/**
+ * Hands one audit log row to the batching ClickHouse writer. A malformed
+ * payload can never become valid on retry, so it is dropped with a metric
+ * instead of failing the job.
+ */
+export const auditLogQueueProcessor = async (
+  job: Job<TQueueJobTypes[QueueName.AuditLogQueue]>,
+) => {
+  const parsed = auditLogRecordInsertSchema.safeParse(job.data.payload);
+  if (!parsed.success) {
+    logger.error("Dropping malformed audit log job", {
+      jobId: job.id,
+      error: parsed.error.message,
+    });
+    recordIncrement("langfuse.audit_log.malformed_job");
+    return;
+  }
+
+  ClickhouseWriter.getInstance().addToQueue(TableName.AuditLogs, parsed.data);
+};

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -14,6 +14,7 @@ import {
   TraceNullRecordInsertType,
   DatasetRunItemRecordInsertType,
   EventRecordInsertType,
+  AuditLogRecordInsertType,
   buildClickHouseLogComment,
 } from "@langfuse/shared/src/server";
 
@@ -59,6 +60,7 @@ export class ClickhouseWriter {
       [TableName.BlobStorageFileLog]: [],
       [TableName.DatasetRunItems]: [],
       [TableName.EventsFull]: [],
+      [TableName.AuditLogs]: [],
     };
 
     this.start();
@@ -127,6 +129,7 @@ export class ClickhouseWriter {
           this.flush(TableName.BlobStorageFileLog, fullQueue),
           this.flush(TableName.DatasetRunItems, fullQueue),
           this.flush(TableName.EventsFull, fullQueue),
+          this.flush(TableName.AuditLogs, fullQueue),
         ]).catch((err) => {
           logger.error("ClickhouseWriter.flushAll", err);
         });
@@ -635,6 +638,7 @@ export enum TableName {
   BlobStorageFileLog = "blob_storage_file_log",
   DatasetRunItems = "dataset_run_items_rmt",
   EventsFull = "events_full", // Primary write target - MV auto-populates events_core
+  AuditLogs = "audit_logs",
 }
 
 type RecordInsertType<T extends TableName> = T extends TableName.Scores
@@ -653,7 +657,9 @@ type RecordInsertType<T extends TableName> = T extends TableName.Scores
               ? DatasetRunItemRecordInsertType
               : T extends TableName.EventsFull
                 ? EventRecordInsertType
-                : never;
+                : T extends TableName.AuditLogs
+                  ? AuditLogRecordInsertType
+                  : never;
 
 type ClickhouseQueue = {
   [T in TableName]: ClickhouseWriterQueueItem<T>[];


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17293 app preview](https://pr-17293.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

**1/4** of the audit-log-on-ClickHouse stack. Bases: `main`. Followed by the tRPC access events PR, the public API access events PR and the read-path cutover PR.

Audit logs move from Postgres to ClickHouse so that read/data-access events (who viewed which trace, who listed sessions with which filters) can be recorded without overwhelming Postgres. This slice adds the storage and the write path; nothing reads from ClickHouse yet.

- New ClickHouse table `audit_logs` (migration `0049`): `ReplacingMergeTree`, monthly partitions, `PRIMARY KEY (org_id, project_id, toStartOfMinute(timestamp))`, `ORDER BY (…, id)`, no TTL. One table holds both `change` rows (before/after) and future `access` rows (surface, route, params, result_count).
- `AuditLogQueue` (BullMQ, one job per event) and a worker consumer that hands rows to `ClickhouseWriter` (new `TableName.AuditLogs`). Consumer flag `QUEUE_CONSUMER_AUDIT_LOG_QUEUE_IS_ENABLED` defaults to `true`.
- `auditLog()` in web keeps writing the Postgres row **and** enqueues the same row for ClickHouse (dual write). The Postgres write stays fail-closed as before; the ClickHouse enqueue is fail-open (logged and counted as `langfuse.audit_log.change_event_dropped`), because by then the caller's mutation and the Postgres row have already committed and a Redis blip must not report a succeeded write as failed. Postgres remains the durable copy for this release, so a dropped enqueue is recoverable by re-running the backfill.
- Background migration `backfillAuditLogsToClickhouse`: resumable cursor on `(created_at, id)`, batched, idempotent because the row id is part of the sorting key. It stays five minutes behind the present (`settleMs`, overridable via args): rows younger than that are left to the dual-write, so a row still committing when the cursor passes its `created_at` cannot be skipped.

**Deliberately not in this slice:** recording access events (slices 2 and 3), reading from ClickHouse in the UI or exports (slice 4). Until slice 4 lands, the ClickHouse table is write-only.

**Release order:** table is created by the ClickHouse migration on deploy → web dual-writes → the background migration backfills. The read cutover in slice 4 does not wait for the backfill to complete; a page can miss old rows for a while.

**Retention:** none in v1 (same as today). Monthly partitions are there so a retention policy can be added later without a schema change.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm exec turbo run lint typecheck --force` on this branch: `Tasks: 12 successful, 12 total`, `Cached: 0 cached, 12 total`
- `pnpm exec knip`: exit 0
- `worker`: `auditLogQueueProcessor.test.ts`, `backfillAuditLogsToClickhouse.test.ts` pass (`Tests 1 passed (1)` for the backfill, now also covering the settle window)
- `web`: `audit-log-clickhouse-dual-write.servertest.ts` passes (`Tests 2 passed (2)`, including "queue down → Postgres row kept, caller not failed")
- Local source-built stack: creating a score config produced the same row id in Postgres `audit_logs` and ClickHouse `audit_logs`; the background migration finished with a persisted cursor.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-275b1cf1-9f61-40d6-852c-7208603fb159?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-275b1cf1-9f61-40d6-852c-7208603fb159&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62619803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 2/5</h2>

The PR is not safe to merge until queue acknowledgment is tied to durable ClickHouse delivery, post-commit Redis failures cannot falsely fail completed mutations, and the backfill handles concurrent commits behind its cursor.

<details open><summary><h3>Summary</h3></summary>

- Adds the `audit_logs` ClickHouse table and background-migration registration.
- Dual-writes new Postgres audit records through a BullMQ queue.
- Adds worker-side validation, batching, configuration, and tests.
- The current delivery acknowledgment and backfill cursor designs leave concrete audit-log loss windows.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Application change] --> B[Postgres audit_logs]
  B --> C[Redis AuditLogQueue]
  C --> D[BullMQ worker]
  D --> E[In-memory ClickhouseWriter buffer]
  E --> F[ClickHouse audit_logs]
  B --> G[Background migration]
  G --> F
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat(audit-logs): add ClickHouse audit\_l..."](https://github.com/langfuse/langfuse/commit/3318ca283f19bdb4841e59271805b5f992bc539e)</sub>

<!-- /greptile_comment -->