### PR TITLE
feat(audit-logs): record public API read access events

### DIFF
--- a/web/src/__tests__/server/audit-log-public-api-access-events.servertest.ts
+++ b/web/src/__tests__/server/audit-log-public-api-access-events.servertest.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from "crypto";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { prisma } from "@langfuse/shared/src/db";
+import {
+  createOrgProjectAndApiKey,
+  createTrace,
+  createTracesCh,
+  QueueJobs,
+} from "@langfuse/shared/src/server";
+
+const mockAdd = vi.fn();
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const originalModule = await importOriginal<Record<string, unknown>>();
+  return {
+    ...originalModule,
+    AuditLogQueue: {
+      getInstance: vi.fn(() => ({ add: mockAdd })),
+    },
+  };
+});
+
+import getTraceHandler from "@/src/pages/api/public/traces/[traceId]";
+import listTracesHandler from "@/src/pages/api/public/traces/index";
+import listSessionsHandler from "@/src/pages/api/public/sessions/index";
+
+const enqueuedPayloads = () =>
+  mockAdd.mock.calls.map(
+    (call) =>
+      (call[1] as { payload: Record<string, unknown> }).payload as Record<
+        string,
+        unknown
+      >,
+  );
+
+const callHandler = async (
+  handler: (req: NextApiRequest, res: NextApiResponse) => Promise<void>,
+  args: { auth: string; query: Record<string, string>; url: string },
+) => {
+  const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+    method: "GET",
+    url: args.url,
+    headers: { authorization: args.auth },
+    query: args.query,
+  });
+  await handler(req, res);
+  return res;
+};
+
+describe("public API access events", () => {
+  let orgId: string;
+  let projectId: string;
+  let apiKeyId: string;
+  let auth: string;
+  let traceId: string;
+
+  beforeEach(async () => {
+    mockAdd.mockReset();
+    mockAdd.mockResolvedValue(undefined);
+
+    const created = await createOrgProjectAndApiKey();
+    orgId = created.orgId;
+    projectId = created.projectId;
+    auth = created.auth;
+    apiKeyId = (
+      await prisma.apiKey.findFirstOrThrow({
+        where: { publicKey: created.publicKey },
+        select: { id: true },
+      })
+    ).id;
+    traceId = randomUUID();
+    await createTracesCh([
+      createTrace({ id: traceId, project_id: projectId, name: "api-read" }),
+    ]);
+  });
+
+  it("records a single trace read with the API key as actor", async () => {
+    const res = await callHandler(getTraceHandler, {
+      auth,
+      url: `/api/public/traces/${traceId}`,
+      query: { traceId },
+    });
+    expect(res._getStatusCode()).toBe(200);
+
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+    expect(mockAdd.mock.calls[0][0]).toBe(QueueJobs.AuditLogJob);
+    const payload = enqueuedPayloads()[0];
+    expect(payload).toMatchObject({
+      org_id: orgId,
+      project_id: projectId,
+      event_kind: "access",
+      actor_type: "API_KEY",
+      api_key_id: apiKeyId,
+      user_id: "",
+      user_org_role: "",
+      user_project_role: "",
+      resource_type: "trace",
+      resource_id: traceId,
+      action: "read",
+      surface: "public-api",
+      route: "GET /api/public/traces/{traceId}",
+      result_count: 1,
+    });
+    expect(JSON.parse(payload.params as string)).toMatchObject({ traceId });
+  });
+
+  it("records a list with the parsed query and the number of returned rows", async () => {
+    const res = await callHandler(listTracesHandler, {
+      auth,
+      url: "/api/public/traces?limit=10&page=1",
+      query: { limit: "10", page: "1", name: "api-read" },
+    });
+    expect(res._getStatusCode()).toBe(200);
+    const body = res._getJSONData() as { data: unknown[] };
+
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+    const payload = enqueuedPayloads()[0];
+    expect(payload).toMatchObject({
+      org_id: orgId,
+      project_id: projectId,
+      actor_type: "API_KEY",
+      api_key_id: apiKeyId,
+      resource_type: "trace",
+      resource_id: "",
+      action: "list",
+      route: "GET /api/public/traces",
+      result_count: body.data.length,
+    });
+    expect(body.data.length).toBeGreaterThan(0);
+    expect(JSON.parse(payload.params as string)).toMatchObject({
+      limit: 10,
+      page: 1,
+      name: "api-read",
+    });
+  });
+
+  it("records an empty list with a zero count", async () => {
+    const res = await callHandler(listSessionsHandler, {
+      auth,
+      url: "/api/public/sessions",
+      query: {},
+    });
+    expect(res._getStatusCode()).toBe(200);
+
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+    expect(enqueuedPayloads()[0]).toMatchObject({
+      resource_type: "session",
+      action: "list",
+      route: "GET /api/public/sessions",
+      result_count: 0,
+    });
+  });
+
+  it("does not record failed requests", async () => {
+    const notFound = await callHandler(getTraceHandler, {
+      auth,
+      url: `/api/public/traces/${randomUUID()}`,
+      query: { traceId: randomUUID() },
+    });
+    expect(notFound._getStatusCode()).toBe(404);
+
+    const unauthorized = await callHandler(getTraceHandler, {
+      auth: "Basic invalid",
+      url: `/api/public/traces/${traceId}`,
+      query: { traceId },
+    });
+    expect(unauthorized._getStatusCode()).toBe(401);
+
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it("fails open when the queue rejects", async () => {
+    mockAdd.mockRejectedValueOnce(new Error("redis down"));
+
+    const res = await callHandler(getTraceHandler, {
+      auth,
+      url: `/api/public/traces/${traceId}`,
+      query: { traceId },
+    });
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/__tests__/server/audit-log-public-api-access-events.servertest.ts
+++ b/web/src/__tests__/server/audit-log-public-api-access-events.servertest.ts
@@ -183,4 +183,27 @@ describe("public API access events", () => {
     expect(res._getStatusCode()).toBe(200);
     expect(mockAdd).toHaveBeenCalledTimes(1);
   });
+
+  it("does not record a read whose response was too large to serialize", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      url: `/api/public/traces/${traceId}`,
+      headers: { authorization: auth },
+      query: { traceId },
+    });
+    // Only the success body blows up; the error body must still go out.
+    const sendJson = res.json.bind(res);
+    let serializations = 0;
+    res.json = ((body: unknown) => {
+      if (serializations++ === 0) {
+        throw new RangeError("Invalid string length");
+      }
+      return sendJson(body);
+    }) as typeof res.json;
+
+    await getTraceHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(422);
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
@@ -479,22 +479,6 @@ export const createAuthedProjectAPIRoute = <
         }
       }
 
-      if (routeConfig.audit) {
-        const { audit } = routeConfig;
-        await recordAccessEvent({
-          actor: { type: "API_KEY", apiKeyId: auth.scope.apiKeyId },
-          orgId: auth.scope.orgId,
-          projectId: auth.scope.projectId,
-          surface: "public-api",
-          route: audit.route,
-          resourceType: audit.resourceType,
-          resourceId: audit.resourceId?.(query),
-          action: audit.action,
-          params: query,
-          resultCount: audit.resultCount ? audit.resultCount(response) : 1,
-        });
-      }
-
       res.status(
         // Check whether status code was already set inside handler to non default value
         res.statusCode !== 200
@@ -510,6 +494,24 @@ export const createAuthedProjectAPIRoute = <
         }
 
         throw error;
+      }
+
+      // Recorded only once the body has been serialized, so a payload that
+      // was too large to deliver never shows up as a successful access.
+      if (routeConfig.audit) {
+        const { audit } = routeConfig;
+        await recordAccessEvent({
+          actor: { type: "API_KEY", apiKeyId: auth.scope.apiKeyId },
+          orgId: auth.scope.orgId,
+          projectId: auth.scope.projectId,
+          surface: "public-api",
+          route: audit.route,
+          resourceType: audit.resourceType,
+          resourceId: audit.resourceId?.(query),
+          action: audit.action,
+          params: query,
+          resultCount: audit.resultCount ? audit.resultCount(response) : 1,
+        });
       }
     });
   };

--- a/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
@@ -44,6 +44,31 @@ import {
   type ProjectAction,
 } from "@/src/features/auth/policy/types";
 import { prisma } from "@langfuse/shared/src/db";
+import {
+  recordAccessEvent,
+  type AccessEventAction,
+} from "@/src/features/audit-logs/accessEvents";
+
+/**
+ * Declares that a successful call to the route is a data access worth an
+ * audit log access event. `route` is the REST route pattern so records stay
+ * stable across renamed handlers.
+ */
+export type AuthedProjectAPIRouteAudit<TQuery extends ZodType<any>> = {
+  route: string;
+  resourceType: string;
+  action: AccessEventAction;
+  /** Picks the accessed entity id from the parsed query. Omit for lists. */
+  resourceId?: (query: z.infer<TQuery>) => string | undefined;
+  /** Counts returned entities. Omit when the handler returns exactly one. */
+  resultCount?: (response: unknown) => number;
+};
+
+/** Counts the `data` array of a paginated public API list response. */
+export const publicApiListResultCount = (response: unknown): number => {
+  const data = (response as { data?: unknown } | null | undefined)?.data;
+  return Array.isArray(data) ? data.length : 0;
+};
 
 // Next's res.json uses JSON.stringify; V8 throws this when the JSON string
 // exceeds the engine limit. Keep this check scoped to the response write.
@@ -103,6 +128,8 @@ export type AuthedProjectAPIRouteConfig<
   rejectInEventsOnlyMode?: boolean;
   /** Stamps a top-level `_deprecation` object onto responses. */
   deprecation?: ApiDeprecationInfo;
+  /** Records an audit log access event once the handler has succeeded. */
+  audit?: AuthedProjectAPIRouteAudit<TQuery>;
   fn: (params: {
     query: z.infer<TQuery>;
     body: z.infer<TBody>;
@@ -450,6 +477,22 @@ export const createAuthedProjectAPIRoute = <
           logger.error("Response validation failed:", parsingResult.error);
           traceException(parsingResult.error);
         }
+      }
+
+      if (routeConfig.audit) {
+        const { audit } = routeConfig;
+        await recordAccessEvent({
+          actor: { type: "API_KEY", apiKeyId: auth.scope.apiKeyId },
+          orgId: auth.scope.orgId,
+          projectId: auth.scope.projectId,
+          surface: "public-api",
+          route: audit.route,
+          resourceType: audit.resourceType,
+          resourceId: audit.resourceId?.(query),
+          action: audit.action,
+          params: query,
+          resultCount: audit.resultCount ? audit.resultCount(response) : 1,
+        });
       }
 
       res.status(

--- a/web/src/pages/api/public/media/[mediaId].ts
+++ b/web/src/pages/api/public/media/[mediaId].ts
@@ -16,6 +16,12 @@ import { ForbiddenError } from "@langfuse/shared";
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get Media data",
+    audit: {
+      route: "GET /api/public/media/{mediaId}",
+      resourceType: "media",
+      action: "download",
+      resourceId: (query) => query.mediaId,
+    },
     action: "media:create",
     querySchema: GetMediaQuerySchema,
     responseSchema: GetMediaResponseSchema,

--- a/web/src/pages/api/public/observations/[observationId].ts
+++ b/web/src/pages/api/public/observations/[observationId].ts
@@ -22,6 +22,12 @@ export default withMiddlewares(
   {
     GET: createAuthedProjectAPIRoute({
       name: "Get Observation",
+      audit: {
+        route: "GET /api/public/observations/{observationId}",
+        resourceType: "observation",
+        action: "read",
+        resourceId: (query) => query.observationId,
+      },
       action: "traces:read",
       allowInAppAgentKey: true,
       rateLimitResource: "public-api-legacy",

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -8,7 +8,10 @@ import {
   LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
   withMiddlewares,
 } from "@/src/features/public-api/server/withMiddlewares";
-import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
+import {
+  createAuthedProjectAPIRoute,
+  publicApiListResultCount,
+} from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 
 import {
   GetObservationsV1Query,
@@ -27,6 +30,12 @@ export default withMiddlewares(
   {
     GET: createAuthedProjectAPIRoute({
       name: "Get Observations",
+      audit: {
+        route: "GET /api/public/observations",
+        resourceType: "observation",
+        action: "list",
+        resultCount: publicApiListResultCount,
+      },
       action: "traces:read",
       allowInAppAgentKey: true,
       rateLimitResource: "public-api-legacy",

--- a/web/src/pages/api/public/sessions/[sessionId].ts
+++ b/web/src/pages/api/public/sessions/[sessionId].ts
@@ -13,6 +13,12 @@ import { SESSIONS_DEPRECATION } from "@/src/features/public-api/server/deprecati
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get Session",
+    audit: {
+      route: "GET /api/public/sessions/{sessionId}",
+      resourceType: "session",
+      action: "read",
+      resourceId: (query) => query.sessionId,
+    },
     action: "sessions:read",
     deprecation: SESSIONS_DEPRECATION,
     rateLimitResource: "public-api-legacy",

--- a/web/src/pages/api/public/sessions/index.ts
+++ b/web/src/pages/api/public/sessions/index.ts
@@ -4,7 +4,10 @@ import {
   GetSessionsV1Response,
 } from "@/src/features/public-api/types/sessions";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
-import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
+import {
+  createAuthedProjectAPIRoute,
+  publicApiListResultCount,
+} from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { legacyPublicApiRateLimitUpgradePaths } from "@/src/features/public-api/server/rateLimitUpgradePaths";
 import { SESSIONS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
@@ -12,6 +15,12 @@ import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEnt
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get Sessions",
+    audit: {
+      route: "GET /api/public/sessions",
+      resourceType: "session",
+      action: "list",
+      resultCount: publicApiListResultCount,
+    },
     action: "sessions:read",
     deprecation: SESSIONS_DEPRECATION,
     rateLimitResource: "public-api-legacy",

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -34,6 +34,12 @@ export default withMiddlewares(
   {
     GET: createAuthedProjectAPIRoute({
       name: "Get Single Trace",
+      audit: {
+        route: "GET /api/public/traces/{traceId}",
+        resourceType: "trace",
+        action: "read",
+        resourceId: (query) => query.traceId,
+      },
       action: "traces:read",
       deprecation: TRACES_DEPRECATION,
       rateLimitResource: "public-api-legacy",

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -13,7 +13,10 @@ import {
   LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
   withMiddlewares,
 } from "@/src/features/public-api/server/withMiddlewares";
-import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
+import {
+  createAuthedProjectAPIRoute,
+  publicApiListResultCount,
+} from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import {
   processEventBatch,
   createIngestionAttribution,
@@ -80,6 +83,12 @@ export default withMiddlewares(
 
     GET: createAuthedProjectAPIRoute({
       name: "Get Traces",
+      audit: {
+        route: "GET /api/public/traces",
+        resourceType: "trace",
+        action: "list",
+        resultCount: publicApiListResultCount,
+      },
       action: "traces:read",
       rateLimitResource: "public-api-legacy",
       querySchema: GetTracesV1Query,

--- a/web/src/pages/api/public/v2/observations/index.ts
+++ b/web/src/pages/api/public/v2/observations/index.ts
@@ -2,7 +2,10 @@ import { getObservationsV2FromEventsTableForPublicApi } from "@langfuse/shared/s
 import { LangfuseNotFoundError } from "@langfuse/shared";
 
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
-import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
+import {
+  createAuthedProjectAPIRoute,
+  publicApiListResultCount,
+} from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { env } from "@/src/env.mjs";
 
 import {
@@ -15,6 +18,12 @@ import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEnt
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get Observations V2",
+    audit: {
+      route: "GET /api/public/v2/observations",
+      resourceType: "observation",
+      action: "list",
+      resultCount: publicApiListResultCount,
+    },
     action: "traces:read",
     allowInAppAgentKey: true,
     querySchema: GetObservationsV2Query,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17295 app preview](https://pr-17295.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

**3/4**, based on #17294. Base retargets when #17294 lands.

Records an audit log **access** event for successful reads through the public API, attributed to the API key.

- `createAuthedProjectAPIRoute` gains an optional `audit` config (`route`, `resourceType`, `action`, `resourceId(query)`, `resultCount(response)`). When set, a successful handler call records one access event with the parsed query as `params`. Fail-open, same as the tRPC path.
- Wired on: `GET /api/public/traces`, `/traces/{id}`, `/observations`, `/observations/{id}`, `/sessions`, `/sessions/{id}`, `/media/{id}` (download), and the v4 `GET /api/public/v2/observations` list.
- `route` is the REST route pattern, not the handler name, so records stay stable across refactors.

**Deliberately not in this slice:** the UI, filters and export showing these rows (slice 4).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm exec turbo run lint typecheck --force` on this branch: `Tasks: 12 successful, 12 total`, `Cached: 0 cached, 12 total`
- `pnpm exec knip`: exit 0
- `web`: `audit-log-public-api-access-events.servertest.ts` (5 tests) — single read with resource id, list with result count, empty list, failed request not recorded, fail-open enqueue.
- Local stack: `GET /api/public/v2/observations?limit=1` with the seed API key produced an `access` / `API_KEY` / `public-api` row in ClickHouse.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-275b1cf1-9f61-40d6-852c-7208603fb159?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-275b1cf1-9f61-40d6-852c-7208603fb159&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62620119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until audit events are prevented from being recorded for responses that subsequently fail serialization.

<details open><summary><h3>Summary</h3></summary>

- Records API-key actor, route pattern, parsed parameters, resource ID, and result count.
- Adds coverage for single reads, list counts, failed requests, and enqueue failures.
- The current response ordering can record an event before serialization fails and places the Redis enqueue on the request latency path.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant C as API client
  participant R as Authenticated route
  participant H as Read handler
  participant Q as Audit queue
  participant S as HTTP serializer

  C->>R: Authenticated GET
  R->>H: Execute parsed request
  H-->>R: Response object
  R->>Q: Await access-event enqueue
  Q-->>R: Enqueued or fail-open return
  R->>S: Serialize and send response
  alt Serialization succeeds
    S-->>C: 200 response
  else Serialization fails
    S-->>C: Error response
    Note over Q,S: Audit event was already recorded
  end
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat(audit-logs): record v2 observations..."](https://github.com/langfuse/langfuse/commit/c0afcccab034df73a4ae38f627d565b04e535533)</sub>

<!-- /greptile_comment -->