### PR TITLE
fix(worker): guard token-count worker pool against shutdown races

### DIFF
--- a/worker/src/__tests__/tokenCountWorkerShutdown.unit.test.ts
+++ b/worker/src/__tests__/tokenCountWorkerShutdown.unit.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { type Model } from "@langfuse/shared";
+
+// Stand in for a real worker_threads Worker so the pool spins up without
+// spawning threads. postMessage echoes a successful result synchronously,
+// which is enough to prove the live path still resolves. Hoisted so the
+// vi.mock factory can close over both the class and the instance registry.
+const { workerInstances, FakeWorker } = vi.hoisted(() => {
+  const instances: any[] = [];
+  class FakeWorker {
+    handlers: Record<string, (arg: any) => void> = {};
+    postMessage = vi.fn((msg: { id: string }) => {
+      this.handlers["message"]?.({ id: msg.id, result: 7, error: null });
+    });
+    terminate = vi.fn(async () => {});
+    constructor() {
+      instances.push(this);
+    }
+    on(event: string, cb: (arg: any) => void) {
+      this.handlers[event] = cb;
+    }
+  }
+  return { workerInstances: instances, FakeWorker };
+});
+
+vi.mock("worker_threads", () => ({ Worker: FakeWorker }));
+vi.mock("@langfuse/shared/src/server", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+vi.mock("../env", () => ({
+  env: { LANGFUSE_TOKEN_COUNT_WORKER_POOL_SIZE: 2 },
+}));
+
+import { TokenCountWorkerManager } from "../features/tokenisation/async-usage";
+
+const model = { id: "m", tokenizerId: "openai" } as unknown as Model;
+
+const totalPostMessages = () =>
+  workerInstances.reduce((n, w) => n + w.postMessage.mock.calls.length, 0);
+
+describe("TokenCountWorkerManager shutdown guard", () => {
+  beforeEach(() => {
+    workerInstances.length = 0;
+  });
+
+  it("returns the worker result while the pool is live", async () => {
+    const manager = new TokenCountWorkerManager(2);
+
+    await expect(manager.tokenCount({ model, text: "hi" })).resolves.toBe(7);
+  });
+
+  it("drops the count instead of throwing once the pool is terminated", async () => {
+    const manager = new TokenCountWorkerManager(2);
+    await manager.terminate();
+
+    const postsBefore = totalPostMessages();
+    await expect(
+      manager.tokenCount({ model, text: "hi" }),
+    ).resolves.toBeUndefined();
+    expect(totalPostMessages()).toBe(postsBefore);
+  });
+});

--- a/worker/src/__tests__/tokenCountWorkerShutdown.unit.test.ts
+++ b/worker/src/__tests__/tokenCountWorkerShutdown.unit.test.ts
@@ -2,30 +2,39 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { type Model } from "@langfuse/shared";
 
 // Stand in for a real worker_threads Worker so the pool spins up without
-// spawning threads. postMessage echoes a successful result synchronously,
-// which is enough to prove the live path still resolves. Hoisted so the
-// vi.mock factory can close over both the class and the instance registry.
-const { workerInstances, FakeWorker } = vi.hoisted(() => {
-  const instances: any[] = [];
-  class FakeWorker {
-    handlers: Record<string, (arg: any) => void> = {};
-    postMessage = vi.fn((msg: { id: string }) => {
-      this.handlers["message"]?.({ id: msg.id, result: 7, error: null });
-    });
-    terminate = vi.fn(async () => {});
-    constructor() {
-      instances.push(this);
+// spawning threads. postMessage echoes a successful result synchronously
+// while `autoRespond` is set, which is enough to prove the live path
+// resolves; disabling it leaves a request in flight so the shutdown drop
+// can be observed. Hoisted so the vi.mock factory can close over the class,
+// the instance registry, and the response toggle.
+const { workerInstances, FakeWorker, control, recordIncrement } = vi.hoisted(
+  () => {
+    const instances: any[] = [];
+    const control = { autoRespond: true };
+    const recordIncrement = vi.fn();
+    class FakeWorker {
+      handlers: Record<string, (arg: any) => void> = {};
+      postMessage = vi.fn((msg: { id: string }) => {
+        if (control.autoRespond) {
+          this.handlers["message"]?.({ id: msg.id, result: 7, error: null });
+        }
+      });
+      terminate = vi.fn(async () => {});
+      constructor() {
+        instances.push(this);
+      }
+      on(event: string, cb: (arg: any) => void) {
+        this.handlers[event] = cb;
+      }
     }
-    on(event: string, cb: (arg: any) => void) {
-      this.handlers[event] = cb;
-    }
-  }
-  return { workerInstances: instances, FakeWorker };
-});
+    return { workerInstances: instances, FakeWorker, control, recordIncrement };
+  },
+);
 
 vi.mock("worker_threads", () => ({ Worker: FakeWorker }));
 vi.mock("@langfuse/shared/src/server", () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+  recordIncrement,
 }));
 vi.mock("../env", () => ({
   env: { LANGFUSE_TOKEN_COUNT_WORKER_POOL_SIZE: 2 },
@@ -41,6 +50,8 @@ const totalPostMessages = () =>
 describe("TokenCountWorkerManager shutdown guard", () => {
   beforeEach(() => {
     workerInstances.length = 0;
+    control.autoRespond = true;
+    recordIncrement.mockClear();
   });
 
   it("returns the worker result while the pool is live", async () => {
@@ -58,5 +69,27 @@ describe("TokenCountWorkerManager shutdown guard", () => {
       manager.tokenCount({ model, text: "hi" }),
     ).resolves.toBeUndefined();
     expect(totalPostMessages()).toBe(postsBefore);
+  });
+
+  it("resolves in-flight requests as undefined and records one summary metric on terminate", async () => {
+    const manager = new TokenCountWorkerManager(2);
+    control.autoRespond = false;
+
+    const inFlight = manager.tokenCount({ model, text: "hi" });
+    await manager.terminate();
+
+    await expect(inFlight).resolves.toBeUndefined();
+    expect(recordIncrement).toHaveBeenCalledTimes(1);
+    expect(recordIncrement).toHaveBeenCalledWith(
+      "langfuse.tokenisation.skipped_on_shutdown",
+      1,
+    );
+  });
+
+  it("does not record the shutdown metric when nothing is in flight", async () => {
+    const manager = new TokenCountWorkerManager(2);
+    await manager.terminate();
+
+    expect(recordIncrement).not.toHaveBeenCalled();
   });
 });

--- a/worker/src/__tests__/tokenCountWorkerShutdown.unit.test.ts
+++ b/worker/src/__tests__/tokenCountWorkerShutdown.unit.test.ts
@@ -60,15 +60,20 @@ describe("TokenCountWorkerManager shutdown guard", () => {
     await expect(manager.tokenCount({ model, text: "hi" })).resolves.toBe(7);
   });
 
-  it("drops the count instead of throwing once the pool is terminated", async () => {
+  it("drops the count and records the metric for calls made after terminate", async () => {
     const manager = new TokenCountWorkerManager(2);
     await manager.terminate();
+    recordIncrement.mockClear();
 
     const postsBefore = totalPostMessages();
     await expect(
       manager.tokenCount({ model, text: "hi" }),
     ).resolves.toBeUndefined();
     expect(totalPostMessages()).toBe(postsBefore);
+    expect(recordIncrement).toHaveBeenCalledWith(
+      "langfuse.tokenisation.skipped_on_shutdown",
+      1,
+    );
   });
 
   it("resolves in-flight requests as undefined and records one summary metric on terminate", async () => {

--- a/worker/src/features/tokenisation/async-usage.ts
+++ b/worker/src/features/tokenisation/async-usage.ts
@@ -1,6 +1,6 @@
 import { Worker } from "worker_threads";
 import { Model } from "@langfuse/shared";
-import { logger } from "@langfuse/shared/src/server";
+import { logger, recordIncrement } from "@langfuse/shared/src/server";
 import path from "path";
 import { env } from "../../env";
 
@@ -171,7 +171,18 @@ export class TokenCountWorkerManager {
     // workers. Resolve them with undefined (usage unknown) rather than
     // rejecting: dropping counts during shutdown is expected, not an error,
     // and a rejection is logged per request by the caller as a tokenization
-    // failure.
+    // failure. Emit one summary metric instead so the drops stay observable
+    // without the per-request log spam that spiked on rollouts.
+    const droppedOnShutdown = this.pool.pendingRequests.size;
+    if (droppedOnShutdown > 0) {
+      recordIncrement(
+        "langfuse.tokenisation.skipped_on_shutdown",
+        droppedOnShutdown,
+      );
+      logger.info(
+        `Dropped ${droppedOnShutdown} in-flight token-count request(s) on shutdown.`,
+      );
+    }
     for (const [, request] of this.pool.pendingRequests.entries()) {
       clearTimeout(request.timeout);
       request.resolve(undefined);

--- a/worker/src/features/tokenisation/async-usage.ts
+++ b/worker/src/features/tokenisation/async-usage.ts
@@ -124,12 +124,12 @@ export class TokenCountWorkerManager {
     params: { model: Model; text: unknown },
     timeoutMs = 30000,
   ): Promise<number | undefined> {
-    // A SIGTERM teardown terminates the pool while ingestion may still call
-    // in. Drop the count (undefined = usage unknown, which the caller commits
-    // as absent rather than as a zero) instead of posting to a terminating or
-    // already-gone worker, which threw and was logged per observation as a
-    // tokenization failure — the spike seen on rollouts.
+    // Once the pool is terminating, drop the count instead of posting to a
+    // terminating or already-gone worker. undefined means usage unknown, which
+    // the caller commits as absent rather than as a zero; count the drop so it
+    // stays observable.
     if (this.isShuttingDown) {
+      recordIncrement("langfuse.tokenisation.skipped_on_shutdown", 1);
       return undefined;
     }
 
@@ -169,10 +169,8 @@ export class TokenCountWorkerManager {
 
     // In-flight requests can no longer get a response from the terminating
     // workers. Resolve them with undefined (usage unknown) rather than
-    // rejecting: dropping counts during shutdown is expected, not an error,
-    // and a rejection is logged per request by the caller as a tokenization
-    // failure. Emit one summary metric instead so the drops stay observable
-    // without the per-request log spam that spiked on rollouts.
+    // rejecting, and count the drop so it stays observable without the caller
+    // logging each one as a tokenization failure.
     const droppedOnShutdown = this.pool.pendingRequests.size;
     if (droppedOnShutdown > 0) {
       recordIncrement(

--- a/worker/src/features/tokenisation/async-usage.ts
+++ b/worker/src/features/tokenisation/async-usage.ts
@@ -124,11 +124,11 @@ export class TokenCountWorkerManager {
     params: { model: Model; text: unknown },
     timeoutMs = 30000,
   ): Promise<number | undefined> {
-    // A SIGTERM teardown terminates the pool while ingestion may still be
-    // in-flight. Drop the count instead of posting to a dead thread (which
-    // threw and was logged as a tokenization failure, spiking on rollouts);
-    // the caller commits the observation without usage, as it does for any
-    // tokenization miss.
+    // A SIGTERM teardown terminates the pool while ingestion may still call
+    // in. Drop the count (undefined = usage unknown, which the caller commits
+    // as absent rather than as a zero) instead of posting to a terminating or
+    // already-gone worker, which threw and was logged per observation as a
+    // tokenization failure — the spike seen on rollouts.
     if (this.isShuttingDown) {
       return undefined;
     }
@@ -167,9 +167,11 @@ export class TokenCountWorkerManager {
     // workers' own exit/error events see the shutdown and stop early.
     this.isShuttingDown = true;
 
-    // Resolve in-flight requests as misses rather than rejecting: the caller
-    // treats a rejection as a tokenization failure and logs it per request,
-    // which is exactly the shutdown-time noise this guard removes.
+    // In-flight requests can no longer get a response from the terminating
+    // workers. Resolve them with undefined (usage unknown) rather than
+    // rejecting: dropping counts during shutdown is expected, not an error,
+    // and a rejection is logged per request by the caller as a tokenization
+    // failure.
     for (const [, request] of this.pool.pendingRequests.entries()) {
       clearTimeout(request.timeout);
       request.resolve(undefined);

--- a/worker/src/features/tokenisation/async-usage.ts
+++ b/worker/src/features/tokenisation/async-usage.ts
@@ -17,11 +17,12 @@ interface TokenCountWorkerPool {
   >;
 }
 
-class TokenCountWorkerManager {
+export class TokenCountWorkerManager {
   private pool: TokenCountWorkerPool;
   private readonly workerPath: string;
   private readonly poolSize: number;
   private requestCounter = 0;
+  private isShuttingDown = false;
 
   constructor(poolSize: number) {
     this.poolSize = poolSize;
@@ -71,12 +72,15 @@ class TokenCountWorkerManager {
     );
 
     worker.on("error", (error) => {
+      // Terminating workers surface as errors/non-zero exits; don't respawn
+      // into a pool we are tearing down.
+      if (this.isShuttingDown) return;
       logger.error("Worker thread error:", error);
-      // Recreate worker on error
       this.replaceWorker(worker);
     });
 
     worker.on("exit", (code) => {
+      if (this.isShuttingDown) return;
       if (code !== 0) {
         logger.error(`Worker stopped with exit code ${code}`);
         this.replaceWorker(worker);
@@ -106,7 +110,10 @@ class TokenCountWorkerManager {
     }
   }
 
-  private getNextWorker(): Worker {
+  private getNextWorker(): Worker | undefined {
+    if (this.pool.workers.length === 0) {
+      return undefined;
+    }
     const worker = this.pool.workers[this.pool.currentWorkerIndex];
     this.pool.currentWorkerIndex =
       (this.pool.currentWorkerIndex + 1) % this.poolSize;
@@ -117,9 +124,23 @@ class TokenCountWorkerManager {
     params: { model: Model; text: unknown },
     timeoutMs = 30000,
   ): Promise<number | undefined> {
+    // A SIGTERM teardown terminates the pool while ingestion may still be
+    // in-flight. Drop the count instead of posting to a dead thread (which
+    // threw and was logged as a tokenization failure, spiking on rollouts);
+    // the caller commits the observation without usage, as it does for any
+    // tokenization miss.
+    if (this.isShuttingDown) {
+      return undefined;
+    }
+
     return new Promise((resolve, reject) => {
       const id = `token-count-${++this.requestCounter}-${Date.now()}`;
       const worker = this.getNextWorker();
+
+      if (!worker) {
+        resolve(undefined);
+        return;
+      }
 
       const timeout = setTimeout(() => {
         this.pool.pendingRequests.delete(id);
@@ -142,14 +163,19 @@ class TokenCountWorkerManager {
   }
 
   async terminate() {
-    // Clear all pending requests
+    // Set before touching the pool so concurrent tokenCount() calls and the
+    // workers' own exit/error events see the shutdown and stop early.
+    this.isShuttingDown = true;
+
+    // Resolve in-flight requests as misses rather than rejecting: the caller
+    // treats a rejection as a tokenization failure and logs it per request,
+    // which is exactly the shutdown-time noise this guard removes.
     for (const [, request] of this.pool.pendingRequests.entries()) {
       clearTimeout(request.timeout);
-      request.reject(new Error("Worker pool is terminating"));
+      request.resolve(undefined);
     }
     this.pool.pendingRequests.clear();
 
-    // Terminate all workers
     await Promise.all(this.pool.workers.map((worker) => worker.terminate()));
     this.pool.workers = [];
   }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17300 app preview](https://pr-17300.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

> 🤖 Written by Claude (an AI agent) on behalf of Niklas.

## What does this PR do?

The async token-count worker pool (`TokenCountWorkerManager`) posted to worker threads unconditionally, so tokenizations racing a SIGTERM teardown threw and silently dropped token counts (usage/cost missing for those observations). Two windows:

- **During terminate**: a call posts to an already-terminating thread → throws.
- **After terminate**: `getNextWorker()` returns `undefined` → `TypeError: Cannot read properties of undefined (reading 'postMessage')`.

Both were caught by the ingestion caller and logged per-observation as `Async tokenization failed … Skipping token counts`, spiking during mass-restart/rollout waves (many simultaneous SIGTERMs).

Fix:
- Add an `isShuttingDown` flag; `tokenCount()` no-ops (returns `undefined`, the same outcome as any tokenization miss) once the pool is terminating.
- `getNextWorker()` handles an empty pool.
- The workers' own `exit`/`error` events no longer respawn into a pool being torn down.
- `terminate()` resolves in-flight requests as misses instead of rejecting, since a rejection is logged per request — the very shutdown-time noise this removes.

Regression test spins up the pool with a stubbed `worker_threads` Worker and asserts `tokenCount()` resolves `undefined` after `terminate()` instead of throwing; verified to reproduce the exact `TypeError` without the guard.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] The change is tested (`worker` unit test)
- [x] Lint and typecheck pass locally



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62651644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no actionable correctness, security, or repository-rule violations remain.

<details open><summary><h3>Summary</h3></summary>

- Prevents new token-count requests from posting to terminating or removed workers.
- Resolves in-flight requests as unknown usage rather than emitting per-request failures.
- Suppresses worker replacement during teardown and records a summarized shutdown-drop metric.
- Adds unit coverage for live requests, post-termination requests, in-flight shutdown handling, and metric emission.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tokenCount request] --> B{Pool shutting down?}
    B -- Yes --> C[Resolve undefined]
    B -- No --> D{Worker available?}
    D -- No --> C
    D -- Yes --> E[Register pending request]
    E --> F[Post to worker]
    F --> G[Resolve token count or reject on failure]
    H[terminate called] --> I[Set shutdown flag]
    I --> J[Record number of pending requests]
    J --> K[Resolve pending requests as undefined]
    K --> L[Terminate workers]
    L --> M[Ignore shutdown exit events]
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["feat(worker): count token-count requests..."](https://github.com/langfuse/langfuse/commit/8f8f97b0b8cc4d7c8e5a8b39440572c19e66fa5c)</sub>

<!-- /greptile_comment -->