### PR TITLE
feat(audit-logs): read audit logs from ClickHouse with filters

### DIFF
--- a/packages/shared/src/server/clickhouse/schema.ts
+++ b/packages/shared/src/server/clickhouse/schema.ts
@@ -22,6 +22,7 @@ export const ClickhouseTableNames = {
   scores_listable_count: "scores_listable_count",
   events_traces: "events_traces",
   events_observations: "events_observations",
+  audit_logs: "audit_logs",
 } as const;
 
 export type ClickhouseTableName = keyof typeof ClickhouseTableNames;

--- a/packages/shared/src/server/repositories/auditLogs.ts
+++ b/packages/shared/src/server/repositories/auditLogs.ts
@@ -1,6 +1,24 @@
+import type { ClickHouseClientConfigOptions } from "@clickhouse/client";
 import type { AuditLog } from "../../db";
+import type { FilterState } from "../../types";
+import { auditLogsTableCols } from "../../tableDefinitions";
 import { convertDateToClickhouseDateTime } from "../clickhouse/client";
-import type { AuditLogRecordInsertType } from "./definitions";
+import {
+  FilterList,
+  StringFilter,
+} from "../queries/clickhouse-sql/clickhouse-filter";
+import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
+import { auditLogsTableUiColumnDefinitions } from "../tableMappings/mapAuditLogsTable";
+import {
+  parseClickhouseUTCDateTimeFormat,
+  queryClickhouse,
+} from "./clickhouse";
+import type {
+  AuditLogActorType,
+  AuditLogEventKind,
+  AuditLogRecordInsertType,
+  AuditLogRecordReadType,
+} from "./definitions";
 
 /**
  * Maps a Postgres audit log row to its ClickHouse change-event twin. The web
@@ -31,4 +49,168 @@ export function convertPostgresAuditLogToClickhouse(
     before: row.before ?? "",
     after: row.after ?? "",
   };
+}
+
+/**
+ * An audit log row as the read path hands it out. Empty ClickHouse strings
+ * become `null` so consumers keep the nullable shape of the former Postgres
+ * model; `createdAt` mirrors the event timestamp for the same reason.
+ */
+export type AuditLogEntry = {
+  id: string;
+  createdAt: Date;
+  eventKind: AuditLogEventKind;
+  type: AuditLogActorType;
+  apiKeyId: string | null;
+  userId: string | null;
+  orgId: string;
+  userOrgRole: string | null;
+  projectId: string | null;
+  userProjectRole: string | null;
+  resourceType: string;
+  resourceId: string;
+  action: string;
+  surface: string | null;
+  route: string | null;
+  params: string | null;
+  resultCount: number;
+  before: string | null;
+  after: string | null;
+};
+
+const emptyToNull = (value: string) => (value === "" ? null : value);
+
+export function convertClickhouseToAuditLogEntry(
+  row: AuditLogRecordReadType,
+): AuditLogEntry {
+  return {
+    id: row.id,
+    createdAt: parseClickhouseUTCDateTimeFormat(row.timestamp),
+    eventKind: row.event_kind,
+    type: row.actor_type,
+    apiKeyId: emptyToNull(row.api_key_id),
+    userId: emptyToNull(row.user_id),
+    orgId: row.org_id,
+    userOrgRole: emptyToNull(row.user_org_role),
+    projectId: emptyToNull(row.project_id),
+    userProjectRole: emptyToNull(row.user_project_role),
+    resourceType: row.resource_type,
+    resourceId: row.resource_id,
+    action: row.action,
+    surface: emptyToNull(row.surface),
+    route: emptyToNull(row.route),
+    params: emptyToNull(row.params),
+    resultCount: Number(row.result_count),
+    before: emptyToNull(row.before),
+    after: emptyToNull(row.after),
+  };
+}
+
+/**
+ * Selects one organisation's audit log. `projectId: null` returns the
+ * organisation-level rows only (stored with an empty `project_id`).
+ */
+export type AuditLogScope = {
+  orgId: string;
+  projectId: string | null;
+};
+
+type AuditLogQueryArgs = AuditLogScope & {
+  filter?: FilterState;
+  clickhouseConfigs?: ClickHouseClientConfigOptions;
+};
+
+const buildScopeFilter = ({ orgId, projectId, filter }: AuditLogQueryArgs) => {
+  const filters = new FilterList([
+    new StringFilter({
+      clickhouseTable: "audit_logs",
+      field: "org_id",
+      operator: "=",
+      value: orgId,
+    }),
+    new StringFilter({
+      clickhouseTable: "audit_logs",
+      field: "project_id",
+      operator: "=",
+      value: projectId ?? "",
+    }),
+  ]);
+  if (filter && filter.length > 0) {
+    filters.push(
+      ...createFilterFromFilterState(
+        filter,
+        auditLogsTableUiColumnDefinitions,
+        auditLogsTableCols,
+      ),
+    );
+  }
+  return filters.apply();
+};
+
+const tagsFor = ({ orgId, projectId }: AuditLogScope, kind: string) => ({
+  feature: "audit-logs",
+  type: "audit_logs",
+  kind,
+  orgId,
+  ...(projectId ? { projectId } : {}),
+});
+
+/**
+ * Newest first. Rows are collapsed by id in the query because the dual write
+ * and the backfill can leave a duplicate in an unmerged part for a while.
+ */
+export async function getAuditLogs(
+  args: AuditLogQueryArgs & { limit: number; offset: number },
+): Promise<AuditLogEntry[]> {
+  const scope = buildScopeFilter(args);
+  const rows = await queryClickhouse<AuditLogRecordReadType>({
+    query: `
+      SELECT
+        id,
+        timestamp,
+        org_id,
+        project_id,
+        event_kind,
+        actor_type,
+        user_id,
+        api_key_id,
+        user_org_role,
+        user_project_role,
+        resource_type,
+        resource_id,
+        action,
+        surface,
+        route,
+        params,
+        result_count,
+        before,
+        after
+      FROM audit_logs
+      WHERE ${scope.query}
+      ORDER BY timestamp DESC, id DESC
+      LIMIT 1 BY id
+      LIMIT {limit: Int32} OFFSET {offset: Int32}
+    `,
+    params: { ...scope.params, limit: args.limit, offset: args.offset },
+    tags: tagsFor(args, "list"),
+    clickhouseConfigs: args.clickhouseConfigs,
+  });
+  return rows.map(convertClickhouseToAuditLogEntry);
+}
+
+export async function getAuditLogsCount(
+  args: AuditLogQueryArgs,
+): Promise<number> {
+  const scope = buildScopeFilter(args);
+  const rows = await queryClickhouse<{ count: string }>({
+    query: `
+      SELECT uniqExact(id) AS count
+      FROM audit_logs
+      WHERE ${scope.query}
+    `,
+    params: scope.params,
+    tags: tagsFor(args, "count"),
+    clickhouseConfigs: args.clickhouseConfigs,
+  });
+  return Number(rows[0]?.count ?? 0);
 }

--- a/packages/shared/src/server/repositories/definitions.ts
+++ b/packages/shared/src/server/repositories/definitions.ts
@@ -616,3 +616,5 @@ export const auditLogRecordInsertSchema = auditLogRecordBaseSchema.extend({
 export type AuditLogRecordInsertType = z.infer<
   typeof auditLogRecordInsertSchema
 >;
+/** Rows come back with the same shape they were written in. */
+export type AuditLogRecordReadType = AuditLogRecordInsertType;

--- a/packages/shared/src/server/tableMappings/index.ts
+++ b/packages/shared/src/server/tableMappings/index.ts
@@ -5,3 +5,4 @@ export * from "./mapExperimentTable";
 export * from "../../tableDefinitions/mapDashboards";
 export * from "./mapScoresTable";
 export * from "./mapDatasetRunItemsTable";
+export * from "./mapAuditLogsTable";

--- a/packages/shared/src/server/tableMappings/mapAuditLogsTable.ts
+++ b/packages/shared/src/server/tableMappings/mapAuditLogsTable.ts
@@ -1,0 +1,25 @@
+import { type UiColumnMappings } from "../../tableDefinitions";
+
+const column = (
+  uiTableName: string,
+  uiTableId: string,
+  clickhouseSelect: string,
+) => ({
+  uiTableName,
+  uiTableId,
+  clickhouseTableName: "audit_logs",
+  clickhouseSelect,
+});
+
+export const auditLogsTableUiColumnDefinitions: UiColumnMappings = [
+  column("Timestamp", "timestamp", "timestamp"),
+  column("Event Kind", "eventKind", "event_kind"),
+  column("Actor Type", "actorType", "actor_type"),
+  column("User ID", "userId", "user_id"),
+  column("API Key ID", "apiKeyId", "api_key_id"),
+  column("Resource Type", "resourceType", "resource_type"),
+  column("Resource ID", "resourceId", "resource_id"),
+  column("Action", "action", "action"),
+  column("Surface", "surface", "surface"),
+  column("Route", "route", "route"),
+];

--- a/packages/shared/src/server/test-utils/clickhouse-helpers.ts
+++ b/packages/shared/src/server/test-utils/clickhouse-helpers.ts
@@ -5,6 +5,7 @@ import {
   ScoreRecordInsertType,
   DatasetRunItemRecordInsertType,
   EventRecordInsertType,
+  AuditLogRecordInsertType,
 } from "../repositories/definitions";
 
 export const createTracesCh = async (trace: TraceRecordInsertType[]) => {
@@ -48,5 +49,13 @@ export const createDatasetRunItemsCh = async (
     table: "dataset_run_items_rmt",
     format: "JSONEachRow",
     values: datasetRunItems,
+  });
+};
+
+export const createAuditLogsCh = async (rows: AuditLogRecordInsertType[]) => {
+  return await clickhouseClient().insert({
+    table: "audit_logs",
+    format: "JSONEachRow",
+    values: rows,
   });
 };

--- a/packages/shared/src/tableDefinitions/auditLogsTable.ts
+++ b/packages/shared/src/tableDefinitions/auditLogsTable.ts
@@ -1,0 +1,75 @@
+import { type ColumnDefinition } from "./types";
+
+export const auditLogEventKinds = ["change", "access"] as const;
+export const auditLogActorTypes = ["USER", "API_KEY"] as const;
+export const auditLogSurfaces = ["trpc", "public-api"] as const;
+
+/**
+ * Filterable columns of the audit log table. `internal` names the ClickHouse
+ * column; the ClickHouse mapping lives in `mapAuditLogsTable`.
+ */
+export const auditLogsTableCols: ColumnDefinition[] = [
+  {
+    name: "Timestamp",
+    id: "timestamp",
+    type: "datetime",
+    internal: "timestamp",
+  },
+  {
+    name: "Event Kind",
+    id: "eventKind",
+    type: "stringOptions",
+    internal: "event_kind",
+    options: auditLogEventKinds.map((value) => ({ value })),
+  },
+  {
+    name: "Actor Type",
+    id: "actorType",
+    type: "stringOptions",
+    internal: "actor_type",
+    options: auditLogActorTypes.map((value) => ({ value })),
+  },
+  {
+    name: "User ID",
+    id: "userId",
+    type: "string",
+    internal: "user_id",
+  },
+  {
+    name: "API Key ID",
+    id: "apiKeyId",
+    type: "string",
+    internal: "api_key_id",
+  },
+  {
+    name: "Resource Type",
+    id: "resourceType",
+    type: "string",
+    internal: "resource_type",
+  },
+  {
+    name: "Resource ID",
+    id: "resourceId",
+    type: "string",
+    internal: "resource_id",
+  },
+  {
+    name: "Action",
+    id: "action",
+    type: "string",
+    internal: "action",
+  },
+  {
+    name: "Surface",
+    id: "surface",
+    type: "stringOptions",
+    internal: "surface",
+    options: auditLogSurfaces.map((value) => ({ value })),
+  },
+  {
+    name: "Route",
+    id: "route",
+    type: "string",
+    internal: "route",
+  },
+];

--- a/packages/shared/src/tableDefinitions/index.ts
+++ b/packages/shared/src/tableDefinitions/index.ts
@@ -9,3 +9,4 @@ export * from "./datasetRunsTable";
 export * from "./datasetRunItemsTable";
 export * from "./usersTable";
 export * from "./scoresTable";
+export * from "./auditLogsTable";

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -51,4 +51,5 @@ export type TableName =
   | "dataset_runs"
   | "dataset_run_items_by_run"
   | "experiments"
-  | "experiment-items";
+  | "experiment-items"
+  | "audit_logs";

--- a/web/src/__tests__/server/audit-log-read-path.servertest.ts
+++ b/web/src/__tests__/server/audit-log-read-path.servertest.ts
@@ -1,0 +1,301 @@
+import { randomUUID } from "crypto";
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import { prisma, type Role } from "@langfuse/shared/src/db";
+import {
+  createAuditLogsCh,
+  createOrgProjectAndApiKey,
+  type AuditLogRecordInsertType,
+} from "@langfuse/shared/src/server";
+import type { Session } from "next-auth";
+
+function makeSession(args: {
+  userId: string;
+  orgId: string;
+  orgRole: Role;
+  projectId: string;
+  projectRole: Role;
+}): Session {
+  return {
+    expires: "1",
+    user: {
+      id: args.userId,
+      canCreateOrganizations: true,
+      name: "Audit Reader",
+      v4BetaEnabled: false,
+      organizations: [
+        {
+          id: args.orgId,
+          name: "org",
+          role: args.orgRole,
+          plan: "cloud:team",
+          cloudConfig: undefined,
+          metadata: {},
+          aiFeaturesEnabled: false,
+          aiTelemetryEnabled: false,
+          projects: [
+            {
+              id: args.projectId,
+              role: args.projectRole,
+              retentionDays: null,
+              deletedAt: null,
+              hasTraces: false,
+              name: "project",
+              metadata: {},
+              createdAt: new Date().toISOString(),
+            },
+          ],
+        },
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: false,
+        searchBar: false,
+        v4BetaToggleVisible: false,
+        observationEvals: false,
+        experimentsV4Enabled: false,
+      },
+      admin: false,
+    },
+    environment: {
+      enableExperimentalFeatures: false,
+      selfHostedInstancePlan: "cloud:team",
+    },
+  };
+}
+
+const baseRow = (
+  overrides: Partial<AuditLogRecordInsertType> &
+    Pick<AuditLogRecordInsertType, "org_id" | "timestamp">,
+): AuditLogRecordInsertType => ({
+  id: randomUUID(),
+  project_id: "",
+  event_kind: "change",
+  actor_type: "USER",
+  user_id: "",
+  api_key_id: "",
+  user_org_role: "",
+  user_project_role: "",
+  resource_type: "prompt",
+  resource_id: randomUUID(),
+  action: "create",
+  surface: "",
+  route: "",
+  params: "",
+  result_count: 0,
+  before: "",
+  after: "",
+  ...overrides,
+});
+
+describe("audit log read path (ClickHouse)", () => {
+  it("lists project audit logs newest first with actors, filters and dedup", async () => {
+    const { orgId, projectId, publicKey } = await createOrgProjectAndApiKey();
+    const apiKey = await prisma.apiKey.findFirstOrThrow({
+      where: { publicKey },
+      select: { id: true },
+    });
+
+    const reader = await prisma.user.create({
+      data: {
+        id: randomUUID(),
+        email: `${randomUUID()}@example.com`,
+        name: "Reader",
+        organizationMemberships: {
+          create: { orgId, role: "OWNER" },
+        },
+      },
+    });
+    const outsider = await prisma.user.create({
+      data: {
+        id: randomUUID(),
+        email: `${randomUUID()}@example.com`,
+        name: "Outsider",
+      },
+    });
+
+    const change = baseRow({
+      org_id: orgId,
+      project_id: projectId,
+      timestamp: "2024-03-01 10:00:00.000",
+      user_id: reader.id,
+      user_org_role: "OWNER",
+      user_project_role: "OWNER",
+      action: "update",
+      before: JSON.stringify({ a: 1 }),
+      after: JSON.stringify({ a: 2 }),
+    });
+    const access = baseRow({
+      org_id: orgId,
+      project_id: projectId,
+      timestamp: "2024-03-02 10:00:00.000",
+      event_kind: "access",
+      actor_type: "API_KEY",
+      api_key_id: apiKey.id,
+      resource_type: "trace",
+      resource_id: "",
+      action: "list",
+      surface: "public-api",
+      route: "GET /api/public/traces",
+      params: JSON.stringify({ limit: 10 }),
+      result_count: 3,
+    });
+    const strangerChange = baseRow({
+      org_id: orgId,
+      project_id: projectId,
+      timestamp: "2024-03-03 10:00:00.000",
+      user_id: outsider.id,
+    });
+    const orgLevel = baseRow({
+      org_id: orgId,
+      timestamp: "2024-03-04 10:00:00.000",
+      user_id: reader.id,
+      resource_type: "project",
+    });
+    const otherOrg = baseRow({
+      org_id: randomUUID(),
+      project_id: projectId,
+      timestamp: "2024-03-05 10:00:00.000",
+    });
+
+    // `change` twice: dual write and backfill may both land before a merge.
+    await createAuditLogsCh([
+      change,
+      change,
+      access,
+      strangerChange,
+      orgLevel,
+      otherOrg,
+    ]);
+
+    const session = makeSession({
+      userId: reader.id,
+      orgId,
+      orgRole: "OWNER",
+      projectId,
+      projectRole: "OWNER",
+    });
+    const caller = appRouter.createCaller({
+      ...createInnerTRPCContext({ session, headers: {} }),
+      prisma,
+    });
+
+    const page = await caller.auditLogs.all({
+      projectId,
+      page: 0,
+      limit: 50,
+    });
+
+    expect(page.totalCount).toBe(3);
+    expect(page.data.map((row) => row.id)).toEqual([
+      strangerChange.id,
+      access.id,
+      change.id,
+    ]);
+
+    const [stranger, accessRow, changeRow] = page.data;
+
+    // A user outside the organisation is not resolved to display data.
+    expect(stranger.actor).toEqual({
+      type: "USER",
+      body: { id: outsider.id, name: null, email: null, image: null },
+    });
+
+    expect(accessRow.eventKind).toBe("access");
+    expect(accessRow.actor).toEqual({
+      type: "API_KEY",
+      body: { id: apiKey.id, publicKey },
+    });
+    expect(accessRow.surface).toBe("public-api");
+    expect(accessRow.route).toBe("GET /api/public/traces");
+    expect(accessRow.params).toBe(JSON.stringify({ limit: 10 }));
+    expect(accessRow.resultCount).toBe(3);
+    expect(accessRow.resourceId).toBe("");
+    expect(accessRow.before).toBeNull();
+    expect(accessRow.after).toBeNull();
+
+    expect(changeRow.eventKind).toBe("change");
+    expect(changeRow.actor).toMatchObject({
+      type: "USER",
+      body: { id: reader.id, name: "Reader" },
+    });
+    expect(changeRow.userOrgRole).toBe("OWNER");
+    expect(changeRow.before).toBe(JSON.stringify({ a: 1 }));
+    expect(changeRow.after).toBe(JSON.stringify({ a: 2 }));
+    expect(changeRow.createdAt).toEqual(new Date("2024-03-01T10:00:00.000Z"));
+
+    const filtered = await caller.auditLogs.all({
+      projectId,
+      filter: [
+        {
+          column: "eventKind",
+          type: "stringOptions",
+          operator: "any of",
+          value: ["access"],
+        },
+      ],
+      page: 0,
+      limit: 50,
+    });
+    expect(filtered.totalCount).toBe(1);
+    expect(filtered.data.map((row) => row.id)).toEqual([access.id]);
+
+    const paged = await caller.auditLogs.all({
+      projectId,
+      page: 1,
+      limit: 2,
+    });
+    expect(paged.totalCount).toBe(3);
+    expect(paged.data.map((row) => row.id)).toEqual([change.id]);
+
+    const orgPage = await caller.auditLogs.allByOrg({
+      orgId,
+      page: 0,
+      limit: 50,
+    });
+    expect(orgPage.totalCount).toBe(1);
+    expect(orgPage.data.map((row) => row.id)).toEqual([orgLevel.id]);
+    expect(orgPage.data[0].projectId).toBeNull();
+  });
+
+  it("rejects filters on unknown columns", async () => {
+    const { orgId, projectId } = await createOrgProjectAndApiKey();
+    const userId = randomUUID();
+    await prisma.user.create({
+      data: {
+        id: userId,
+        email: `${randomUUID()}@example.com`,
+        organizationMemberships: { create: { orgId, role: "OWNER" } },
+      },
+    });
+    const caller = appRouter.createCaller({
+      ...createInnerTRPCContext({
+        session: makeSession({
+          userId,
+          orgId,
+          orgRole: "OWNER",
+          projectId,
+          projectRole: "OWNER",
+        }),
+        headers: {},
+      }),
+      prisma,
+    });
+
+    await expect(
+      caller.auditLogs.all({
+        projectId,
+        filter: [
+          {
+            column: "nope",
+            type: "string",
+            operator: "=",
+            value: "x",
+          },
+        ],
+        page: 0,
+        limit: 50,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/web/src/ee/features/audit-log-viewer/AuditLogsTable.tsx
+++ b/web/src/ee/features/audit-log-viewer/AuditLogsTable.tsx
@@ -10,7 +10,11 @@ import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { SettingsTableCard } from "@/src/components/layouts/settings-table-card";
 import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
-import { BatchExportTableName, auditLogsTableCols } from "@langfuse/shared";
+import {
+  BatchExportTableName,
+  auditLogsTableCols,
+  type FilterState,
+} from "@langfuse/shared";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { useDebounce } from "@/src/hooks/useDebounce";
@@ -33,6 +37,13 @@ export function AuditLogsTable(props: AuditLogsTableProps) {
     "audit_logs",
     props.scope === "project" ? props.projectId : undefined,
   );
+
+  // A filter change shrinks the result set, so the current offset may point
+  // past its end; both query params update in the same tick (batched).
+  const setFilterStateAndResetPage = useDebounce((state: FilterState) => {
+    setPaginationState({ pageIndex: 0 });
+    setFilterState(state);
+  });
 
   // Use the appropriate query based on scope
   const projectAuditLogs = api.auditLogs.all.useQuery(
@@ -190,7 +201,7 @@ export function AuditLogsTable(props: AuditLogsTableProps) {
         columns={columns}
         filterColumnDefinition={auditLogsTableCols}
         filterState={filterState}
-        setFilterState={useDebounce(setFilterState)}
+        setFilterState={setFilterStateAndResetPage}
         rowHeight={rowHeight}
         setRowHeight={setRowHeight}
         actionButtons={

--- a/web/src/ee/features/audit-log-viewer/AuditLogsTable.tsx
+++ b/web/src/ee/features/audit-log-viewer/AuditLogsTable.tsx
@@ -10,8 +10,10 @@ import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { SettingsTableCard } from "@/src/components/layouts/settings-table-card";
 import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
-import { BatchExportTableName } from "@langfuse/shared";
+import { BatchExportTableName, auditLogsTableCols } from "@langfuse/shared";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
+import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
+import { useDebounce } from "@/src/hooks/useDebounce";
 
 // Both endpoints return the same shape
 type AuditLogRow = RouterOutputs["auditLogs"]["all"]["data"][number];
@@ -26,10 +28,17 @@ export function AuditLogsTable(props: AuditLogsTableProps) {
     pageSize: withDefault(NumberParam, 50),
   });
 
+  const [filterState, setFilterState] = useQueryFilterState(
+    [],
+    "audit_logs",
+    props.scope === "project" ? props.projectId : undefined,
+  );
+
   // Use the appropriate query based on scope
   const projectAuditLogs = api.auditLogs.all.useQuery(
     {
       projectId: props.scope === "project" ? props.projectId : "",
+      filter: filterState,
       page: paginationState.pageIndex,
       limit: paginationState.pageSize,
     },
@@ -39,6 +48,7 @@ export function AuditLogsTable(props: AuditLogsTableProps) {
   const orgAuditLogs = api.auditLogs.allByOrg.useQuery(
     {
       orgId: props.scope === "organization" ? props.orgId : "",
+      filter: filterState,
       page: paginationState.pageIndex,
       limit: paginationState.pageSize,
     },
@@ -59,6 +69,14 @@ export function AuditLogsTable(props: AuditLogsTableProps) {
         return date.toLocaleString();
       },
     },
+    createTextTableColumn<AuditLogRow>({
+      accessorKey: "eventKind",
+      header: "Kind",
+      headerTooltip: {
+        description:
+          "Change events record a modification with its before and after state. Access events record a read, list or download.",
+      },
+    }),
     {
       accessorKey: "actor",
       header: "Actor",
@@ -112,6 +130,43 @@ export function AuditLogsTable(props: AuditLogsTableProps) {
       accessorKey: "action",
       header: "Action",
     }),
+    createTextTableColumn<AuditLogRow, string | null>({
+      accessorKey: "surface",
+      header: "Surface",
+      headerTooltip: {
+        description:
+          "Where an access event came from: the Langfuse UI (trpc) or the public API. Empty for change events.",
+      },
+      mapValue: (value) => value ?? undefined,
+    }),
+    createTextTableColumn<AuditLogRow, string | null>({
+      accessorKey: "route",
+      header: "Route",
+      size: 220,
+      mapValue: (value) => value ?? undefined,
+    }),
+    createIOTableColumn<AuditLogRow>({
+      accessorKey: "params",
+      header: "Params",
+      headerTooltip: {
+        description:
+          "The request parameters of an access event, such as filters and pagination.",
+      },
+      size: 300,
+      getCell: (value) => value || undefined,
+      singleLine: rowHeight === "s",
+    }),
+    createTextTableColumn<AuditLogRow, number>({
+      accessorKey: "resultCount",
+      header: "Results",
+      headerTooltip: {
+        description: "How many entities an access event returned.",
+      },
+      mapValue: (value, context) =>
+        context.row.original.eventKind === "access"
+          ? String(value ?? 0)
+          : undefined,
+    }),
     createIOTableColumn<AuditLogRow>({
       accessorKey: "before",
       header: "Before",
@@ -133,6 +188,9 @@ export function AuditLogsTable(props: AuditLogsTableProps) {
       <DataTableToolbar
         tableName="audit-logs"
         columns={columns}
+        filterColumnDefinition={auditLogsTableCols}
+        filterState={filterState}
+        setFilterState={useDebounce(setFilterState)}
         rowHeight={rowHeight}
         setRowHeight={setRowHeight}
         actionButtons={
@@ -142,8 +200,8 @@ export function AuditLogsTable(props: AuditLogsTableProps) {
                   key="audit-logs-export"
                   projectId={props.projectId}
                   tableName={BatchExportTableName.AuditLogs}
-                  filterState={[]}
-                  orderByState={{ column: "createdAt", order: "DESC" }}
+                  filterState={filterState}
+                  orderByState={{ column: "timestamp", order: "DESC" }}
                 />,
               ]
             : []

--- a/web/src/features/filters/hooks/useFilterState.ts
+++ b/web/src/features/filters/hooks/useFilterState.ts
@@ -14,6 +14,7 @@ import {
   splitOnUnescapedPipe,
   unescapePipeInValue,
   normalizeLegacySessionPositionInTraceKey,
+  auditLogsTableCols,
 } from "@langfuse/shared";
 import { scoresTableCols } from "@/src/server/api/definitions/scoresTable";
 import {
@@ -190,6 +191,7 @@ const tableCols = {
   dataset_run_items_by_run: datasetRunItemsTableCols,
   experiments: experimentsTableCols,
   "experiment-items": experimentItemsTableCols,
+  audit_logs: auditLogsTableCols,
   widgets: [
     { id: "environment", name: "Environment" },
     { id: "traceName", name: "Trace Name" },

--- a/web/src/server/api/routers/auditLogs.ts
+++ b/web/src/server/api/routers/auditLogs.ts
@@ -7,8 +7,13 @@ import {
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { throwIfNoOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
-import { paginationZod } from "@langfuse/shared";
-import { AuditLogRecordType, type AuditLog } from "@langfuse/shared/src/db";
+import { paginationZod, singleFilter } from "@langfuse/shared";
+import { AuditLogRecordType, type prisma } from "@langfuse/shared/src/db";
+import {
+  type AuditLogEntry,
+  getAuditLogs,
+  getAuditLogsCount,
+} from "@langfuse/shared/src/server";
 
 type AuditLogActor =
   | {
@@ -27,7 +32,7 @@ type AuditLogActor =
   | null;
 
 function mapAuditLogsWithActors(
-  auditLogs: AuditLog[],
+  auditLogs: AuditLogEntry[],
   userMap: Map<
     string,
     {
@@ -75,203 +80,139 @@ function mapAuditLogsWithActors(
   });
 }
 
+const auditLogFilterZod = z.array(singleFilter).nullish();
+
+/**
+ * Reads one page from ClickHouse and resolves the actors against Postgres.
+ * Users are only resolved when they belong to the organisation and API keys
+ * only when they belong to the scope, so a row never leaks another tenant's
+ * display data through a spoofed id.
+ */
+async function getAuditLogPage(args: {
+  db: typeof prisma;
+  orgId: string;
+  projectId: string | null;
+  filter: z.infer<typeof auditLogFilterZod>;
+  page: number;
+  limit: number;
+}) {
+  const scope = {
+    orgId: args.orgId,
+    projectId: args.projectId,
+    filter: args.filter ?? [],
+  };
+  const [auditLogs, totalCount] = await Promise.all([
+    getAuditLogs({
+      ...scope,
+      limit: args.limit,
+      offset: args.page * args.limit,
+    }),
+    getAuditLogsCount(scope),
+  ]);
+
+  const userIds = [
+    ...new Set(auditLogs.flatMap((log) => (log.userId ? [log.userId] : []))),
+  ];
+  const apiKeyIds = [
+    ...new Set(
+      auditLogs.flatMap((log) => (log.apiKeyId ? [log.apiKeyId] : [])),
+    ),
+  ];
+
+  const [users, apiKeys] = await Promise.all([
+    userIds.length === 0
+      ? []
+      : args.db.user.findMany({
+          where: {
+            id: { in: userIds },
+            organizationMemberships: { some: { orgId: args.orgId } },
+          },
+          select: { id: true, name: true, email: true, image: true },
+        }),
+    apiKeyIds.length === 0
+      ? []
+      : args.db.apiKey.findMany({
+          where: {
+            id: { in: apiKeyIds },
+            ...(args.projectId
+              ? { projectId: args.projectId }
+              : { orgId: args.orgId, scope: "ORGANIZATION" }),
+          },
+          select: { id: true, publicKey: true },
+        }),
+  ]);
+
+  const userMap = new Map(users.map((user) => [user.id, user]));
+  const apiKeyMap = new Map(apiKeys.map((apiKey) => [apiKey.id, apiKey]));
+
+  return {
+    data: mapAuditLogsWithActors(auditLogs, userMap, apiKeyMap),
+    totalCount,
+  };
+}
+
 export const auditLogsRouter = createTRPCRouter({
   all: protectedProjectProcedure
     .input(
       z.object({
         projectId: z.string(),
+        filter: auditLogFilterZod,
         ...paginationZod,
       }),
     )
     .query(async ({ ctx, input }) => {
-      // Check if user has access to audit logs feature
       throwIfNoEntitlement({
         entitlement: "audit-logs",
         sessionUser: ctx.session.user,
         projectId: input.projectId,
       });
 
-      // Check if user has access to the project
       throwIfNoProjectAccess({
         session: ctx.session,
         projectId: input.projectId,
         scope: "projectAuditLogs:read",
       });
 
-      const [auditLogs, totalCount] = await Promise.all([
-        ctx.prisma.auditLog.findMany({
-          where: {
-            projectId: input.projectId,
-          },
-          orderBy: {
-            createdAt: "desc",
-          },
-          skip: input.page * input.limit,
-          take: input.limit,
-        }),
-        ctx.prisma.auditLog.count({
-          where: {
-            projectId: input.projectId,
-          },
-        }),
-      ]);
-
-      // Fetch user information for each audit log
-      const userIds = [
-        ...new Set(
-          auditLogs.flatMap((log) => (log?.userId ? [log.userId] : [])),
-        ),
-      ];
-      const apiKeyIds = [
-        ...new Set(
-          auditLogs.flatMap((log) => (log?.apiKeyId ? [log.apiKeyId] : [])),
-        ),
-      ];
-
-      const [users, apiKeys] = await Promise.all([
-        ctx.prisma.user.findMany({
-          where: {
-            id: {
-              in: userIds,
-            },
-            organizationMemberships: {
-              some: {
-                organization: {
-                  projects: {
-                    some: {
-                      id: input.projectId,
-                    },
-                  },
-                },
-              },
-            },
-          },
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            image: true,
-          },
-        }),
-        ctx.prisma.apiKey.findMany({
-          where: {
-            id: {
-              in: apiKeyIds,
-            },
-            projectId: input.projectId,
-          },
-          select: {
-            id: true,
-            publicKey: true,
-          },
-        }),
-      ]);
-
-      const userMap = new Map(users.map((user) => [user.id, user]));
-      const apiKeyMap = new Map(apiKeys.map((apiKey) => [apiKey.id, apiKey]));
-
-      return {
-        data: mapAuditLogsWithActors(auditLogs, userMap, apiKeyMap),
-        totalCount,
-      };
+      return getAuditLogPage({
+        db: ctx.prisma,
+        orgId: ctx.session.orgId,
+        projectId: input.projectId,
+        filter: input.filter,
+        page: input.page,
+        limit: input.limit,
+      });
     }),
 
   allByOrg: protectedOrganizationProcedure
     .input(
       z.object({
         orgId: z.string(),
+        filter: auditLogFilterZod,
         ...paginationZod,
       }),
     )
     .query(async ({ ctx, input }) => {
-      // Check if user has access to audit logs feature at org level
       throwIfNoEntitlement({
         entitlement: "audit-logs",
         sessionUser: ctx.session.user,
         orgId: input.orgId,
       });
 
-      // Check if user has access to organization audit logs
       throwIfNoOrganizationAccess({
         session: ctx.session,
         organizationId: input.orgId,
         scope: "orgAuditLogs:read",
       });
 
-      // Fetch organization-level audit logs (where projectId is null)
-      // This includes: organization CRUD, project CRUD, org membership changes
-      const [auditLogs, totalCount] = await Promise.all([
-        ctx.prisma.auditLog.findMany({
-          where: {
-            orgId: input.orgId,
-            projectId: null,
-          },
-          orderBy: {
-            createdAt: "desc",
-          },
-          skip: input.page * input.limit,
-          take: input.limit,
-        }),
-        ctx.prisma.auditLog.count({
-          where: {
-            orgId: input.orgId,
-            projectId: null,
-          },
-        }),
-      ]);
-
-      // Fetch user information for each audit log
-      const userIds = [
-        ...new Set(
-          auditLogs.flatMap((log) => (log?.userId ? [log.userId] : [])),
-        ),
-      ];
-      const apiKeyIds = [
-        ...new Set(
-          auditLogs.flatMap((log) => (log?.apiKeyId ? [log.apiKeyId] : [])),
-        ),
-      ];
-
-      const [users, apiKeys] = await Promise.all([
-        ctx.prisma.user.findMany({
-          where: {
-            id: {
-              in: userIds,
-            },
-            organizationMemberships: {
-              some: {
-                orgId: input.orgId,
-              },
-            },
-          },
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            image: true,
-          },
-        }),
-        ctx.prisma.apiKey.findMany({
-          where: {
-            id: {
-              in: apiKeyIds,
-            },
-            orgId: input.orgId,
-            scope: "ORGANIZATION",
-          },
-          select: {
-            id: true,
-            publicKey: true,
-          },
-        }),
-      ]);
-
-      const userMap = new Map(users.map((user) => [user.id, user]));
-      const apiKeyMap = new Map(apiKeys.map((apiKey) => [apiKey.id, apiKey]));
-
-      return {
-        data: mapAuditLogsWithActors(auditLogs, userMap, apiKeyMap),
-        totalCount,
-      };
+      // Organisation-level rows only: organisation and project CRUD, org
+      // memberships. Project rows live on the project pages.
+      return getAuditLogPage({
+        db: ctx.prisma,
+        orgId: input.orgId,
+        projectId: null,
+        filter: input.filter,
+        page: input.page,
+        limit: input.limit,
+      });
     }),
 });

--- a/worker/src/__tests__/backfillAuditLogsToClickhouse.test.ts
+++ b/worker/src/__tests__/backfillAuditLogsToClickhouse.test.ts
@@ -27,6 +27,9 @@ const readClickhouseRows = (orgId: string) =>
     params: { orgId },
   });
 
+const readState = (state: unknown) =>
+  state as { cursorCreatedAt: string; cursorId: string; processedRows: number };
+
 describe("BackfillAuditLogsToClickhouse", () => {
   let migrationId: string;
   let orgId: string;
@@ -97,21 +100,26 @@ describe("BackfillAuditLogsToClickhouse", () => {
     });
     expect(copied[2].project_id).toBe("");
 
-    const state = await prisma.backgroundMigration.findUniqueOrThrow({
-      where: { id: migrationId },
-      select: { state: true },
-    });
-    expect(state.state).toEqual({
-      cursorCreatedAt: rows[2].createdAt.toISOString(),
-      cursorId: rows[2].id,
-      processedRows: 3,
-    });
+    // Other tests write audit logs concurrently, so the cursor is asserted
+    // relative to our rows rather than as an exact value.
+    const state = readState(
+      (
+        await prisma.backgroundMigration.findUniqueOrThrow({
+          where: { id: migrationId },
+          select: { state: true },
+        })
+      ).state,
+    );
+    expect(new Date(state.cursorCreatedAt).getTime()).toBeGreaterThanOrEqual(
+      rows[2].createdAt.getTime(),
+    );
+    expect(state.processedRows).toBeGreaterThanOrEqual(3);
 
     // A later row appears after the cursor: a re-run copies only that one and
     // re-inserting nothing else keeps the row count stable.
     const lateRow = {
       id: `row-late-${uuidv4()}`,
-      createdAt: new Date(base + 10_000),
+      createdAt: new Date(),
       orgId,
       projectId,
       type: "USER" as const,
@@ -132,13 +140,17 @@ describe("BackfillAuditLogsToClickhouse", () => {
       ...rows.map((r) => r.id),
       lateRow.id,
     ]);
-    const stateAfter = await prisma.backgroundMigration.findUniqueOrThrow({
-      where: { id: migrationId },
-      select: { state: true },
-    });
-    expect(stateAfter.state).toMatchObject({
-      cursorId: lateRow.id,
-      processedRows: 4,
-    });
+    const stateAfter = readState(
+      (
+        await prisma.backgroundMigration.findUniqueOrThrow({
+          where: { id: migrationId },
+          select: { state: true },
+        })
+      ).state,
+    );
+    expect(
+      new Date(stateAfter.cursorCreatedAt).getTime(),
+    ).toBeGreaterThanOrEqual(lateRow.createdAt.getTime());
+    expect(stateAfter.processedRows).toBeGreaterThan(state.processedRows);
   });
 });

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -13,6 +13,7 @@ import {
   applyCommentFilters,
   createEvent,
   createEventsCh,
+  createAuditLogsCh,
   getEventsForBlobStorageExport,
   streamTransformations,
 } from "@langfuse/shared/src/server";
@@ -1600,62 +1601,84 @@ describe("batch export test suite", () => {
   it("should export audit logs", async () => {
     const { projectId, orgId } = await createOrgProjectAndApiKey();
 
-    // Create some audit log entries directly in the database
+    const base = {
+      org_id: orgId,
+      project_id: projectId,
+      user_org_role: "",
+      user_project_role: "",
+      surface: "",
+      route: "",
+      params: "",
+      result_count: 0,
+      before: "",
+      after: "",
+    };
     const auditLogEntries = [
       {
+        ...base,
         id: randomUUID(),
-        projectId: projectId,
-        orgId: orgId,
-        type: "USER" as const,
-        userId: randomUUID(),
-        userOrgRole: "OWNER",
-        userProjectRole: "ADMIN",
-        resourceType: "trace",
-        resourceId: randomUUID(),
-        action: "CREATE",
-        before: null,
+        timestamp: "2024-01-01 10:00:00.000",
+        event_kind: "change" as const,
+        actor_type: "USER" as const,
+        user_id: randomUUID(),
+        api_key_id: "",
+        user_org_role: "OWNER",
+        user_project_role: "ADMIN",
+        resource_type: "trace",
+        resource_id: randomUUID(),
+        action: "create",
         after: JSON.stringify({ name: "test-trace", version: 1 }),
-        createdAt: new Date("2024-01-01T10:00:00Z"),
-        updatedAt: new Date("2024-01-01T10:00:00Z"),
       },
       {
+        ...base,
         id: randomUUID(),
-        projectId: projectId,
-        orgId: orgId,
-        type: "API_KEY" as const,
-        apiKeyId: randomUUID(),
-        resourceType: "score",
-        resourceId: randomUUID(),
-        action: "UPDATE",
+        timestamp: "2024-01-02 10:00:00.000",
+        event_kind: "change" as const,
+        actor_type: "API_KEY" as const,
+        user_id: "",
+        api_key_id: randomUUID(),
+        resource_type: "score",
+        resource_id: randomUUID(),
+        action: "update",
         before: JSON.stringify({ value: 0.5 }),
         after: JSON.stringify({ value: 0.8 }),
-        createdAt: new Date("2024-01-02T10:00:00Z"),
-        updatedAt: new Date("2024-01-02T10:00:00Z"),
       },
       {
+        ...base,
         id: randomUUID(),
-        projectId: projectId,
-        orgId: orgId,
-        type: "USER" as const,
-        userId: randomUUID(),
-        userOrgRole: "MEMBER",
-        userProjectRole: "VIEWER",
-        resourceType: "prompt",
-        resourceId: randomUUID(),
-        action: "DELETE",
-        before: JSON.stringify({ name: "old-prompt", content: "Hello World" }),
-        after: null,
-        createdAt: new Date("2024-01-03T10:00:00Z"),
-        updatedAt: new Date("2024-01-03T10:00:00Z"),
+        timestamp: "2024-01-03 10:00:00.000",
+        event_kind: "access" as const,
+        actor_type: "USER" as const,
+        user_id: randomUUID(),
+        api_key_id: "",
+        user_org_role: "MEMBER",
+        user_project_role: "VIEWER",
+        resource_type: "trace",
+        resource_id: "",
+        action: "list",
+        surface: "trpc",
+        route: "traces.all",
+        params: JSON.stringify({ projectId, limit: 50 }),
+        result_count: 7,
+      },
+      // Another organisation's row in the same project id must never leak.
+      {
+        ...base,
+        id: randomUUID(),
+        org_id: randomUUID(),
+        timestamp: "2024-01-04 10:00:00.000",
+        event_kind: "change" as const,
+        actor_type: "USER" as const,
+        user_id: randomUUID(),
+        api_key_id: "",
+        resource_type: "prompt",
+        resource_id: randomUUID(),
+        action: "delete",
       },
     ];
 
-    // Insert audit log entries
-    await prisma.auditLog.createMany({
-      data: auditLogEntries,
-    });
+    await createAuditLogsCh(auditLogEntries);
 
-    // Export audit logs
     const stream = await getDatabaseReadStreamPaginated({
       projectId: projectId,
       tableName: BatchExportTableName.AuditLogs,
@@ -1672,34 +1695,62 @@ describe("batch export test suite", () => {
 
     expect(rows).toHaveLength(3);
 
-    // Verify the audit logs are sorted by createdAt DESC
-    expect(rows[0].action).toBe("DELETE");
-    expect(rows[0].resourceType).toBe("prompt");
+    // Newest first
+    expect(rows[0].eventKind).toBe("access");
+    expect(rows[0].action).toBe("list");
+    expect(rows[0].resourceType).toBe("trace");
+    expect(rows[0].resourceId).toBe("");
     expect(rows[0].type).toBe("USER");
-    expect(rows[0].before).toBe(
-      JSON.stringify({ name: "old-prompt", content: "Hello World" }),
-    );
+    expect(rows[0].surface).toBe("trpc");
+    expect(rows[0].route).toBe("traces.all");
+    expect(rows[0].params).toBe(JSON.stringify({ projectId, limit: 50 }));
+    expect(rows[0].resultCount).toBe(7);
+    expect(rows[0].before).toBe(null);
     expect(rows[0].after).toBe(null);
 
-    expect(rows[1].action).toBe("UPDATE");
+    expect(rows[1].eventKind).toBe("change");
+    expect(rows[1].action).toBe("update");
     expect(rows[1].resourceType).toBe("score");
     expect(rows[1].type).toBe("API_KEY");
+    expect(rows[1].userId).toBe(null);
     expect(rows[1].before).toBe(JSON.stringify({ value: 0.5 }));
     expect(rows[1].after).toBe(JSON.stringify({ value: 0.8 }));
 
-    expect(rows[2].action).toBe("CREATE");
+    expect(rows[2].action).toBe("create");
     expect(rows[2].resourceType).toBe("trace");
     expect(rows[2].type).toBe("USER");
+    expect(rows[2].userOrgRole).toBe("OWNER");
     expect(rows[2].before).toBe(null);
     expect(rows[2].after).toBe(
       JSON.stringify({ name: "test-trace", version: 1 }),
     );
+    expect(rows[2].createdAt).toEqual(new Date("2024-01-01T10:00:00Z"));
 
-    // Verify all rows have the correct project ID
     rows.forEach((row) => {
       expect(row.projectId).toBe(projectId);
       expect(row.orgId).toBe(orgId);
     });
+
+    // Filters flow through to ClickHouse
+    const filteredStream = await getDatabaseReadStreamPaginated({
+      projectId: projectId,
+      tableName: BatchExportTableName.AuditLogs,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: [
+        {
+          column: "eventKind",
+          type: "stringOptions",
+          operator: "any of",
+          value: ["access"],
+        },
+      ],
+      orderBy: { column: "createdAt", order: "DESC" },
+    });
+    const filteredRows: any[] = [];
+    for await (const chunk of filteredStream) {
+      filteredRows.push(chunk);
+    }
+    expect(filteredRows.map((row) => row.id)).toEqual([auditLogEntries[2].id]);
   });
 
   it("should export traces with searchQuery and searchType filters applied correctly", async () => {

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -28,6 +28,7 @@ import {
   getTracesByIds,
   getScoresForTraces,
   getDatasetItems,
+  getAuditLogs,
   type PreferredClickhouseService,
 } from "@langfuse/shared/src/server";
 import Decimal from "decimal.js";
@@ -48,7 +49,7 @@ const tableNameToTimeFilterColumn: Record<BatchTableNames, string> = {
   datasets: "createdAt",
   dataset_run_items: "createdAt",
   dataset_items: "createdAt", // TODO: flip to validFrom once we write in new format
-  audit_logs: "createdAt",
+  audit_logs: "timestamp",
 };
 const tableNameToTimeFilterColumnCh: Record<BatchTableNames, string> = {
   scores: "timestamp",
@@ -59,7 +60,7 @@ const tableNameToTimeFilterColumnCh: Record<BatchTableNames, string> = {
   datasets: "createdAt",
   dataset_run_items: "createdAt",
   dataset_items: "createdAt",
-  audit_logs: "createdAt",
+  audit_logs: "timestamp",
 };
 const isGenerationTimestampFilter = (
   filter: FilterCondition,
@@ -633,26 +634,31 @@ export const getDatabaseReadStreamPaginated = async ({
     }
 
     case "audit_logs": {
+      const project = await prisma.project.findUnique({
+        where: { id: projectId },
+        select: { orgId: true },
+      });
+      if (!project) {
+        throw new Error(`Project ${projectId} not found`);
+      }
+
       return new DatabaseReadStream<unknown>(
         async (pageSize: number, offset: number) => {
-          const auditLogs = await prisma.auditLog.findMany({
-            where: {
-              projectId: projectId,
-              createdAt: {
-                lt: cutoffCreatedAt,
-              },
-            },
-            orderBy: {
-              createdAt: "desc",
-            },
-            skip: offset,
-            take: pageSize,
+          const auditLogs = await getAuditLogs({
+            orgId: project.orgId,
+            projectId,
+            filter: filter
+              ? [...filter, createdAtCutoffFilter]
+              : [createdAtCutoffFilter],
+            limit: pageSize,
+            offset,
+            clickhouseConfigs,
           });
 
           return auditLogs.map((log) => ({
             id: log.id,
             createdAt: log.createdAt,
-            updatedAt: log.updatedAt,
+            eventKind: log.eventKind,
             type: log.type,
             apiKeyId: log.apiKeyId,
             userId: log.userId,
@@ -663,6 +669,10 @@ export const getDatabaseReadStreamPaginated = async ({
             resourceType: log.resourceType,
             resourceId: log.resourceId,
             action: log.action,
+            surface: log.surface,
+            route: log.route,
+            params: log.params,
+            resultCount: log.resultCount,
             before: log.before,
             after: log.after,
           }));


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17296 app preview](https://pr-17296.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

**4/4**, based on #17295. Base retargets when #17295 lands.

Cuts the audit log read path over from Postgres to the ClickHouse `audit_logs` table and exposes the new access-event data.

- Repository `getAuditLogs` / `getAuditLogsCount` (shared): scoped by `org_id` + `project_id` (`''` for org-level rows), standard `FilterState` filters via `auditLogsTableCols` / `auditLogsTableUiColumnDefinitions`, newest first. Rows are collapsed by id (`LIMIT 1 BY id`, `uniqExact(id)`) because a row can sit twice in unmerged parts while the dual write and the backfill overlap.
- tRPC `auditLogs.all` / `allByOrg` read from ClickHouse and accept `filter`. Actor enrichment (user name/avatar, API key public key) stays in Postgres and is still scoped to the organisation / project so a spoofed id cannot leak another tenant's display data.
- Project and organisation **Audit Logs** settings tables get the filter toolbar (Kind, Actor Type, User ID, API Key ID, Resource Type, Resource ID, Action, Surface, Route, Timestamp) and new columns Kind, Surface, Route, Params, Results.
- The `audit_logs` batch export reads from ClickHouse and honours the table filters. Export columns gain `eventKind`, `surface`, `route`, `params`, `resultCount`; `updatedAt` is dropped (the ClickHouse row has no such field).

Reads do not wait for the backfill: until `backfillAuditLogsToClickhouse` has finished, a page can miss older rows.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm exec turbo run lint typecheck --force` on this branch: `Tasks: 12 successful, 12 total`, `Cached: 0 cached, 12 total`
- `pnpm exec knip`: exit 0
- `web`: `audit-log-read-path.servertest.ts` (2 tests) — ordering, dedup of a double-inserted row, actor resolution incl. a user outside the org, filter by kind, pagination, org-level scope, cross-org isolation, unknown filter column rejected. `batchExport-trpc.servertest.ts` (13) still green.
- `worker`: `batchExport.test.ts` "should export audit logs" rewritten against ClickHouse incl. a filter and a cross-org row.
- Browser, local source-built stack: video below.

<a href="https://cursor.com/agents/bc-275b1cf1-9f61-40d6-852c-7208603fb159/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faudit_logs_change_and_access_events_with_kind_filter.mp4"><img src="https://cursor.com/artifacts/c/art-35b52417-19fd-4f12-a32c-0a50e3f461b1" alt="audit_logs_change_and_access_events_with_kind_filter.mp4" /></a>

![Audit logs table with change and access rows](https://cursor.com/artifacts/c/art-014f7662-05b2-4278-b1c0-f58f86abe448)

## Test it on the preview

1. Open `https://pr-17296.preview.langfuse.com` (URL follows the PR number), sign in, open a project's traces list and a trace.
2. Project Settings → Audit Logs: `access` rows for `events.all` / `events.byTraceId` (or `traces.all` / `traces.byId` on v3) appear with Surface `trpc`, Route and Params.
3. Filters → Kind → `access`, then `change`; scroll right for Params / Results / Before / After.
4. Organization Settings → Audit Logs shows only org-level rows.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-275b1cf1-9f61-40d6-852c-7208603fb159?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-275b1cf1-9f61-40d6-852c-7208603fb159&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62620319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge after addressing the non-blocking empty-page behavior when filters are changed.

<details open><summary><h3>Summary</h3></summary>

- Adds shared ClickHouse audit-log list/count repositories with organization and project scoping.
- Adds audit-log filter definitions and exposes filters in project and organization settings.
- Enriches ClickHouse rows with tenant-scoped user and API-key information from Postgres.
- Switches batch exports to ClickHouse and includes access-event metadata.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Audit Logs UI
  participant API as auditLogs tRPC router
  participant CH as ClickHouse audit_logs
  participant PG as Postgres
  UI->>API: scope, filter, page, limit
  API->>API: Verify entitlement and RBAC
  par Read page and count
    API->>CH: Scoped filtered list, deduplicated by id
    API->>CH: Scoped uniqExact(id) count
  end
  CH-->>API: Audit-log rows and count
  API->>PG: Resolve scoped users and API keys
  PG-->>API: Actor display data
  API-->>UI: Enriched audit-log page
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat(audit-logs): read audit logs from C..."](https://github.com/langfuse/langfuse/commit/fd7644107e6a1b575de41397ef5269a843ad133f)</sub>

<!-- /greptile_comment -->