### PR TITLE
fix(blob-export): raise S3 part size and fail oversized windows loudly

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -11,6 +11,7 @@ export * from "./ingestion/eventBucketPath";
 export * from "./cache";
 export * from "./services/BufferedStreamUploader";
 export * from "./services/S3ChunkedUploadStrategy";
+export * from "./services/s3MultipartLimits";
 export * from "./services/email/transport";
 export * from "./services/email/organizationInvitation/sendMembershipInvitationEmail";
 export * from "./services/email/batchExportSuccess/sendBatchExportSuccessEmail";

--- a/packages/shared/src/server/services/BufferedStreamUploader.ts
+++ b/packages/shared/src/server/services/BufferedStreamUploader.ts
@@ -1,6 +1,12 @@
 import type { Readable } from "stream";
 import { backOff } from "exponential-backoff";
 import { logger } from "../logger";
+import {
+  S3_MAX_PARTS,
+  S3MultipartLimitExceededError,
+  formatGiB,
+  maxBytesForPartSize,
+} from "./s3MultipartLimits";
 
 const TRANSIENT_ERROR_PATTERNS = [
   "socket hang up",
@@ -233,6 +239,25 @@ export class BufferedStreamUploader {
 
   private async enqueuePart(partData: Buffer): Promise<void> {
     this.partNumber++;
+
+    // S3 hard limit: fail fast with a non-retryable error instead of uploading
+    // 10k parts and then failing at CompleteMultipartUpload (or worse: letting
+    // a BullMQ retry re-query a TTL-shrunk window and commit a truncated object
+    // as success — issue #17282). The finally in upload() aborts the multipart
+    // so no orphaned parts are left behind to bill.
+    if (this.partNumber > S3_MAX_PARTS) {
+      const partMiB = (this.params.partSizeBytes / 1024 / 1024).toFixed(1);
+      throw new S3MultipartLimitExceededError(
+        `Blob export for key ${this.params.key} exceeds S3's ${S3_MAX_PARTS}-part limit ` +
+          `at ${partMiB} MiB/part (max ~${formatGiB(maxBytesForPartSize(this.params.partSizeBytes))}). ` +
+          `Increase partSizeBytes and/or shorten the export window (e.g. daily -> hourly).`,
+        {
+          key: this.params.key,
+          partSizeBytes: this.params.partSizeBytes,
+          partsAttempted: this.partNumber,
+        },
+      );
+    }
 
     // Wait for a slot if all concurrent slots are full
     while (

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -31,6 +31,14 @@ import {
 } from "./BufferedStreamUploader";
 import { S3ChunkedUploadStrategy } from "./S3ChunkedUploadStrategy";
 import {
+  S3_DEFAULT_PART_SIZE_BYTES,
+  S3_DEFAULT_QUEUE_SIZE,
+  S3MultipartLimitExceededError,
+  formatGiB,
+  isS3MultipartLimitExceededError,
+  maxBytesForPartSize,
+} from "./s3MultipartLimits";
+import {
   buildS3RequestDiagnostics,
   isS3DiagnosableError,
   type S3DiagnosticsContext,
@@ -827,6 +835,12 @@ class S3StorageService implements StorageService {
     partSize,
     queueSize,
   }: UploadFile): Promise<void> {
+    // lib-storage defaults partSize to 5 MiB and never scales it, capping every
+    // object at 10,000 x 5 MiB = 48.83 GiB ("Exceeded 10000 parts"). Default to
+    // 64 MiB (~625 GiB ceiling) so large blob-export windows don't hit the wall;
+    // callers with an explicit tuning (e.g. blob export 100 MiB) still win.
+    const resolvedPartSize = partSize ?? S3_DEFAULT_PART_SIZE_BYTES;
+    const resolvedQueueSize = queueSize ?? S3_DEFAULT_QUEUE_SIZE;
     try {
       await new Upload({
         client: this.client,
@@ -836,16 +850,31 @@ class S3StorageService implements StorageService {
           Body: data,
           ContentType: fileType,
         }),
-        // Use provided partSize and queueSize, or fall back to defaults
-        // Default: 5 MB part size supports files up to ~50 GB (5 MB × 10,000 parts)
-        // For large files, use partSize: 100 * 1024 * 1024 (100 MB) to support up to ~1 TB
-        partSize: partSize,
-        queueSize: queueSize,
+        partSize: resolvedPartSize,
+        queueSize: resolvedQueueSize,
       }).done();
 
       return;
     } catch (err) {
       logger.error(`Failed to upload file to ${fileName}`, err);
+      if (isS3MultipartLimitExceededError(err)) {
+        // Non-retryable: retrying the same bytes cannot succeed, and for blob
+        // exports a retry re-queries a TTL-shrunk window and can commit a
+        // truncated object as success (issue #17282). Throw a named error so
+        // the worker converts it to BullMQ UnrecoverableError instead of
+        // retrying; the cause chain is preserved for diagnostics.
+        throw new S3MultipartLimitExceededError(
+          `Upload of ${fileName} exceeds S3's 10,000-part limit at ` +
+            `${(resolvedPartSize / 1024 / 1024).toFixed(1)} MiB/part ` +
+            `(max ~${formatGiB(maxBytesForPartSize(resolvedPartSize))}). ` +
+            `Increase partSize and/or shorten the export window (e.g. daily -> hourly).`,
+          {
+            key: fileName,
+            partSizeBytes: resolvedPartSize,
+            cause: err,
+          },
+        );
+      }
       handleStorageError(err, "upload file to S3");
     }
   }
@@ -860,10 +889,17 @@ class S3StorageService implements StorageService {
     stats,
   }: UploadFileBuffered): Promise<UploadPartStats | undefined> {
     if (env.LANGFUSE_S3_UPLOAD_ENABLE_BUFFERED !== "true") {
-      // Tuning applies only on the buffered path. Forward no overrides so the
-      // fallback keeps lib-storage's defaults — forwarding the resolved 100 MiB
-      // partSize would ~20x per-upload memory (buffered is off by default).
-      await this.uploadFile({ fileName, fileType, data });
+      // Fallback is the same lib-storage path as uploadFile, so it must honor
+      // the caller's partSize: dropping the resolved 100 MiB tuning here would
+      // silently reintroduce the 5 MiB SDK default and its 48.83 GiB wall
+      // (issue #17282). Peak lib-storage buffer is ~partSize x queueSize.
+      await this.uploadFile({
+        fileName,
+        fileType,
+        data,
+        partSize: partSizeBytes,
+        queueSize: maxConcurrentParts,
+      });
       return undefined;
     }
 
@@ -893,6 +929,10 @@ class S3StorageService implements StorageService {
       return await uploader.upload(data);
     } catch (err) {
       logger.error(`Failed to upload file (buffered) to ${fileName}`, err);
+      // Preserve the non-retryable identity so the worker can convert it to
+      // BullMQ UnrecoverableError instead of retrying into a TTL-truncated
+      // object. handleStorageError would wrap it and hide the name.
+      if (isS3MultipartLimitExceededError(err)) throw err;
       handleStorageError(err, "upload file to S3 (buffered)");
     }
   }

--- a/packages/shared/src/server/services/s3MultipartLimits.test.ts
+++ b/packages/shared/src/server/services/s3MultipartLimits.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest";
+import { Readable } from "stream";
+
+import {
+  S3_DEFAULT_PART_SIZE_BYTES,
+  S3_MAX_PARTS,
+  S3MultipartLimitExceededError,
+  formatGiB,
+  isS3MultipartLimitExceededError,
+  maxBytesForPartSize,
+} from "./s3MultipartLimits";
+import {
+  BufferedStreamUploader,
+  type ChunkedUploadStrategy,
+} from "./BufferedStreamUploader";
+
+describe("s3MultipartLimits", () => {
+  it("defaults lib-storage parts to 64 MiB for a ~625 GiB ceiling (issue #17282)", () => {
+    expect(S3_DEFAULT_PART_SIZE_BYTES).toBe(64 * 1024 * 1024);
+    expect(S3_MAX_PARTS).toBe(10_000);
+    // 64 MiB x 10k = 625 GiB, ~13x the old 48.83 GiB wall (5 MiB x 10k).
+    expect(maxBytesForPartSize(S3_DEFAULT_PART_SIZE_BYTES)).toBe(
+      64 * 1024 * 1024 * 10_000,
+    );
+    expect(maxBytesForPartSize(5 * 1024 * 1024)).toBe(52_428_800_000);
+    expect(formatGiB(52_428_800_000)).toBe("48.8 GiB");
+  });
+
+  it("detects our named error even through handleStorageError-style wrapping", () => {
+    const inner = new S3MultipartLimitExceededError("too big", {
+      key: "k",
+      partSizeBytes: 1,
+    });
+    const wrapped = new Error("Failed to upload file to S3", {
+      cause: inner,
+    });
+    expect(isS3MultipartLimitExceededError(inner)).toBe(true);
+    expect(isS3MultipartLimitExceededError(wrapped)).toBe(true);
+  });
+
+  it("detects lib-storage's bare 'Exceeded 10000 parts' message", () => {
+    const libStorageError = new Error(
+      "Exceeded 10000 parts in multipart upload to Bucket: b Key: k",
+    );
+    expect(isS3MultipartLimitExceededError(libStorageError)).toBe(true);
+    expect(
+      isS3MultipartLimitExceededError(
+        new Error("Failed to upload", { cause: libStorageError }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not misclassify ordinary upload failures", () => {
+    expect(isS3MultipartLimitExceededError(new Error("socket hang up"))).toBe(
+      false,
+    );
+    expect(isS3MultipartLimitExceededError(new Error("AccessDenied"))).toBe(
+      false,
+    );
+    expect(isS3MultipartLimitExceededError(null)).toBe(false);
+    expect(isS3MultipartLimitExceededError(undefined)).toBe(false);
+  });
+});
+
+describe("BufferedStreamUploader S3 part-count guard", () => {
+  // Plain counters instead of a self-referential strategy object: the mock
+  // closures must not reference the object under construction.
+  const makeStrategy = () => {
+    const counters = { abortCalls: 0, completeCalls: 0 };
+    const strategy: ChunkedUploadStrategy = {
+      initialize: vi.fn(async () => undefined),
+      uploadPart: vi.fn(async (_data: Buffer, partNumber: number) => ({
+        partIdentifier: `etag-${partNumber}`,
+        partNumber,
+      })),
+      complete: vi.fn(async () => {
+        counters.completeCalls++;
+      }),
+      abort: vi.fn(async () => {
+        counters.abortCalls++;
+      }),
+      uploadSingleObject: vi.fn(async () => undefined),
+    };
+    return { strategy, counters };
+  };
+
+  it("fails fast with S3MultipartLimitExceededError past 10k parts and aborts", async () => {
+    const { strategy, counters } = makeStrategy();
+    const partSizeBytes = 5 * 1024 * 1024;
+    const uploader = new BufferedStreamUploader({
+      strategy,
+      partSizeBytes,
+      maxPartAttempts: 1,
+      maxConcurrentParts: 2,
+      key: "langfuse-export/p/observations_v2/2026-09-06T01-20-00.parquet",
+    });
+
+    // 10,001 parts of exactly partSizeBytes each.
+    const onePart = Buffer.alloc(partSizeBytes, 1);
+    async function* gen() {
+      for (let i = 0; i < S3_MAX_PARTS + 1; i++) {
+        yield onePart;
+      }
+    }
+
+    const failure = await uploader
+      .upload(Readable.from(gen()))
+      .then(
+        () => null,
+        (e: unknown) => e,
+      );
+    expect(failure).toBeInstanceOf(S3MultipartLimitExceededError);
+    expect(failure).toMatchObject({ name: "S3MultipartLimitExceededError" });
+    // The worker keys its no-retry path off this predicate (BullMQ
+    // UnrecoverableError), so the thrown error must stay detectable.
+    expect(isS3MultipartLimitExceededError(failure)).toBe(true);
+    // Abort runs on failure so no orphaned parts are left behind to bill.
+    expect(counters.abortCalls).toBeGreaterThanOrEqual(1);
+  });
+
+  it("uploads exactly 10k parts successfully (boundary)", async () => {
+    const { strategy, counters } = makeStrategy();
+    const partSizeBytes = 1024;
+    const uploader = new BufferedStreamUploader({
+      strategy,
+      partSizeBytes,
+      maxPartAttempts: 1,
+      maxConcurrentParts: 4,
+      key: "boundary-key",
+    });
+
+    const onePart = Buffer.alloc(partSizeBytes, 2);
+    async function* gen() {
+      for (let i = 0; i < S3_MAX_PARTS; i++) {
+        yield onePart;
+      }
+    }
+
+    const stats = await uploader.upload(Readable.from(gen()));
+    expect(stats.partsUploaded).toBe(S3_MAX_PARTS);
+    expect(counters.completeCalls).toBe(1);
+  });
+});

--- a/packages/shared/src/server/services/s3MultipartLimits.ts
+++ b/packages/shared/src/server/services/s3MultipartLimits.ts
@@ -1,0 +1,124 @@
+// S3 multipart limits shared by every S3 upload path.
+//
+// S3 caps a multipart upload at 10,000 parts. `@aws-sdk/lib-storage`'s `Upload`
+// defaults to a 5 MiB partSize and does NOT scale it with the payload, so any
+// object over 10,000 x 5 MiB = 52,428,800,000 bytes (48.83 GiB) fails with
+// "Exceeded 10000 parts". The scheduled blob export hit exactly this wall:
+// the upload threw, BullMQ retried, ClickHouse retention TTL shrank the window
+// on each retry, and a truncated object eventually committed as "success"
+// (https://github.com/langfuse/langfuse/issues/17282).
+//
+// The buffered uploader (`BufferedStreamUploader` + `S3ChunkedUploadStrategy`)
+// already takes an explicit partSize (default 100 MiB for blob exports), but
+// the lib-storage fallback (`S3StorageService.uploadFile`) left partSize
+// undefined and inherited the 5 MiB SDK default. Both paths now share these
+// constants and the non-retryable error below.
+
+/** S3 hard limit: maximum parts per multipart upload. */
+export const S3_MAX_PARTS = 10_000;
+
+/** S3 minimum part size (5 MiB). Last part may be smaller. */
+export const S3_MIN_PART_SIZE_BYTES = 5 * 1024 * 1024;
+
+/** S3 maximum part size (5 GiB). */
+export const S3_MAX_PART_SIZE_BYTES = 5 * 1024 * 1024 * 1024;
+
+/**
+ * Default part size for lib-storage uploads when the caller provides none.
+ *
+ * 64 MiB x 10,000 parts = 671,088,640,000 bytes (~625 GiB) ceiling, ~13x the
+ * previous 48.83 GiB wall, at ~256 MiB peak buffer (64 MiB x queueSize 4).
+ * Matches the issue's suggested fix; blob exports that need more use the
+ * buffered path with 100 MiB parts (~953 GiB ceiling).
+ */
+export const S3_DEFAULT_PART_SIZE_BYTES = 64 * 1024 * 1024;
+
+/** Default lib-storage concurrency (matches the SDK default). */
+export const S3_DEFAULT_QUEUE_SIZE = 4;
+
+/** Maximum object size for a given part size under the 10k-part cap. */
+export function maxBytesForPartSize(partSizeBytes: number): number {
+  return Math.floor(partSizeBytes) * S3_MAX_PARTS;
+}
+
+/**
+ * Non-retryable error: the payload needs more than S3's 10,000 parts at the
+ * configured part size. Retrying the same window cannot succeed (and for blob
+ * exports retrying is actively harmful: the ClickHouse retention TTL deletes
+ * the oldest rows between attempts, so a retry can commit a truncated object
+ * as success). Callers must surface this loudly and NOT retry; operators fix
+ * it by raising partSizeBytes and/or shortening the export window (e.g. daily
+ * -> hourly).
+ */
+export class S3MultipartLimitExceededError extends Error {
+  override name = "S3MultipartLimitExceededError";
+  readonly key?: string;
+  readonly partSizeBytes?: number;
+  readonly partsAttempted?: number;
+
+  constructor(
+    message: string,
+    opts?: {
+      key?: string;
+      partSizeBytes?: number;
+      partsAttempted?: number;
+      cause?: unknown;
+    },
+  ) {
+    super(message, opts?.cause !== undefined ? { cause: opts.cause } : undefined);
+    this.key = opts?.key;
+    this.partSizeBytes = opts?.partSizeBytes;
+    this.partsAttempted = opts?.partsAttempted;
+  }
+}
+
+const LIMIT_MESSAGE_PATTERNS = [
+  /exceeded\s+10000\s+parts/i,
+  /exceed.*10000/i,
+  /too\s+many\s+parts/i,
+  /maximum.*parts/i,
+  /part\s*number.*10000/i,
+  /multipart.*limit/i,
+];
+
+function messageMatchesLimit(text: string): boolean {
+  return LIMIT_MESSAGE_PATTERNS.some((p) => p.test(text));
+}
+
+function* errorCauseChain(error: unknown, maxDepth = 10): Generator<object> {
+  let current: unknown = error;
+  for (let depth = 0; depth < maxDepth; depth++) {
+    if (!current || typeof current !== "object") return;
+    yield current as object;
+    current = (current as { cause?: unknown }).cause;
+  }
+}
+
+/**
+ * True when the error (or any link in its cause chain) is a multipart-part-count
+ * limit failure: our own S3MultipartLimitExceededError, or the lib-storage
+ * "Exceeded 10000 parts" (and close variants from S3-compatible stores).
+ */
+export function isS3MultipartLimitExceededError(error: unknown): boolean {
+  for (const link of errorCauseChain(error)) {
+    if ((link as { name?: unknown }).name === "S3MultipartLimitExceededError") {
+      return true;
+    }
+    // `.message` covers lib-storage's bare Error ("Exceeded 10000 parts ...");
+    // `.Code`/`.code` cover S3-compatible stores that surface it as a code.
+    const candidates: unknown[] = [
+      (link as { message?: unknown }).message,
+      (link as { Code?: unknown }).Code,
+      (link as { code?: unknown }).code,
+    ];
+    for (const c of candidates) {
+      if (typeof c === "string" && messageMatchesLimit(c)) return true;
+    }
+  }
+  return false;
+}
+
+/** Human-readable GiB with one decimal, for error/log messages. */
+export function formatGiB(bytes: number): string {
+  return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
+}

--- a/worker/src/features/blobstorage/abortClassification.ts
+++ b/worker/src/features/blobstorage/abortClassification.ts
@@ -59,7 +59,7 @@ const CH_EXCEPTION_PATTERN =
   /db::\w*exception|memory_limit_exceeded|timeout_exceeded|too_many_simultaneous_queries|socket_timeout|cannot_schedule_task/;
 
 const UPLOAD_FAULT_PATTERN =
-  /slowdown|access denied|accessdenied|nosuchupload|nosuchbucket|entitytoolarge|requesttimeout|invalidpart|signaturedoesnotmatch|notimplemented|preconditionfailed/;
+  /slowdown|access denied|accessdenied|nosuchupload|nosuchbucket|entitytoolarge|requesttimeout|invalidpart|signaturedoesnotmatch|notimplemented|preconditionfailed|exceeded.*parts|too many parts|multipart.*limit|s3multipartlimitexceeded/;
 
 // Rarely reaches this path (a BullMQ stall re-enqueues rather than throwing).
 const STALL_PATTERN = /stalled|missing lock|lock.*(lapse|renew)/;

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1,6 +1,6 @@
 import { pipeline, Transform, type Readable } from "stream";
 import { monitorEventLoopDelay } from "perf_hooks";
-import { Job } from "bullmq";
+import { Job, UnrecoverableError } from "bullmq";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   QueueName,
@@ -32,6 +32,7 @@ import {
   blobStorageEndpointConnectionValidationOptions,
   validateBlobStorageEndpoint,
   dispatchProjectNotification,
+  isS3MultipartLimitExceededError,
 } from "@langfuse/shared/src/server";
 import {
   registerInFlightBlobExport,
@@ -1563,7 +1564,12 @@ export const handleBlobStorageIntegrationProjectJob = async (
   } catch (error) {
     const errorMessage = extractStorageErrorMessage(error);
 
-    const isFinalAttempt = isFinalBullmqAttempt(job, error);
+    // Deterministic size fault: never retry (see rethrow below), so treat this
+    // attempt as final for the failure notification even though BullMQ would
+    // otherwise retry 5 times.
+    const isMultipartLimit = isS3MultipartLimitExceededError(error);
+    const isFinalAttempt =
+      isMultipartLimit || isFinalBullmqAttempt(job, error);
     // Defined => disable, on the first occurrence: a config fault cannot succeed
     // on a retry, and the failures metric counts every failed attempt.
     const customerFaultReason = classifyCustomerFault(error);
@@ -1625,6 +1631,16 @@ export const handleBlobStorageIntegrationProjectJob = async (
       `[BLOB INTEGRATION] Error processing blob storage integration for project ${projectId}: ${chain}`,
       error instanceof Error ? { stack: error.stack } : {},
     );
+    // Oversized window (>10k S3 parts) is deterministic: retrying re-queries a
+    // TTL-shrunk window and can commit a truncated object as success (#17282).
+    // Fail permanently so the persisted lastError stays visible instead of being
+    // overwritten by a "successful" truncated retry.
+    if (isS3MultipartLimitExceededError(error)) {
+      const fatal = new UnrecoverableError(chain);
+      (fatal as unknown as { cause?: unknown }).cause = error;
+      if (error instanceof Error) fatal.stack = error.stack;
+      throw fatal;
+    }
     const rethrown = new Error(chain, { cause: error });
     // Copy the original stack so BullMQ and the queue processor see the real
     // failure site rather than this rethrow line. rethrown.stack starts with
@@ -1800,6 +1816,13 @@ async function notifyBlobStorageExportFailed(
 
 function extractStorageErrorMessage(error: unknown): string {
   if (!(error instanceof Error)) return String(error).slice(0, 1000);
+
+  // Multipart-limit errors carry the actionable remediation (raise partSize,
+  // shorten window) on the outer error; the cause is the bare SDK message
+  // ("Exceeded 10000 parts"). Prefer the outer message so lastError stays useful.
+  if (isS3MultipartLimitExceededError(error)) {
+    return error.message.slice(0, 1000);
+  }
 
   // handleStorageError wraps SDK errors via { cause: sdkError }
   // Unwrap to get the raw SDK message (S3/Azure/GCS)


### PR DESCRIPTION
Fixes #17282.

## Problem
Scheduled blob exports used \@aws-sdk/lib-storage\ without a \partSize\, inheriting the 5 MiB SDK default. S3 caps multipart uploads at 10,000 parts, so any window producing a Parquet over 10,000 x 5 MiB = 48.83 GiB failed mid-upload. BullMQ retried, each retry re-queried ClickHouse after retention-TTL deletions had shrunk the window, and a truncated object eventually committed and was reported as a successful export with no visible error state.

## Changes
- \packages/shared\: new \s3MultipartLimits.ts\ — shared constants (\S3_MAX_PARTS\, 64 MiB default part size for a ~625 GiB ceiling), \S3MultipartLimitExceededError\, and \isS3MultipartLimitExceededError()\ (detects our error through \handleStorageError\ wrapping plus lib-storage's bare message).
- \S3StorageService.uploadFile\: default lib-storage \partSize\ to 64 MiB instead of 5 MiB; convert limit failures to the named non-retryable error (cause chain preserved).
- \S3StorageService.uploadFileBuffered\ fallback (buffered disabled): forward the resolved \partSizeBytes\/\maxConcurrentParts\ instead of dropping the 100 MiB tuning back to the 5 MiB default; rethrow limit errors unwrapped.
- \BufferedStreamUploader\: fail fast past 10,000 parts; the existing \inally\ aborts the multipart so no orphaned parts are left behind to bill.
- Worker blob-export handler: convert limit errors to BullMQ \UnrecoverableError\ (no retry into TTL-truncated success), treat as final attempt for the failure notification, and persist the actionable message in \lastError\.
- Abort classification: limit signatures count as concrete \upload-error\.
- Tests: ceiling math, detector (named/wrapped/lib-storage/negatives), uploader 10,001-part failure + abort and 10,000-part boundary.

## Verification
- \	sc --strict\ clean on the new module; detector runtime checks pass (7/7) under node type-stripping.
- Full \itest\ suite not run locally (workspace install is heavy); please let CI run it.

## Out of scope
- Parquet \owCount\ in the manifest (binary stream; would need an extra COUNT query or footer parse). Non-Parquet paths already record it; \sizeBytes\ + persisted \lastError\ now give detection signals.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62644105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until multipart-limit failures remain retryable when their durable error state cannot be persisted.

<details open><summary><h3>Summary</h3></summary>

- Adds shared multipart limits, formatting, and error-detection utilities.
- Propagates multipart tuning through both buffered and lib-storage upload paths.
- Persists actionable oversized-export errors and classifies them as concrete upload failures.
- Adds unit coverage for error detection and the 10,000-part boundary.
- One failure-state edge case remains: a transient database error can prevent `lastError` persistence while the job is still marked unrecoverable.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[ClickHouse export stream] --> B{Upload path}
    B -->|lib-storage| C[64 MiB default parts]
    B -->|buffered| D[Configured parts]
    C --> E{More than 10,000 parts?}
    D --> E
    E -->|No| F[Complete multipart upload]
    E -->|Yes| G[Abort multipart upload]
    G --> H[Persist actionable lastError]
    H --> I[BullMQ UnrecoverableError]
    H -. persistence failure currently still follows .-> I
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(blob-export): raise S3 part size and..."](https://github.com/langfuse/langfuse/commit/7bca10473981e409fefcb2ab6eedae999ae4f707)</sub>

<!-- /greptile_comment -->