### PR TITLE
fix(session): Loosen redesigned session timeline truncation

### DIFF
--- a/web/src/features/sessions/SessionConversationTimeline/ConnectedSessionConversationTimeline.tsx
+++ b/web/src/features/sessions/SessionConversationTimeline/ConnectedSessionConversationTimeline.tsx
@@ -10,7 +10,7 @@ import { type SessionObservation } from "@/src/features/sessions/SessionConversa
 import { type EventSessionTrace } from "@/src/features/sessions/sessionDetailPageTypes";
 import { api, sendAsPostOption, type RouterOutputs } from "@/src/utils/api";
 
-const BATCH_IO_SIZE = 500;
+const BATCH_IO_SIZE = 50;
 
 type EventObservation = RouterOutputs["events"]["all"]["observations"][number];
 type SessionBatchIOQueryResult = {
@@ -109,7 +109,6 @@ export function ConnectedSessionConversationTimeline({
             minStartTime: new Date(Math.min(...timestamps)),
             maxStartTime: new Date(Math.max(...timestamps)),
             truncated: false,
-            ioCharLimit: 10_000,
           },
           {
             ...sendAsPostOption,

--- a/web/src/features/sessions/SessionConversationTimeline/fns/prepareSessionTimelineObservations.clienttest.ts
+++ b/web/src/features/sessions/SessionConversationTimeline/fns/prepareSessionTimelineObservations.clienttest.ts
@@ -215,6 +215,39 @@ describe("prepareSessionTimelineObservations", () => {
     ]);
   });
 
+  it("deduplicates large inherited input throughout a deeply nested trace", () => {
+    const inheritedText = "large inherited input ".repeat(600);
+    const inheritedInput = [{ role: "user", content: inheritedText }];
+    const observations = [
+      observation("level-0", inheritedInput, null, "AGENT"),
+    ];
+    for (let level = 1; level < 25; level += 1) {
+      observations.push(
+        observation(
+          `level-${level}`,
+          inheritedInput,
+          null,
+          "AGENT",
+          new Date(level),
+          "trace-1",
+          `level-${level - 1}`,
+        ),
+      );
+    }
+
+    const prepared = prepareSessionTimelineObservations(observations);
+    const visibleText = prepared.flatMap(({ processedMessages }) =>
+      processedMessages.messages.flatMap((message) =>
+        message.parts.flatMap((part) =>
+          part.type === "text" ? [part.text] : [],
+        ),
+      ),
+    );
+
+    expect(inheritedText.length).toBeGreaterThan(10_000);
+    expect(visibleText).toEqual([inheritedText]);
+  });
+
   it("emits rolled-up tool calls as nested items before generation output", () => {
     const prepared = prepareSessionTimelineObservations([
       observation("generation", "Question", [


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17299 app preview](https://pr-17299.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62648999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with a non-blocking concern that uncapped observation payloads can cause excessive bandwidth and browser-memory consumption for unusually large sessions.

<details open><summary><h3>Summary</h3></summary>

- Reduces observation I/O batches from 500 to 50 records.
- Removes the per-value 10,000-character limit from timeline batch requests.
- Adds coverage for deduplicating a large inherited input across a deeply nested trace.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(session): Redesigned session timelin..."](https://github.com/langfuse/langfuse/commit/913afc048a4310a7454979d65ea4124d0053b8b1)</sub>

<!-- /greptile_comment -->