### PR TITLE
feat(audit-logs): record tRPC read access events

### DIFF
--- a/web/src/__tests__/server/audit-log-access-events.servertest.ts
+++ b/web/src/__tests__/server/audit-log-access-events.servertest.ts
@@ -229,6 +229,72 @@ describe("tRPC access events", () => {
     expect(trace?.id).toBe(traceId);
     expect(mockAdd).toHaveBeenCalledTimes(1);
   });
+
+  describe("signed-in non-member viewing a public trace", () => {
+    let publicTraceId: string;
+    let outsiderSession: Session;
+
+    beforeEach(async () => {
+      publicTraceId = randomUUID();
+      await createTracesCh([
+        createTrace({ id: publicTraceId, project_id: projectId, public: true }),
+      ]);
+      outsiderSession = buildSession({
+        userId,
+        orgId: randomUUID(),
+        projectId: randomUUID(),
+      });
+    });
+
+    it("resolves the organisation from the project and records without roles", async () => {
+      const caller = createCaller(outsiderSession);
+
+      const trace = await caller.traces.byId({
+        traceId: publicTraceId,
+        projectId,
+      });
+      expect(trace?.id).toBe(publicTraceId);
+
+      expect(mockAdd).toHaveBeenCalledTimes(1);
+      expect(enqueuedPayloads()[0]).toMatchObject({
+        org_id: orgId,
+        project_id: projectId,
+        user_id: userId,
+        user_org_role: "",
+        user_project_role: "",
+        resource_id: publicTraceId,
+      });
+    });
+
+    it("fails open when the organisation lookup fails", async () => {
+      const failingPrisma = new Proxy(prisma, {
+        get(target, prop, receiver) {
+          if (prop !== "project") return Reflect.get(target, prop, receiver);
+          return new Proxy(target.project, {
+            get(project, method, projectReceiver) {
+              if (method === "findFirst") {
+                return () => Promise.reject(new Error("postgres down"));
+              }
+              return Reflect.get(project, method, projectReceiver);
+            },
+          });
+        },
+      });
+      const ctx = createInnerTRPCContext({
+        session: outsiderSession,
+        headers: {},
+      });
+      const caller = appRouter.createCaller({ ...ctx, prisma: failingPrisma });
+
+      const trace = await caller.traces.byId({
+        traceId: publicTraceId,
+        projectId,
+      });
+
+      expect(trace?.id).toBe(publicTraceId);
+      expect(mockAdd).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe("serializeAccessEventParams", () => {

--- a/web/src/__tests__/server/audit-log-access-events.servertest.ts
+++ b/web/src/__tests__/server/audit-log-access-events.servertest.ts
@@ -1,0 +1,247 @@
+import { randomUUID } from "crypto";
+import type { Session } from "next-auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { prisma } from "@langfuse/shared/src/db";
+import {
+  createOrgProjectAndApiKey,
+  createTrace,
+  createTracesCh,
+  QueueJobs,
+} from "@langfuse/shared/src/server";
+
+const mockAdd = vi.fn();
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const originalModule = await importOriginal<Record<string, unknown>>();
+  return {
+    ...originalModule,
+    AuditLogQueue: {
+      getInstance: vi.fn(() => ({ add: mockAdd })),
+    },
+  };
+});
+
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import {
+  ACCESS_EVENT_PARAMS_MAX_CHARS,
+  serializeAccessEventParams,
+} from "@/src/features/audit-logs/accessEvents";
+
+const buildSession = (args: {
+  userId: string;
+  orgId: string;
+  projectId: string;
+}): Session => ({
+  expires: "1",
+  user: {
+    id: args.userId,
+    canCreateOrganizations: true,
+    name: "Access Test User",
+    organizations: [
+      {
+        id: args.orgId,
+        name: "Access Test Org",
+        role: "MEMBER",
+        plan: "cloud:hobby",
+        cloudConfig: undefined,
+        metadata: {},
+        aiFeaturesEnabled: false,
+        aiTelemetryEnabled: false,
+        projects: [
+          {
+            id: args.projectId,
+            role: "VIEWER",
+            retentionDays: 30,
+            deletedAt: null,
+            name: "Access Test Project",
+            hasTraces: true,
+            metadata: {},
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      },
+    ],
+    featureFlags: {
+      excludeClickhouseRead: false,
+      templateFlag: true,
+      searchBar: false,
+      v4BetaToggleVisible: false,
+      observationEvals: false,
+      experimentsV4Enabled: false,
+    },
+    admin: false,
+  },
+  environment: {} as Session["environment"],
+});
+
+const createCaller = (session: Session | null) => {
+  const ctx = createInnerTRPCContext({ session, headers: {} });
+  return appRouter.createCaller({ ...ctx, prisma });
+};
+
+const enqueuedPayloads = () =>
+  mockAdd.mock.calls.map(
+    (call) =>
+      (call[1] as { payload: Record<string, unknown> }).payload as Record<
+        string,
+        unknown
+      >,
+  );
+
+describe("tRPC access events", () => {
+  let orgId: string;
+  let projectId: string;
+  let userId: string;
+  let traceId: string;
+
+  beforeEach(async () => {
+    mockAdd.mockReset();
+    mockAdd.mockResolvedValue(undefined);
+
+    const created = await createOrgProjectAndApiKey();
+    orgId = created.orgId;
+    projectId = created.projectId;
+    userId = randomUUID();
+    traceId = randomUUID();
+    await createTracesCh([
+      createTrace({ id: traceId, project_id: projectId, name: "access-me" }),
+    ]);
+  });
+
+  it("records a single read through a trace getter and derives the org from the membership", async () => {
+    const caller = createCaller(buildSession({ userId, orgId, projectId }));
+
+    const trace = await caller.traces.byId({ traceId, projectId });
+    expect(trace?.id).toBe(traceId);
+
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+    expect(mockAdd.mock.calls[0][0]).toBe(QueueJobs.AuditLogJob);
+    const payload = enqueuedPayloads()[0];
+    expect(payload).toMatchObject({
+      org_id: orgId,
+      project_id: projectId,
+      event_kind: "access",
+      actor_type: "USER",
+      user_id: userId,
+      api_key_id: "",
+      user_org_role: "MEMBER",
+      user_project_role: "VIEWER",
+      resource_type: "trace",
+      resource_id: traceId,
+      action: "read",
+      surface: "trpc",
+      route: "traces.byId",
+      result_count: 1,
+      before: "",
+      after: "",
+    });
+    expect(JSON.parse(payload.params as string)).toMatchObject({
+      traceId,
+      projectId,
+    });
+    expect(typeof payload.id).toBe("string");
+    expect(typeof payload.timestamp).toBe("string");
+  });
+
+  it("records a list through a project procedure with the returned row count", async () => {
+    const caller = createCaller(buildSession({ userId, orgId, projectId }));
+
+    const result = await caller.traces.all({
+      projectId,
+      filter: [],
+      searchQuery: null,
+      searchType: ["id"],
+      orderBy: { column: "timestamp", order: "DESC" },
+      page: 0,
+      limit: 50,
+    });
+    expect(result.traces.map((t) => t.id)).toContain(traceId);
+
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+    const payload = enqueuedPayloads()[0];
+    expect(payload).toMatchObject({
+      org_id: orgId,
+      project_id: projectId,
+      event_kind: "access",
+      user_id: userId,
+      user_org_role: "MEMBER",
+      user_project_role: "VIEWER",
+      resource_type: "trace",
+      resource_id: "",
+      action: "list",
+      route: "traces.all",
+      result_count: result.traces.length,
+    });
+    expect(JSON.parse(payload.params as string)).toMatchObject({
+      projectId,
+      limit: 50,
+      page: 0,
+    });
+  });
+
+  it("ignores procedures that are not on the allowlist", async () => {
+    const caller = createCaller(buildSession({ userId, orgId, projectId }));
+
+    await caller.traces.countAll({
+      projectId,
+      filter: [],
+      searchQuery: null,
+      searchType: ["id"],
+      orderBy: null,
+    });
+
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it("does not record reads that fail", async () => {
+    const caller = createCaller(buildSession({ userId, orgId, projectId }));
+
+    await expect(
+      caller.traces.byId({ traceId: randomUUID(), projectId }),
+    ).rejects.toThrow();
+
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it("does not record anonymous views of public traces", async () => {
+    const publicTraceId = randomUUID();
+    await createTracesCh([
+      createTrace({ id: publicTraceId, project_id: projectId, public: true }),
+    ]);
+    const caller = createCaller(null);
+
+    const trace = await caller.traces.byId({
+      traceId: publicTraceId,
+      projectId,
+    });
+    expect(trace?.id).toBe(publicTraceId);
+
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it("fails open when the queue rejects", async () => {
+    mockAdd.mockRejectedValueOnce(new Error("redis down"));
+    const caller = createCaller(buildSession({ userId, orgId, projectId }));
+
+    const trace = await caller.traces.byId({ traceId, projectId });
+
+    expect(trace?.id).toBe(traceId);
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("serializeAccessEventParams", () => {
+  it("keeps small inputs verbatim", () => {
+    expect(serializeAccessEventParams({ a: 1 })).toBe('{"a":1}');
+    expect(serializeAccessEventParams(undefined)).toBe("");
+  });
+
+  it("replaces oversized inputs with a truncated preview", () => {
+    const big = { filter: "x".repeat(ACCESS_EVENT_PARAMS_MAX_CHARS * 2) };
+    const parsed = JSON.parse(serializeAccessEventParams(big));
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.originalLength).toBe(JSON.stringify(big).length);
+    expect(parsed.preview).toHaveLength(ACCESS_EVENT_PARAMS_MAX_CHARS);
+  });
+});

--- a/web/src/features/audit-logs/accessEvents.ts
+++ b/web/src/features/audit-logs/accessEvents.ts
@@ -1,0 +1,131 @@
+import { randomUUID } from "crypto";
+import {
+  AuditLogQueue,
+  convertDateToClickhouseDateTime,
+  logger,
+  QueueJobs,
+  recordIncrement,
+  type AuditLogRecordInsertType,
+} from "@langfuse/shared/src/server";
+
+/** How a resource was accessed. Kept separate from change actions on purpose. */
+export type AccessEventAction = "read" | "list" | "export" | "download";
+
+/** Request surfaces that emit access events. */
+type AccessEventSurface = "trpc" | "public-api";
+
+type AccessEventActor =
+  | {
+      type: "USER";
+      userId: string;
+      orgRole?: string;
+      projectRole?: string;
+    }
+  | {
+      type: "API_KEY";
+      apiKeyId: string;
+      /** Set for in-app agent keys that act on behalf of a user. */
+      userId?: string;
+    };
+
+export type AccessEvent = {
+  actor: AccessEventActor;
+  orgId: string;
+  /** Empty for organisation-level reads. */
+  projectId?: string;
+  surface: AccessEventSurface;
+  /** Stable handler identifier, e.g. the tRPC path or the REST route pattern. */
+  route: string;
+  resourceType: string;
+  /** Set for single-entity reads; empty for lists. */
+  resourceId?: string;
+  action: AccessEventAction;
+  /** The request's validated input or query; serialised and size-capped. */
+  params: unknown;
+  /** Number of entities returned. 0 when unknown or not applicable. */
+  resultCount: number;
+};
+
+/**
+ * Upper bound for the serialised `params` column. Larger inputs (e.g. huge
+ * filter arrays) are replaced by a truncated preview so a single read can never
+ * write an unbounded blob.
+ */
+export const ACCESS_EVENT_PARAMS_MAX_CHARS = 4096;
+
+export function serializeAccessEventParams(params: unknown): string {
+  if (params === undefined || params === null) return "";
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(params) ?? "";
+  } catch {
+    return JSON.stringify({ unserializable: true });
+  }
+  if (serialized.length <= ACCESS_EVENT_PARAMS_MAX_CHARS) return serialized;
+  return JSON.stringify({
+    truncated: true,
+    originalLength: serialized.length,
+    preview: serialized.slice(0, ACCESS_EVENT_PARAMS_MAX_CHARS),
+  });
+}
+
+function buildAccessEventRecord(
+  event: AccessEvent,
+  now: Date = new Date(),
+): AuditLogRecordInsertType {
+  const actor = event.actor;
+  return {
+    id: randomUUID(),
+    timestamp: convertDateToClickhouseDateTime(now),
+    org_id: event.orgId,
+    project_id: event.projectId ?? "",
+    event_kind: "access",
+    actor_type: actor.type,
+    user_id: actor.userId ?? "",
+    api_key_id: actor.type === "API_KEY" ? actor.apiKeyId : "",
+    user_org_role: actor.type === "USER" ? (actor.orgRole ?? "") : "",
+    user_project_role: actor.type === "USER" ? (actor.projectRole ?? "") : "",
+    resource_type: event.resourceType,
+    resource_id: event.resourceId ?? "",
+    action: event.action,
+    surface: event.surface,
+    route: event.route,
+    params: serializeAccessEventParams(event.params),
+    result_count: Math.max(0, Math.floor(event.resultCount)),
+    before: "",
+    after: "",
+  };
+}
+
+/**
+ * Queues an access event for ClickHouse. Fails open: a read must never be
+ * blocked by the audit trail, so enqueue problems are logged and counted but
+ * not thrown.
+ */
+export async function recordAccessEvent(event: AccessEvent): Promise<void> {
+  try {
+    const queue = AuditLogQueue.getInstance();
+    if (!queue) {
+      recordIncrement("langfuse.audit_log.access_event_dropped", 1, {
+        reason: "queue_unavailable",
+      });
+      return;
+    }
+    const record = buildAccessEventRecord(event);
+    await queue.add(QueueJobs.AuditLogJob, {
+      id: record.id,
+      timestamp: new Date(),
+      name: QueueJobs.AuditLogJob,
+      payload: record,
+    });
+  } catch (error) {
+    logger.error("Failed to enqueue audit log access event", {
+      error,
+      route: event.route,
+      surface: event.surface,
+    });
+    recordIncrement("langfuse.audit_log.access_event_dropped", 1, {
+      reason: "enqueue_failed",
+    });
+  }
+}

--- a/web/src/features/audit-logs/trpcAccessEvents.ts
+++ b/web/src/features/audit-logs/trpcAccessEvents.ts
@@ -1,0 +1,205 @@
+import type { Session } from "next-auth";
+import type { prisma as _prisma } from "@langfuse/shared/src/db";
+import { logger } from "@langfuse/shared/src/server";
+import {
+  recordAccessEvent,
+  type AccessEventAction,
+} from "@/src/features/audit-logs/accessEvents";
+
+type RawInput = Record<string, unknown>;
+
+type TrpcAccessEventRoute = {
+  resourceType: string;
+  action: AccessEventAction;
+  /** Picks the accessed entity id from the raw input. Omit for lists. */
+  resourceId?: (input: RawInput) => string | undefined;
+  /** Counts returned entities. Omit when the handler returns exactly one. */
+  resultCount?: (output: unknown) => number;
+};
+
+const arrayLength = (key: string) => (output: unknown) => {
+  const value = (output as Record<string, unknown> | null | undefined)?.[key];
+  return Array.isArray(value) ? value.length : 0;
+};
+
+const topLevelArrayLength = (output: unknown) =>
+  Array.isArray(output) ? output.length : 0;
+
+const stringField = (key: string) => (input: RawInput) =>
+  typeof input[key] === "string" ? (input[key] as string) : undefined;
+
+/**
+ * tRPC procedures whose successful completion is recorded as an access event.
+ * Procedures not listed here are never logged. Keys are full tRPC paths.
+ */
+const TRPC_ACCESS_EVENT_ROUTES: Readonly<Record<string, TrpcAccessEventRoute>> =
+  {
+    "traces.byId": {
+      resourceType: "trace",
+      action: "read",
+      resourceId: stringField("traceId"),
+    },
+    "traces.byIdWithObservationsAndScores": {
+      resourceType: "trace",
+      action: "read",
+      resourceId: stringField("traceId"),
+    },
+    "events.byTraceId": {
+      resourceType: "trace",
+      action: "read",
+      resourceId: stringField("traceId"),
+    },
+    "traces.all": {
+      resourceType: "trace",
+      action: "list",
+      resultCount: arrayLength("traces"),
+    },
+    "observations.byId": {
+      resourceType: "observation",
+      action: "read",
+      resourceId: stringField("observationId"),
+    },
+    "generations.all": {
+      resourceType: "observation",
+      action: "list",
+      resultCount: arrayLength("generations"),
+    },
+    "events.all": {
+      resourceType: "observation",
+      action: "list",
+      resultCount: arrayLength("observations"),
+    },
+    "sessions.byIdWithScores": {
+      resourceType: "session",
+      action: "read",
+      resourceId: stringField("sessionId"),
+    },
+    "sessions.byIdWithScoresFromEvents": {
+      resourceType: "session",
+      action: "read",
+      resourceId: stringField("sessionId"),
+    },
+    "sessions.all": {
+      resourceType: "session",
+      action: "list",
+      resultCount: arrayLength("sessions"),
+    },
+    "sessions.allFromEvents": {
+      resourceType: "session",
+      action: "list",
+      resultCount: arrayLength("sessions"),
+    },
+    "batchExport.create": {
+      resourceType: "batchExport",
+      action: "export",
+      resultCount: () => 0,
+    },
+    "batchExport.downloadUrl": {
+      resourceType: "batchExport",
+      action: "download",
+      resourceId: stringField("batchExportId"),
+    },
+    "media.getById": {
+      resourceType: "media",
+      action: "download",
+      resourceId: stringField("mediaId"),
+    },
+    "media.getByTraceOrObservationId": {
+      resourceType: "media",
+      action: "download",
+      resultCount: topLevelArrayLength,
+    },
+  };
+
+/**
+ * The session as it looks after any of the protected middlewares. Project
+ * procedures add org and project ids and roles; trace and session getters add
+ * only the project role and may serve anonymous viewers of public traces.
+ */
+type ProtectedSession = Session & {
+  orgId?: string;
+  orgRole?: string;
+  projectId?: string;
+  projectRole?: string;
+};
+
+async function resolveOrg(
+  session: ProtectedSession,
+  projectId: string,
+  prisma: typeof _prisma,
+): Promise<{ orgId: string; orgRole?: string } | null> {
+  if (session.orgId) {
+    return { orgId: session.orgId, orgRole: session.orgRole };
+  }
+  const membership = session.user?.organizations.find((org) =>
+    org.projects.some((project) => project.id === projectId),
+  );
+  if (membership) {
+    return { orgId: membership.id, orgRole: membership.role };
+  }
+  const project = await prisma.project.findFirst({
+    where: { id: projectId },
+    select: { orgId: true },
+  });
+  return project ? { orgId: project.orgId } : null;
+}
+
+/**
+ * Records one access event for a successfully completed allowlisted tRPC
+ * procedure. Anonymous viewers of public traces and sessions are not recorded:
+ * there is no actor to attribute the access to.
+ */
+export async function recordTrpcAccessEvent(args: {
+  path: string;
+  /** `ctx.session` as left by the authorisation middleware of the procedure. */
+  session: unknown;
+  prisma: typeof _prisma;
+  rawInput: unknown;
+  output: unknown;
+}): Promise<void> {
+  const route = TRPC_ACCESS_EVENT_ROUTES[args.path];
+  if (!route) return;
+
+  const session =
+    typeof args.session === "object" && args.session !== null
+      ? (args.session as ProtectedSession)
+      : null;
+  const userId = session?.user?.id;
+  if (!session || !userId) return;
+
+  const input =
+    typeof args.rawInput === "object" && args.rawInput !== null
+      ? (args.rawInput as RawInput)
+      : {};
+  const projectId =
+    session.projectId ??
+    (typeof input.projectId === "string" ? input.projectId : undefined);
+  if (!projectId) return;
+
+  const org = await resolveOrg(session, projectId, args.prisma);
+  if (!org) {
+    logger.warn("Skipping access event, project has no organisation", {
+      path: args.path,
+      projectId,
+    });
+    return;
+  }
+
+  await recordAccessEvent({
+    actor: {
+      type: "USER",
+      userId,
+      orgRole: org.orgRole,
+      projectRole: session.projectRole,
+    },
+    orgId: org.orgId,
+    projectId,
+    surface: "trpc",
+    route: args.path,
+    resourceType: route.resourceType,
+    resourceId: route.resourceId?.(input),
+    action: route.action,
+    params: input,
+    resultCount: route.resultCount ? route.resultCount(args.output) : 1,
+  });
+}

--- a/web/src/features/audit-logs/trpcAccessEvents.ts
+++ b/web/src/features/audit-logs/trpcAccessEvents.ts
@@ -1,6 +1,6 @@
 import type { Session } from "next-auth";
 import type { prisma as _prisma } from "@langfuse/shared/src/db";
-import { logger } from "@langfuse/shared/src/server";
+import { logger, recordIncrement } from "@langfuse/shared/src/server";
 import {
   recordAccessEvent,
   type AccessEventAction,
@@ -65,6 +65,11 @@ const TRPC_ACCESS_EVENT_ROUTES: Readonly<Record<string, TrpcAccessEventRoute>> =
       resultCount: arrayLength("generations"),
     },
     "events.all": {
+      resourceType: "observation",
+      action: "list",
+      resultCount: arrayLength("observations"),
+    },
+    "events.listCursor": {
       resourceType: "observation",
       action: "list",
       resultCount: arrayLength("observations"),
@@ -144,19 +149,43 @@ async function resolveOrg(
   return project ? { orgId: project.orgId } : null;
 }
 
-/**
- * Records one access event for a successfully completed allowlisted tRPC
- * procedure. Anonymous viewers of public traces and sessions are not recorded:
- * there is no actor to attribute the access to.
- */
-export async function recordTrpcAccessEvent(args: {
+type TrpcAccessEventArgs = {
   path: string;
   /** `ctx.session` as left by the authorisation middleware of the procedure. */
   session: unknown;
   prisma: typeof _prisma;
   rawInput: unknown;
   output: unknown;
-}): Promise<void> {
+};
+
+/**
+ * Records one access event for a successfully completed allowlisted tRPC
+ * procedure. Anonymous viewers of public traces and sessions are not recorded:
+ * there is no actor to attribute the access to.
+ *
+ * Fails open like `recordAccessEvent`: the procedure has already succeeded, so
+ * a failure while resolving the organisation must not turn into an error for
+ * the caller.
+ */
+export async function recordTrpcAccessEvent(
+  args: TrpcAccessEventArgs,
+): Promise<void> {
+  try {
+    await recordTrpcAccessEventOrThrow(args);
+  } catch (error) {
+    logger.error("Failed to record audit log access event", {
+      error,
+      path: args.path,
+    });
+    recordIncrement("langfuse.audit_log.access_event_dropped", 1, {
+      reason: "resolve_failed",
+    });
+  }
+}
+
+async function recordTrpcAccessEventOrThrow(
+  args: TrpcAccessEventArgs,
+): Promise<void> {
   const route = TRPC_ACCESS_EVENT_ROUTES[args.path];
   if (!route) return;
 

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -24,6 +24,7 @@ import * as opentelemetry from "@opentelemetry/api";
 import { type IncomingHttpHeaders } from "node:http";
 import { getTRPCErrorCodeFromHTTPStatusCode } from "@/src/server/utils/trpc-utils";
 import { sendAdminAccessWebhook } from "@/src/server/adminAccessWebhook";
+import { recordTrpcAccessEvent } from "@/src/features/audit-logs/trpcAccessEvents";
 
 type CreateContextOptions = {
   session: Session | null;
@@ -239,6 +240,33 @@ const withOtelTracingProcedure = t.procedure
   .use(tracing({ collectInput: true, collectResult: true }));
 
 /**
+ * Records an audit log access event after an allowlisted read procedure
+ * succeeds. Runs after the authorisation middlewares so the actor and roles on
+ * the session are final. Never fails the request.
+ *
+ * Written as a plain generic function rather than `t.middleware` because the
+ * trace and session getters widen `ctx.session` beyond `Session | null`, and a
+ * `t.middleware` result cannot be appended after them.
+ */
+const withAccessAuditLog = async <TResult extends { ok: boolean }>(opts: {
+  ctx: { session: unknown; prisma: typeof prisma };
+  path: string;
+  getRawInput: () => Promise<unknown>;
+  next: () => Promise<TResult>;
+}): Promise<TResult> => {
+  const res = await opts.next();
+  if (!res.ok) return res;
+  await recordTrpcAccessEvent({
+    path: opts.path,
+    session: opts.ctx.session,
+    prisma: opts.ctx.prisma,
+    rawInput: await opts.getRawInput(),
+    output: (res as { data?: unknown }).data,
+  });
+  return res;
+};
+
+/**
  * Public (unauthenticated) procedure
  *
  * This is the base piece you use to build new queries and mutations on your tRPC API. It does not
@@ -403,7 +431,8 @@ const enforceUserIsAuthedAndProjectMember = t.middleware(async (opts) => {
 
 export const protectedProjectProcedure = withOtelTracingProcedure
   .use(withErrorHandling)
-  .use(enforceUserIsAuthedAndProjectMember);
+  .use(enforceUserIsAuthedAndProjectMember)
+  .use(withAccessAuditLog);
 
 /** requireV4Writes rejects calls from deployments without v4 event tables */
 export const requireV4Writes = t.middleware(({ next }) => {
@@ -644,11 +673,13 @@ const enforceTraceAccess = (readSource: "v3" | "v4") =>
 
 export const protectedGetTraceProcedure = withOtelTracingProcedure
   .use(withErrorHandling)
-  .use(enforceTraceAccess("v3"));
+  .use(enforceTraceAccess("v3"))
+  .use(withAccessAuditLog);
 
 export const protectedGetEventsTraceProcedure = withOtelTracingProcedure
   .use(withErrorHandling)
-  .use(enforceTraceAccess("v4"));
+  .use(enforceTraceAccess("v4"))
+  .use(withAccessAuditLog);
 
 /*
  * Protect session-level getter routes.
@@ -729,7 +760,8 @@ const enforceSessionAccess = t.middleware(async (opts) => {
 
 export const protectedGetSessionProcedure = withOtelTracingProcedure
   .use(withErrorHandling)
-  .use(enforceSessionAccess);
+  .use(enforceSessionAccess)
+  .use(withAccessAuditLog);
 
 const inputAdminSchema = z.object({
   adminApiKey: z.string(),


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17294 app preview](https://pr-17294.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

**2/4**, based on #17293. Base retargets to `main` when #17293 lands.

Records an audit log **access** event when a user reads data through an allowlisted tRPC procedure in the Langfuse UI: single-entity reads (trace, observation, session, media), lists (traces, observations/events, sessions) with the request parameters and the number of returned rows, and export creation/download.

- `recordAccessEvent()` builds an `access` row and enqueues it on the `AuditLogQueue` from #17293. It fails open: a read is never blocked by the audit trail; enqueue failures are logged and counted (`langfuse.audit_log.access_event_dropped`).
- `withAccessAuditLog` runs after the authorisation middlewares of `protectedProjectProcedure`, `protectedGetTraceProcedure`, `protectedGetEventsTraceProcedure` and `protectedGetSessionProcedure`, only for successful calls, only for paths in `TRPC_ACCESS_EVENT_ROUTES`. Anonymous viewers of public traces are not recorded (no actor).
- Request-level, not per returned id: the row stores the route, the raw input (filters, pagination) and a `result_count`. Returned ids are not stored.

**Deliberately not in this slice:** public API access events (slice 3), any UI or export that shows these rows (slice 4).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm exec turbo run lint typecheck --force` on this branch: `Tasks: 12 successful, 12 total`, `Cached: 0 cached, 12 total`
- `pnpm exec knip`: exit 0
- `web`: `audit-log-access-events.servertest.ts` (8 tests) — single read, list with result count, non-allowlisted procedure ignored, failed read ignored, anonymous view ignored, fail-open enqueue.
- Local stack (v4 events_only): viewing a trace, the traces list and the sessions list produced `events.byTraceId`, `media.getByTraceOrObservationId`, `events.all`, `sessions.allFromEvents` access rows in ClickHouse.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-275b1cf1-9f61-40d6-852c-7208603fb159?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-275b1cf1-9f61-40d6-852c-7208603fb159&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62619946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 3/5</h2>

This PR is not yet safe to merge because audit metadata lookup can turn successful reads into failures and an active observation-list path bypasses auditing.

<details open><summary><h3>Summary</h3></summary>

- Introduces access-event serialization, record construction, queueing, and dropped-event metrics.
- Adds route metadata and output-count extraction for selected trace, observation, session, media, and export procedures.
- Installs post-authorization audit middleware on the relevant protected procedure builders.
- Adds server tests for successful reads, allowlist behavior, anonymous access, failures, and queue rejection.
- Two blocking gaps remain: organisation resolution can violate fail-open behavior, and one active observation-list route bypasses the allowlist.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[tRPC request] --> B[Authorization middleware]
  B -->|Denied| C[Return authorization error]
  B -->|Allowed| D[Procedure handler]
  D -->|Failure| E[Return procedure error without audit event]
  D -->|Success| F{Route allowlisted?}
  F -->|No| G[Return result without audit event]
  F -->|Yes| H{Authenticated actor?}
  H -->|No| I[Return result without audit event]
  H -->|Yes| J[Resolve project organisation]
  J -->|Resolution throws| K[Request fails despite successful read]
  J -->|Resolved| L[Build and enqueue access event]
  L -->|Queue failure| M[Log and count dropped event]
  L -->|Success| N[Return successful result]
  M --> N
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat(audit-logs): record tRPC read acces..."](https://github.com/langfuse/langfuse/commit/dcea661a784b4a4ebc5410c97c979281fee329e5)</sub>

<!-- /greptile_comment -->