### PR TITLE
feat(ai-gateway): resolve trusted executions through Web

### DIFF
--- a/ai-gateway/Cargo.lock
+++ b/ai-gateway/Cargo.lock
@@ -7,7 +7,12 @@ name = "ai-gateway"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "futures-util",
+ "hmac",
+ "reqwest",
  "serde",
+ "serde_json",
+ "sha2",
  "tokio",
  "tower",
  "tracing",
@@ -69,10 +74,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -81,13 +123,111 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -106,6 +246,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,9 +269,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "rand_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -186,6 +384,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -194,20 +409,149 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -220,6 +564,24 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchit"
@@ -247,7 +609,7 @@ checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -255,6 +617,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "percent-encoding"
@@ -269,6 +637,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,12 +655,249 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustls"
+version = "0.23.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -341,6 +955,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +985,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -378,8 +1021,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -408,6 +1063,40 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
 
 [[package]]
 name = "thread_local"
@@ -417,6 +1106,31 @@ checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -431,7 +1145,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -443,6 +1157,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.5",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -458,6 +1182,24 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -529,10 +1271,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "valuable"
@@ -541,10 +1319,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "windows-link"
@@ -554,11 +1422,173 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/ai-gateway/Cargo.lock
+++ b/ai-gateway/Cargo.lock
@@ -87,11 +87,11 @@ checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -135,9 +135,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.1",
+ "cpufeatures",
  "rand_core",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -157,15 +169,6 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
@@ -175,23 +178,32 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
@@ -276,16 +288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
 ]
@@ -365,6 +367,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f864f10dfb56725ce5ce5472bc52252c8f93a4ab86327122cebf62c5f59a17"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -968,12 +979,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -1317,12 +1328,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/ai-gateway/Cargo.toml
+++ b/ai-gateway/Cargo.toml
@@ -21,6 +21,11 @@ futures-util = "0.3"
 tokio = { version = "1.53.1", features = ["io-util"] }
 tower = { version = "0.5", features = ["util"] }
 
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+# Avoid requiring annotations on every side-effect-free getter.
+must_use_candidate = "allow"
+
 [profile.release]
 lto = "thin"
 strip = true

--- a/ai-gateway/Cargo.toml
+++ b/ai-gateway/Cargo.toml
@@ -7,11 +7,11 @@ license = "MIT"
 
 [dependencies]
 axum = { version = "0.8.9", default-features = false, features = ["http1", "json", "tokio"] }
-hmac = "0.12"
+hmac = "0.13"
 reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls-native-roots"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.11"
 tokio = { version = "1.53.1", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["fmt", "json"] }

--- a/ai-gateway/Cargo.toml
+++ b/ai-gateway/Cargo.toml
@@ -7,12 +7,17 @@ license = "MIT"
 
 [dependencies]
 axum = { version = "0.8.9", default-features = false, features = ["http1", "json", "tokio"] }
+hmac = "0.12"
+reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls-native-roots"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
 tokio = { version = "1.53.1", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["fmt", "json"] }
 
 [dev-dependencies]
+futures-util = "0.3"
 tokio = { version = "1.53.1", features = ["io-util"] }
 tower = { version = "0.5", features = ["util"] }
 

--- a/ai-gateway/README.md
+++ b/ai-gateway/README.md
@@ -112,25 +112,27 @@ probes, missing inference routes and a clean SIGTERM exit, then removes it.
 ### Web resolution client
 
 `resolution::Resolver` resolves a gateway key through an operator-configured Web
-origin. It is a library boundary; the binary does not initialize it yet. The
+base URL. It is a library boundary; the binary does not initialize it yet. The
 caller supplies the existing `LANGFUSE_AI_GATEWAY_SERVICE_KEY` and a trusted Web
-origin to `ResolverConfig::new`. HTTPS is required except on loopback for local
-development. Origins cannot contain credentials, a path prefix, query or fragment.
+base URL to `ResolverConfig::new`. HTTPS is required except on loopback for local
+development. URLs cannot contain credentials, a query or fragment. Include the
+Web deployment's `NEXT_PUBLIC_BASE_PATH`, if set: both `https://host/app` and
+`https://host/app/` resolve through `/app/api/internal/ai-gateway/v1/resolve`.
 
 ```rust,no_run
 use ai_gateway::resolution::{ApiFormat, ResolveError, Resolver, ResolverConfig};
 
-async fn example(web_origin: &str, service_key: &str, gateway_key: &str)
+async fn example(web_base_url: &str, service_key: &str, gateway_key: &str)
     -> Result<(), ResolveError>
 {
-    let resolver = Resolver::new(ResolverConfig::new(web_origin, service_key)?)?;
+    let resolver = Resolver::new(ResolverConfig::new(web_base_url, service_key)?)?;
     let execution = resolver.resolve(gateway_key, ApiFormat::OpenAiResponses).await?;
     assert_eq!(execution.connection().base_url(), "https://api.openai.com/v1");
     Ok(())
 }
 ```
 
-Each call sends `POST /api/internal/ai-gateway/v1/resolve` with
+Each call sends `POST <base path>/api/internal/ai-gateway/v1/resolve` with
 `Authorization: Bearer <gateway key>`, the Web v1 HMAC header, and exactly
 `{"apiFormat":"openai.responses"}`. The client neither receives nor parses an
 inference request body. Reuse the resolver across requests: its connection pool is
@@ -176,7 +178,7 @@ cargo test --locked
 - `server.rs`: router, probe state and bounded graceful shutdown. A listener and
   shutdown future are injected, so tests do not depend on fixed ports or signals.
 - `main.rs`: configuration, logging, signal registration and process exit.
-- `resolution/mod.rs`: trusted-origin configuration and bounded Web HTTP client.
+- `resolution/mod.rs`: trusted base URL configuration and bounded Web HTTP client.
 - `resolution/contracts.rs`: strict Web response validation and immutable execution context.
 - `resolution/signing.rs`: Web v1 HMAC; a literal shared fixture pins byte compatibility.
 - `tests/support`: local ephemeral-port HTTP servers with injected Axum routers.

--- a/ai-gateway/README.md
+++ b/ai-gateway/README.md
@@ -1,8 +1,8 @@
 # AI Gateway service foundation
 
 A standalone Rust HTTP process with health probes, bounded shutdown, structured
-logs and a container. Inference, Web resolution and customer telemetry are not
-implemented yet; inference paths return 404. No Web, database or provider
+logs and a container, with a tested Web resolution client library. Inference and
+customer telemetry are not implemented yet; inference paths return 404. No Web, database or provider
 credentials are needed to build, start or test this package.
 
 ## Run locally
@@ -109,6 +109,43 @@ probes, missing inference routes and a clean SIGTERM exit, then removes it.
 
 ## Tests and module boundaries
 
+### Web resolution client
+
+`resolution::Resolver` resolves a gateway key through an operator-configured Web
+origin. It is a library boundary; the binary does not initialize it yet. The
+caller supplies the existing `LANGFUSE_AI_GATEWAY_SERVICE_KEY` and a trusted Web
+origin to `ResolverConfig::new`. HTTPS is required except on loopback for local
+development. Origins cannot contain credentials, a path prefix, query or fragment.
+
+```rust,no_run
+use ai_gateway::resolution::{ApiFormat, ResolveError, Resolver, ResolverConfig};
+
+async fn example(web_origin: &str, service_key: &str, gateway_key: &str)
+    -> Result<(), ResolveError>
+{
+    let resolver = Resolver::new(ResolverConfig::new(web_origin, service_key)?)?;
+    let execution = resolver.resolve(gateway_key, ApiFormat::OpenAiResponses).await?;
+    assert_eq!(execution.connection().base_url(), "https://api.openai.com/v1");
+    Ok(())
+}
+```
+
+Each call sends `POST /api/internal/ai-gateway/v1/resolve` with
+`Authorization: Bearer <gateway key>`, the Web v1 HMAC header, and exactly
+`{"apiFormat":"openai.responses"}`. The client neither receives nor parses an
+inference request body. Reuse the resolver across requests: its connection pool is
+shared, while credentials and execution contexts stay request-local.
+
+The whole HTTP exchange has a five-second deadline and a 256 KiB response limit,
+including chunked responses. Redirects, automatic retries, ambient proxy settings
+and transparent decompression are disabled. Errors expose fixed categories;
+upstream error bodies and transport details are discarded. Successful responses
+must match the strict v1 schema, the official OpenAI Responses connection, and an
+unexpired project ingestion grant. Ingestion tokens remain opaque. Resolution
+caching, provider execution and telemetry are separate slices.
+
+### Verification
+
 From the repository root:
 
 ```sh
@@ -139,6 +176,9 @@ cargo test --locked
 - `server.rs`: router, probe state and bounded graceful shutdown. A listener and
   shutdown future are injected, so tests do not depend on fixed ports or signals.
 - `main.rs`: configuration, logging, signal registration and process exit.
+- `resolution/mod.rs`: trusted-origin configuration and bounded Web HTTP client.
+- `resolution/contracts.rs`: strict Web response validation and immutable execution context.
+- `resolution/signing.rs`: Web v1 HMAC; a literal shared fixture pins byte compatibility.
 - `tests/support`: local ephemeral-port HTTP servers with injected Axum routers.
   `fake_dependency_records_requests_and_returns_scripted_response` demonstrates
   configurable status/body/headers and request recording. Specialized provider

--- a/ai-gateway/src/config.rs
+++ b/ai-gateway/src/config.rs
@@ -26,6 +26,11 @@ impl fmt::Display for ConfigError {
 impl Error for ConfigError {}
 
 impl Config {
+    /// Read gateway configuration from the process environment, using defaults for absent values.
+    ///
+    /// # Errors
+    /// Returns an error if a configured value is not Unicode or fails validation
+    /// in [`Self::from_values`]. Error messages never include the supplied values.
     pub fn from_env() -> Result<Self, ConfigError> {
         Self::from_values(
             read_env("LANGFUSE_AI_GATEWAY_LISTEN_ADDRESS")?.as_deref(),
@@ -35,6 +40,11 @@ impl Config {
         )
     }
 
+    /// Parse gateway configuration, using defaults for absent values.
+    ///
+    /// # Errors
+    /// Returns an error for an invalid IP address and port, a shutdown timeout outside
+    /// 1–300 integer seconds, or an unsupported log level or format.
     pub fn from_values(
         listen_address: Option<&str>,
         shutdown_timeout: Option<&str>,

--- a/ai-gateway/src/lib.rs
+++ b/ai-gateway/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod config;
+pub mod resolution;
 pub mod server;

--- a/ai-gateway/src/resolution/contracts.rs
+++ b/ai-gateway/src/resolution/contracts.rs
@@ -1,0 +1,186 @@
+use super::{ResolveError, valid_token};
+use serde::{
+    Deserialize, Deserializer, Serialize,
+    de::{DeserializeOwned, IntoDeserializer},
+};
+use std::{collections::BTreeMap, fmt};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+pub enum ApiFormat {
+    #[serde(rename = "openai.responses")]
+    OpenAiResponses,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IngestionMode {
+    Usage,
+    Full,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(untagged)]
+pub enum MetadataValue {
+    String(String),
+    Number(serde_json::Number),
+    Bool(bool),
+}
+
+#[derive(Deserialize)]
+enum Provider {
+    #[serde(rename = "openai")]
+    OpenAi,
+}
+
+#[derive(Deserialize)]
+enum TokenType {
+    Bearer,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Auth {
+    #[serde(rename = "type", deserialize_with = "string_enum")]
+    _token_type: TokenType,
+    token: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Connection {
+    id: String,
+    #[serde(rename = "provider", deserialize_with = "string_enum")]
+    _provider: Provider,
+    #[serde(deserialize_with = "string_enum")]
+    api_format: ApiFormat,
+    base_url: String,
+    auth: Auth,
+}
+
+impl Connection {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+    pub fn api_format(&self) -> ApiFormat {
+        self.api_format
+    }
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+    pub fn provider_token(&self) -> &str {
+        &self.auth.token
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Attribution {
+    organization_id: String,
+    project_id: String,
+    key_id: String,
+    key_metadata: BTreeMap<String, MetadataValue>,
+}
+
+impl Attribution {
+    pub fn organization_id(&self) -> &str {
+        &self.organization_id
+    }
+    pub fn project_id(&self) -> &str {
+        &self.project_id
+    }
+    pub fn key_id(&self) -> &str {
+        &self.key_id
+    }
+    pub fn key_metadata(&self) -> &BTreeMap<String, MetadataValue> {
+        &self.key_metadata
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Ingestion {
+    access_token: String,
+    #[serde(rename = "token_type", deserialize_with = "string_enum")]
+    _token_type: TokenType,
+    expires_at: u64,
+}
+
+impl Ingestion {
+    pub fn access_token(&self) -> &str {
+        &self.access_token
+    }
+    pub fn expires_at(&self) -> u64 {
+        self.expires_at
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Response {
+    version: u8,
+    connection: Connection,
+    attribution: Attribution,
+    #[serde(deserialize_with = "string_enum")]
+    ingestion_mode: IngestionMode,
+    ingestion: Ingestion,
+}
+
+/// A validated v1 execution. Construction is restricted to successful resolution.
+pub struct ResolvedExecution(Response);
+
+// Web enums are JSON strings. Serde's externally tagged enums also accept objects.
+fn string_enum<'de, D: Deserializer<'de>, T: DeserializeOwned>(
+    deserializer: D,
+) -> Result<T, D::Error> {
+    T::deserialize(String::deserialize(deserializer)?.into_deserializer())
+}
+
+impl ResolvedExecution {
+    pub fn connection(&self) -> &Connection {
+        &self.0.connection
+    }
+    pub fn attribution(&self) -> &Attribution {
+        &self.0.attribution
+    }
+    pub fn ingestion_mode(&self) -> IngestionMode {
+        self.0.ingestion_mode
+    }
+    pub fn ingestion(&self) -> &Ingestion {
+        &self.0.ingestion
+    }
+}
+
+impl fmt::Debug for ResolvedExecution {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResolvedExecution").finish_non_exhaustive()
+    }
+}
+
+pub(super) fn decode(
+    bytes: &[u8],
+    expected_format: ApiFormat,
+    now: u64,
+) -> Result<ResolvedExecution, ResolveError> {
+    let response: Response =
+        serde_json::from_slice(bytes).map_err(|_| ResolveError::InvalidResponse)?;
+    let connection = &response.connection;
+    let attribution = &response.attribution;
+    if response.version != 1
+        || connection.api_format != expected_format
+        || connection.base_url != "https://api.openai.com/v1"
+        || !valid_token(&connection.auth.token)
+        || !valid_token(&response.ingestion.access_token)
+        || response.ingestion.expires_at <= now
+        || [
+            &connection.id,
+            &attribution.organization_id,
+            &attribution.project_id,
+            &attribution.key_id,
+        ]
+        .iter()
+        .any(|value| value.trim().is_empty())
+    {
+        return Err(ResolveError::InvalidResponse);
+    }
+    Ok(ResolvedExecution(response))
+}

--- a/ai-gateway/src/resolution/mod.rs
+++ b/ai-gateway/src/resolution/mod.rs
@@ -1,0 +1,217 @@
+//! Resolve credentials through trusted Web before any provider execution.
+mod contracts;
+mod signing;
+
+pub use contracts::{
+    ApiFormat, Attribution, Connection, Ingestion, IngestionMode, MetadataValue, ResolvedExecution,
+};
+use reqwest::{
+    Client, Url,
+    header::{AUTHORIZATION, CONTENT_TYPE, HeaderValue},
+};
+use std::{
+    fmt,
+    net::IpAddr,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+const RESOLVE_PATH: &str = "/api/internal/ai-gateway/v1/resolve";
+
+struct Limits {
+    timeout: Duration,
+    max_response_bytes: usize,
+}
+
+/// Operator-supplied Web origin and the existing gateway/Web service key.
+pub struct ResolverConfig {
+    url: Url,
+    service_key: String,
+    limits: Limits,
+}
+
+impl ResolverConfig {
+    pub fn new(web_url: &str, service_key: &str) -> Result<Self, ResolveError> {
+        let mut url = Url::parse(web_url).map_err(|_| ResolveError::Configuration)?;
+        let loopback = url.host_str().is_some_and(|host| {
+            host == "localhost"
+                || host
+                    .trim_matches(['[', ']'])
+                    .parse::<IpAddr>()
+                    .is_ok_and(|ip| ip.is_loopback())
+        });
+        if !(url.scheme() == "https" || (url.scheme() == "http" && loopback))
+            || url.host_str().is_none()
+            || !url.username().is_empty()
+            || url.password().is_some()
+            || url.query().is_some()
+            || url.fragment().is_some()
+            || url.path() != "/"
+            || service_key.trim().is_empty()
+        {
+            return Err(ResolveError::Configuration);
+        }
+        url.set_path(RESOLVE_PATH);
+        Ok(Self {
+            url,
+            service_key: service_key.to_owned(),
+            limits: Limits {
+                timeout: Duration::from_secs(5),
+                max_response_bytes: 256 * 1024,
+            },
+        })
+    }
+}
+
+/// Reuses the HTTP connection pool; credentials belong exclusively to each request.
+pub struct Resolver {
+    client: Client,
+    config: ResolverConfig,
+}
+
+impl Resolver {
+    pub fn new(config: ResolverConfig) -> Result<Self, ResolveError> {
+        let client = Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .retry(reqwest::retry::never())
+            .no_proxy()
+            .no_gzip()
+            .no_brotli()
+            .no_zstd()
+            .no_deflate()
+            .build()
+            .map_err(|_| ResolveError::Configuration)?;
+        Ok(Self { client, config })
+    }
+
+    pub async fn resolve(
+        &self,
+        gateway_key: &str,
+        api_format: ApiFormat,
+    ) -> Result<ResolvedExecution, ResolveError> {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| ResolveError::Unavailable)?;
+        self.resolve_at(gateway_key, api_format, timestamp).await
+    }
+
+    async fn resolve_at(
+        &self,
+        gateway_key: &str,
+        api_format: ApiFormat,
+        timestamp: Duration,
+    ) -> Result<ResolvedExecution, ResolveError> {
+        if gateway_key.len() > 8192 || !valid_token(gateway_key) {
+            return Err(ResolveError::InvalidCredential);
+        }
+        let started = Instant::now();
+        let body = tokio::time::timeout(
+            self.config.limits.timeout,
+            self.fetch(gateway_key, api_format, timestamp.as_secs()),
+        )
+        .await
+        .map_err(|_| ResolveError::Timeout)??;
+        contracts::decode(
+            &body,
+            api_format,
+            timestamp.saturating_add(started.elapsed()).as_secs(),
+        )
+    }
+
+    async fn fetch(
+        &self,
+        gateway_key: &str,
+        api_format: ApiFormat,
+        timestamp: u64,
+    ) -> Result<Vec<u8>, ResolveError> {
+        let mut credential = HeaderValue::from_str(&format!("Bearer {gateway_key}"))
+            .map_err(|_| ResolveError::InvalidCredential)?;
+        credential.set_sensitive(true);
+        let mut signature = HeaderValue::from_str(&signing::authorization(
+            &self.config.service_key,
+            gateway_key,
+            timestamp,
+        ))
+        .map_err(|_| ResolveError::Configuration)?;
+        signature.set_sensitive(true);
+        let body = serde_json::to_vec(&serde_json::json!({ "apiFormat": api_format }))
+            .map_err(|_| ResolveError::Configuration)?;
+        let mut response = self
+            .client
+            .post(self.config.url.clone())
+            .header(AUTHORIZATION, credential)
+            .header("langfuse-gateway-authorization", signature)
+            .header(CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await
+            .map_err(|_| ResolveError::Transport)?;
+        match response.status().as_u16() {
+            200 => {}
+            401 => return Err(ResolveError::Authentication),
+            403 => return Err(ResolveError::Forbidden),
+            404 => return Err(ResolveError::NoRoute),
+            429 | 500..=599 => return Err(ResolveError::Unavailable),
+            _ => return Err(ResolveError::InvalidResponse),
+        }
+        let limit = self.config.limits.max_response_bytes;
+        if response
+            .content_length()
+            .is_some_and(|size| size > limit as u64)
+        {
+            return Err(ResolveError::ResponseTooLarge);
+        }
+        let mut bytes = Vec::new();
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .map_err(|_| ResolveError::Transport)?
+        {
+            if chunk.len() > limit - bytes.len() {
+                return Err(ResolveError::ResponseTooLarge);
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        Ok(bytes)
+    }
+}
+
+fn valid_token(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_graphic())
+}
+
+/// Sanitized failure categories. Upstream bodies and transport errors are never retained.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolveError {
+    Configuration,
+    InvalidCredential,
+    Authentication,
+    Forbidden,
+    NoRoute,
+    Unavailable,
+    Timeout,
+    Transport,
+    InvalidResponse,
+    ResponseTooLarge,
+}
+
+impl fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Configuration => "invalid resolver configuration",
+            Self::InvalidCredential => "invalid gateway credential",
+            Self::Authentication => "gateway authentication failed",
+            Self::Forbidden => "gateway access forbidden",
+            Self::NoRoute => "no eligible connection",
+            Self::Unavailable => "resolution unavailable",
+            Self::Timeout => "resolution deadline exceeded",
+            Self::Transport => "resolution transport failed",
+            Self::InvalidResponse => "invalid resolution response",
+            Self::ResponseTooLarge => "resolution response too large",
+        })
+    }
+}
+
+impl std::error::Error for ResolveError {}
+
+#[cfg(test)]
+mod tests;

--- a/ai-gateway/src/resolution/mod.rs
+++ b/ai-gateway/src/resolution/mod.rs
@@ -22,7 +22,7 @@ struct Limits {
     max_response_bytes: usize,
 }
 
-/// Operator-supplied Web origin and the existing gateway/Web service key.
+/// Operator-supplied Web base URL and the existing gateway/Web service key.
 pub struct ResolverConfig {
     url: Url,
     service_key: String,
@@ -30,12 +30,12 @@ pub struct ResolverConfig {
 }
 
 impl ResolverConfig {
-    /// Configure resolution against a trusted Web origin.
+    /// Configure resolution against a trusted Web base URL, including any deployment prefix.
     ///
     /// # Errors
     /// Returns [`ResolveError::Configuration`] for a blank service key or an invalid
-    /// origin. Origins require HTTPS (HTTP is allowed on loopback), with no userinfo,
-    /// query, fragment, or path other than `/`.
+    /// base URL. URLs require HTTPS (HTTP is allowed on loopback), with no userinfo,
+    /// query, or fragment.
     pub fn new(web_url: &str, service_key: &str) -> Result<Self, ResolveError> {
         let mut url = Url::parse(web_url).map_err(|_| ResolveError::Configuration)?;
         let loopback = url.host_str().is_some_and(|host| {
@@ -51,12 +51,12 @@ impl ResolverConfig {
             || url.password().is_some()
             || url.query().is_some()
             || url.fragment().is_some()
-            || url.path() != "/"
             || service_key.trim().is_empty()
         {
             return Err(ResolveError::Configuration);
         }
-        url.set_path(RESOLVE_PATH);
+        let resolve_path = format!("{}{RESOLVE_PATH}", url.path().trim_end_matches('/'));
+        url.set_path(&resolve_path);
         Ok(Self {
             url,
             service_key: service_key.to_owned(),

--- a/ai-gateway/src/resolution/mod.rs
+++ b/ai-gateway/src/resolution/mod.rs
@@ -30,6 +30,12 @@ pub struct ResolverConfig {
 }
 
 impl ResolverConfig {
+    /// Configure resolution against a trusted Web origin.
+    ///
+    /// # Errors
+    /// Returns [`ResolveError::Configuration`] for a blank service key or an invalid
+    /// origin. Origins require HTTPS (HTTP is allowed on loopback), with no userinfo,
+    /// query, fragment, or path other than `/`.
     pub fn new(web_url: &str, service_key: &str) -> Result<Self, ResolveError> {
         let mut url = Url::parse(web_url).map_err(|_| ResolveError::Configuration)?;
         let loopback = url.host_str().is_some_and(|host| {
@@ -69,6 +75,10 @@ pub struct Resolver {
 }
 
 impl Resolver {
+    /// Build a resolver with a reusable HTTP connection pool.
+    ///
+    /// # Errors
+    /// Returns [`ResolveError::Configuration`] if the HTTP client cannot be initialized.
     pub fn new(config: ResolverConfig) -> Result<Self, ResolveError> {
         let client = Client::builder()
             .redirect(reqwest::redirect::Policy::none())
@@ -83,6 +93,12 @@ impl Resolver {
         Ok(Self { client, config })
     }
 
+    /// Resolve a gateway credential and API format into a validated execution contract.
+    ///
+    /// # Errors
+    /// Returns a sanitized [`ResolveError`] for invalid credentials, authentication or
+    /// authorization failures, missing routes, unavailable Web or system time, request
+    /// construction or transport failures, timeouts, or oversized or invalid responses.
     pub async fn resolve(
         &self,
         gateway_key: &str,

--- a/ai-gateway/src/resolution/signing.rs
+++ b/ai-gateway/src/resolution/signing.rs
@@ -1,0 +1,29 @@
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+
+pub(super) fn authorization(service_key: &str, gateway_key: &str, timestamp: u64) -> String {
+    let key_hash = Sha256::digest(gateway_key.as_bytes());
+    let payload = format!("gateway-web-v1\n{timestamp}\n{key_hash:x}");
+    // HMAC accepts keys of any length.
+    let mut mac = Hmac::<Sha256>::new_from_slice(service_key.as_bytes()).expect("valid HMAC key");
+    mac.update(payload.as_bytes());
+    let signature = mac.finalize().into_bytes();
+    format!("HMAC timestamp={timestamp},signature={signature:x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_web_v1_fixture() {
+        assert_eq!(
+            authorization(
+                "gateway-web-test-secret-not-for-production",
+                "gw_test_alice",
+                1_800_000_000
+            ),
+            "HMAC timestamp=1800000000,signature=e104b6baa50d9b766b036e27876683aa1f4bff7f31bb6af66dce6b636a53b2bd"
+        );
+    }
+}

--- a/ai-gateway/src/resolution/signing.rs
+++ b/ai-gateway/src/resolution/signing.rs
@@ -1,14 +1,23 @@
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::{Digest, Sha256};
+use std::fmt::Write;
 
 pub(super) fn authorization(service_key: &str, gateway_key: &str, timestamp: u64) -> String {
-    let key_hash = Sha256::digest(gateway_key.as_bytes());
-    let payload = format!("gateway-web-v1\n{timestamp}\n{key_hash:x}");
+    let key_hash = lowercase_hex(&Sha256::digest(gateway_key.as_bytes()));
+    let payload = format!("gateway-web-v1\n{timestamp}\n{key_hash}");
     // HMAC accepts keys of any length.
     let mut mac = Hmac::<Sha256>::new_from_slice(service_key.as_bytes()).expect("valid HMAC key");
     mac.update(payload.as_bytes());
-    let signature = mac.finalize().into_bytes();
-    format!("HMAC timestamp={timestamp},signature={signature:x}")
+    let signature = lowercase_hex(&mac.finalize().into_bytes());
+    format!("HMAC timestamp={timestamp},signature={signature}")
+}
+
+fn lowercase_hex(bytes: &[u8]) -> String {
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(encoded, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    encoded
 }
 
 #[cfg(test)]

--- a/ai-gateway/src/resolution/tests.rs
+++ b/ai-gateway/src/resolution/tests.rs
@@ -414,7 +414,6 @@ fn web_configuration_rejects_unsafe_or_ambiguous_urls() {
         "not a URL",
         "http://web.example",
         "https://user:password@web.example",
-        "https://web.example/prefix",
         "https://web.example?query=true",
         "https://web.example#fragment",
     ] {

--- a/ai-gateway/src/resolution/tests.rs
+++ b/ai-gateway/src/resolution/tests.rs
@@ -1,0 +1,429 @@
+use super::*;
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, Response, StatusCode, header},
+    routing::any,
+};
+use futures_util::{StreamExt, stream};
+use serde_json::{Value, json};
+use std::{
+    convert::Infallible,
+    future::Future,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+use tokio::{net::TcpListener, task::JoinHandle};
+
+const NOW: u64 = 1_800_000_000;
+const NOW_TIME: Duration = Duration::from_secs(NOW);
+const SERVICE_KEY: &str = "gateway-web-test-secret-not-for-production";
+const GATEWAY_KEY: &str = "gw_test_alice";
+
+struct FakeWeb {
+    url: String,
+    calls: Arc<AtomicUsize>,
+    task: JoinHandle<()>,
+}
+
+impl Drop for FakeWeb {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl FakeWeb {
+    async fn start<F, Fut>(handler: F) -> Self
+    where
+        F: Fn(Request<Body>) -> Fut + Clone + Send + Sync + 'static,
+        Fut: Future<Output = Response<Body>> + Send + 'static,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let calls = Arc::new(AtomicUsize::new(0));
+        let count = calls.clone();
+        let app = Router::new().fallback(any(move |request| {
+            count.fetch_add(1, Ordering::SeqCst);
+            handler(request)
+        }));
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        Self { url, calls, task }
+    }
+
+    fn resolver(&self) -> Resolver {
+        self.resolver_with_limits(Duration::from_secs(2), 256 * 1024)
+    }
+
+    fn resolver_with_limits(&self, timeout: Duration, max_response_bytes: usize) -> Resolver {
+        let mut config = ResolverConfig::new(&self.url, SERVICE_KEY).unwrap();
+        config.limits = Limits {
+            timeout,
+            max_response_bytes,
+        };
+        Resolver::new(config).unwrap()
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+fn response(value: Value) -> Response<Body> {
+    Response::builder()
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(value.to_string()))
+        .unwrap()
+}
+
+fn success(project: &str, provider_token: &str) -> Value {
+    json!({
+        "version": 1,
+        "connection": {
+            "id": "connection-1",
+            "provider": "openai",
+            "api_format": "openai.responses",
+            "base_url": "https://api.openai.com/v1",
+            "auth": {"type": "Bearer", "token": provider_token}
+        },
+        "attribution": {
+            "organization_id": "org-1",
+            "project_id": project,
+            "key_id": "key-1",
+            "key_metadata": {"customer": "private-customer-label", "enabled": true, "number": 42}
+        },
+        "ingestion_mode": "usage",
+        "ingestion": {"access_token": "private-ingestion-token", "token_type": "Bearer", "expires_at": NOW + 300}
+    })
+}
+
+#[tokio::test]
+async fn signs_the_exact_key_and_sends_only_the_api_format() {
+    let web = FakeWeb::start(|request| async move {
+        assert_eq!(request.method(), "POST");
+        assert_eq!(request.uri(), "/api/internal/ai-gateway/v1/resolve");
+        assert_eq!(request.headers()[header::AUTHORIZATION], "Bearer gw_test_alice");
+        assert_eq!(request.headers()[header::CONTENT_TYPE], "application/json");
+        assert_eq!(request.headers()["langfuse-gateway-authorization"],
+            "HMAC timestamp=1800000000,signature=e104b6baa50d9b766b036e27876683aa1f4bff7f31bb6af66dce6b636a53b2bd");
+        assert_eq!(to_bytes(request.into_body(), 1024).await.unwrap(),
+            r#"{"apiFormat":"openai.responses"}"#);
+        response(success("project-1", "private-provider-token"))
+    }).await;
+
+    let context = web
+        .resolver()
+        .resolve_at(GATEWAY_KEY, ApiFormat::OpenAiResponses, NOW_TIME)
+        .await
+        .unwrap();
+    assert_eq!(context.connection().id(), "connection-1");
+    assert_eq!(
+        context.connection().provider_token(),
+        "private-provider-token"
+    );
+    assert_eq!(context.attribution().project_id(), "project-1");
+    assert_eq!(
+        context.ingestion().access_token(),
+        "private-ingestion-token"
+    );
+    let debug = format!("{context:?}");
+    for sensitive in [
+        SERVICE_KEY,
+        GATEWAY_KEY,
+        "private-provider-token",
+        "private-ingestion-token",
+        "private-customer-label",
+    ] {
+        assert!(
+            !debug.contains(sensitive),
+            "execution context leaked a secret"
+        );
+    }
+    assert_eq!(web.calls(), 1);
+}
+
+#[tokio::test]
+async fn denied_and_failed_resolutions_are_classified_without_retries_or_body_leaks() {
+    for status in [401, 403, 404, 500, 503] {
+        let web = FakeWeb::start(move |_| async move {
+            Response::builder()
+                .status(status)
+                .body(Body::from("private-upstream-error"))
+                .unwrap()
+        })
+        .await;
+        let error = web
+            .resolver()
+            .resolve_at(GATEWAY_KEY, ApiFormat::OpenAiResponses, NOW_TIME)
+            .await
+            .unwrap_err();
+        assert!(match status {
+            401 => matches!(error, ResolveError::Authentication),
+            403 => matches!(error, ResolveError::Forbidden),
+            404 => matches!(error, ResolveError::NoRoute),
+            _ => matches!(error, ResolveError::Unavailable),
+        });
+        assert!(!format!("{error:?} {error}").contains("private-upstream-error"));
+        assert_eq!(web.calls(), 1);
+    }
+}
+
+#[tokio::test]
+async fn never_follows_redirects_with_credentials() {
+    let destination =
+        FakeWeb::start(|_| async { response(success("project-1", "provider-token")) }).await;
+    let location = destination.url.clone();
+    let web = FakeWeb::start(move |_| {
+        let location = location.clone();
+        async move {
+            Response::builder()
+                .status(StatusCode::TEMPORARY_REDIRECT)
+                .header(header::LOCATION, location)
+                .body(Body::empty())
+                .unwrap()
+        }
+    })
+    .await;
+    assert!(
+        web.resolver()
+            .resolve_at(GATEWAY_KEY, ApiFormat::OpenAiResponses, NOW_TIME)
+            .await
+            .is_err()
+    );
+    assert_eq!(web.calls(), 1);
+    assert_eq!(destination.calls(), 0);
+}
+
+#[tokio::test]
+async fn rejects_oversized_declared_and_chunked_responses() {
+    for declared in [true, false] {
+        let web = FakeWeb::start(move |_| async move {
+            if declared {
+                Response::builder()
+                    .header(header::CONTENT_LENGTH, "4096")
+                    .body(Body::from("x".repeat(4096)))
+                    .unwrap()
+            } else {
+                let chunks =
+                    stream::iter([Ok::<_, Infallible>(vec![b'x'; 80]), Ok(vec![b'y'; 80])]);
+                Response::new(Body::from_stream(chunks))
+            }
+        })
+        .await;
+        let result = web
+            .resolver_with_limits(Duration::from_secs(2), 128)
+            .resolve_at(GATEWAY_KEY, ApiFormat::OpenAiResponses, NOW_TIME)
+            .await;
+        assert!(matches!(result, Err(ResolveError::ResponseTooLarge)));
+        assert_eq!(web.calls(), 1);
+    }
+}
+
+#[tokio::test]
+async fn deadline_covers_response_headers_and_body() {
+    for delay_headers in [true, false] {
+        let web = FakeWeb::start(move |_| async move {
+            if delay_headers {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                response(success("project-1", "provider-token"))
+            } else {
+                let first = stream::iter([Ok::<_, Infallible>("{")]);
+                let rest = stream::once(async {
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    Ok::<_, Infallible>("}")
+                });
+                Response::new(Body::from_stream(first.chain(rest)))
+            }
+        })
+        .await;
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            web.resolver_with_limits(Duration::from_millis(30), 256 * 1024)
+                .resolve_at(GATEWAY_KEY, ApiFormat::OpenAiResponses, NOW_TIME),
+        )
+        .await
+        .expect("resolver must enforce its deadline");
+        assert!(matches!(result, Err(ResolveError::Timeout)));
+        assert_eq!(web.calls(), 1);
+    }
+}
+
+#[tokio::test]
+async fn malformed_credentials_never_reach_web() {
+    let web = FakeWeb::start(|_| async { response(success("project-1", "provider-token")) }).await;
+    for key in ["", "has space", "has\r\nheader", "has\ttab"] {
+        let result = web
+            .resolver()
+            .resolve_at(key, ApiFormat::OpenAiResponses, NOW_TIME)
+            .await;
+        assert!(matches!(result, Err(ResolveError::InvalidCredential)));
+    }
+    assert_eq!(web.calls(), 0);
+}
+
+#[tokio::test]
+async fn rejects_a_grant_that_expires_while_resolving_across_a_second_boundary() {
+    let web = FakeWeb::start(|_| async {
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        let mut body = success("project-1", "provider-token");
+        body["ingestion"]["expires_at"] = json!(NOW + 1);
+        response(body)
+    })
+    .await;
+    let result = web
+        .resolver()
+        .resolve_at(
+            GATEWAY_KEY,
+            ApiFormat::OpenAiResponses,
+            NOW_TIME + Duration::from_millis(900),
+        )
+        .await;
+    assert!(matches!(result, Err(ResolveError::InvalidResponse)));
+}
+
+#[tokio::test]
+async fn concurrent_resolutions_keep_credentials_and_contexts_isolated() {
+    let web = FakeWeb::start(|request| async move {
+        let key = request.headers()[header::AUTHORIZATION].to_str().unwrap();
+        match key {
+            "Bearer gw_test_alice" => {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                response(success("project-alice", "token-alice"))
+            }
+            "Bearer gw_test_bob" => response(success("project-bob", "token-bob")),
+            _ => panic!("unexpected request credential"),
+        }
+    })
+    .await;
+    let resolver = web.resolver();
+    let (alice, bob) = tokio::join!(
+        resolver.resolve_at("gw_test_alice", ApiFormat::OpenAiResponses, NOW_TIME),
+        resolver.resolve_at("gw_test_bob", ApiFormat::OpenAiResponses, NOW_TIME),
+    );
+    let alice = alice.unwrap();
+    let bob = bob.unwrap();
+    assert_eq!(alice.attribution().project_id(), "project-alice");
+    assert_eq!(alice.connection().provider_token(), "token-alice");
+    assert_eq!(bob.attribution().project_id(), "project-bob");
+    assert_eq!(bob.connection().provider_token(), "token-bob");
+    assert_eq!(web.calls(), 2);
+}
+
+#[tokio::test]
+async fn rejects_incompatible_or_incomplete_execution_contexts() {
+    let mutations = [
+        ("/version", json!(2)),
+        ("/connection/provider", json!({"openai": null})),
+        ("/connection/api_format", json!({"openai.responses": null})),
+        ("/connection/auth/type", json!({"Bearer": null})),
+        ("/ingestion/token_type", json!({"Bearer": null})),
+        ("/ingestion_mode", json!({"usage": null})),
+        ("/connection/provider", json!("anthropic")),
+        ("/connection/api_format", json!("openai.chatcompletions")),
+        ("/connection/base_url", json!("https://attacker.example/v1")),
+        (
+            "/connection/base_url",
+            json!("https://api.openai.com.attacker.example/v1"),
+        ),
+        ("/connection/base_url", json!("http://api.openai.com/v1")),
+        (
+            "/connection/base_url",
+            json!("https://api.openai.com/v1?redirect=elsewhere"),
+        ),
+        ("/connection/auth/type", json!("Basic")),
+        ("/connection/auth/token", json!("")),
+        ("/connection/auth/token", json!("bad\r\nheader")),
+        ("/connection/id", json!("")),
+        ("/attribution/project_id", json!("")),
+        (
+            "/attribution/key_metadata",
+            json!({"nested": {"key": "value"}}),
+        ),
+        ("/attribution/key_metadata", json!({"null": null})),
+        ("/ingestion_mode", json!("none")),
+        ("/ingestion/access_token", json!("")),
+        ("/ingestion/token_type", json!("Basic")),
+        ("/ingestion/expires_at", json!(NOW)),
+    ];
+    for (pointer, value) in mutations {
+        let mut body = success("project-1", "provider-token");
+        *body.pointer_mut(pointer).unwrap() = value;
+        assert_invalid_context(body).await;
+    }
+    for field in [
+        "version",
+        "connection",
+        "attribution",
+        "ingestion_mode",
+        "ingestion",
+    ] {
+        let mut body = success("project-1", "provider-token");
+        body.as_object_mut().unwrap().remove(field);
+        assert_invalid_context(body).await;
+    }
+    let mut body = success("project-1", "provider-token");
+    body["unexpected"] = json!(true);
+    assert_invalid_context(body).await;
+}
+
+async fn assert_invalid_context(body: Value) {
+    let web = FakeWeb::start(move |_| {
+        let body = body.clone();
+        async move { response(body) }
+    })
+    .await;
+    let result = web
+        .resolver()
+        .resolve_at(GATEWAY_KEY, ApiFormat::OpenAiResponses, NOW_TIME)
+        .await;
+    assert!(matches!(result, Err(ResolveError::InvalidResponse)));
+    assert_eq!(web.calls(), 1);
+}
+
+#[tokio::test]
+async fn rejects_malformed_json_without_exposing_response_contents() {
+    let web = FakeWeb::start(|_| async {
+        Response::new(Body::from("private-provider-secret invalid JSON"))
+    })
+    .await;
+    let error = web
+        .resolver()
+        .resolve_at(GATEWAY_KEY, ApiFormat::OpenAiResponses, NOW_TIME)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, ResolveError::InvalidResponse));
+    assert!(!format!("{error:?} {error}").contains("private-provider-secret"));
+}
+
+#[test]
+fn web_configuration_rejects_unsafe_or_ambiguous_urls() {
+    for key in ["", " \n\t"] {
+        assert!(matches!(
+            ResolverConfig::new("https://web.example", key),
+            Err(ResolveError::Configuration)
+        ));
+    }
+    for url in [
+        "not a URL",
+        "http://web.example",
+        "https://user:password@web.example",
+        "https://web.example/prefix",
+        "https://web.example?query=true",
+        "https://web.example#fragment",
+    ] {
+        assert!(matches!(
+            ResolverConfig::new(url, SERVICE_KEY),
+            Err(ResolveError::Configuration)
+        ));
+    }
+    for url in [
+        "https://web.example",
+        "http://127.0.0.1:3000",
+        "http://[::1]:3000",
+    ] {
+        assert!(ResolverConfig::new(url, SERVICE_KEY).is_ok());
+    }
+}

--- a/ai-gateway/src/resolution/tests.rs
+++ b/ai-gateway/src/resolution/tests.rs
@@ -72,6 +72,10 @@ impl FakeWeb {
     }
 }
 
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Response fixtures consume their JSON values, including inline json! expressions"
+)]
 fn response(value: Value) -> Response<Body> {
     Response::builder()
         .header(header::CONTENT_TYPE, "application/json")

--- a/ai-gateway/src/server.rs
+++ b/ai-gateway/src/server.rs
@@ -48,6 +48,10 @@ async fn readiness(State(state): State<AppState>) -> (StatusCode, Json<Probe>) {
 
 /// Serve an initialized router until shutdown, then bound connection draining.
 /// A timeout must terminate the owning process/runtime to stop remaining tasks.
+///
+/// # Errors
+/// Returns the server's I/O error, or [`io::ErrorKind::TimedOut`] if connections
+/// do not finish draining within `shutdown_timeout`.
 pub async fn serve(
     listener: TcpListener,
     app: Router,
@@ -69,7 +73,7 @@ pub async fn serve(
     state.ready.store(true, Ordering::Release);
     let result = tokio::select! {
         result = &mut server => result,
-        _ = async {
+        () = async {
             let _ = draining_rx.await;
             tokio::time::sleep(shutdown_timeout).await;
         } => Err(io::Error::new(io::ErrorKind::TimedOut, "gateway shutdown deadline exceeded")),


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17302 app preview](https://pr-17302.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

The Rust gateway needs a trusted execution context before it can call a provider. This adds the Web resolution client for OpenAI Responses: it signs the existing Web contract with the shared service key and returns a validated connection, attribution and project ingestion grant.

The client uses a five-second deadline, a 256 KiB incremental response limit, request-local credentials and sanitized errors. It disables redirects, automatic retries, ambient proxies and decompression. Signing, response contracts and HTTP behavior live in separate modules under `ai-gateway/src/resolution/`.

This PR affects only `ai-gateway`. It leaves binary startup and inference routes for subsequent changes; no live provider requests, caching or telemetry are added. The dependency lockfile accounts for most of the diff. HMAC 0.13 and SHA-2 0.11 use the current RustCrypto digest API; the signing fixture remains unchanged. Other direct dependencies are current except reqwest, whose 0.13 release requires a separate TLS configuration migration.

Clippy pedantic is enabled for all gateway targets and enforced by the existing warnings-as-errors lint command. The package allows `must_use_candidate`; the JSON test response helper has a documented local `needless_pass_by_value` expectation. Public fallible functions document their errors.

Configured Web base paths are preserved: `https://host/app` and `https://host/app/` both resolve through `/app/api/internal/ai-gateway/v1/resolve`, supporting self-hosted `NEXT_PUBLIC_BASE_PATH` builds.

Validation:

- `cargo fmt --all -- --check` and `cargo clippy --locked --all-targets -- -D warnings` passed.
- `cargo test --locked`: 16 library, 4 lifecycle and 3 startup tests passed. Fake Web covers exact signing/body, denial, redirects, deadlines, response limits, strict contracts and concurrent credential isolation.
- Shared HMAC fixture independently verified with Python. Regression tests cover string-only enums and expiry across a second boundary.
- Updated crypto dependencies passed the Rust CI job: formatting, Clippy, all 23 tests, runtime image build and smoke (non-root startup, probes, missing inference route and SIGTERM). Local image rebuilds hit Docker Hub metadata timeouts; CI independently verified the updated container.
- The latest base-path fix passed Rust formatting, strict Clippy and all 23 existing tests locally. The obsolete path-prefix rejection case was removed; no new regression test was added. JavaScript checks and a local image rebuild were skipped for this focused Rust URL-construction change. No live Web/provider integration was exercised.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62653260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no actionable correctness, security, or repository-rule violations were identified.

<details open><summary><h3>Summary</h3></summary>

- Validates the configured Web origin and builds a hardened, bounded HTTP client.
- Signs request-local gateway credentials using the existing Web HMAC contract.
- Strictly validates connection, attribution, and ingestion-grant responses.
- Adds comprehensive tests, documentation, and the required Rust dependencies.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Resolver
    participant Web
    participant Contracts

    Caller->>Resolver: resolve(gateway_key, openai.responses)
    Resolver->>Resolver: Validate credential and create HMAC signature
    Resolver->>Web: POST /api/internal/ai-gateway/v1/resolve
    Note over Resolver,Web: 5-second deadline, no redirects/retries/proxies/decompression
    Web-->>Resolver: Bounded v1 execution response
    Resolver->>Contracts: Decode and validate strict schema
    Contracts-->>Resolver: ResolvedExecution
    Resolver-->>Caller: Connection, attribution, and ingestion grant
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat(ai-gateway): resolve trusted execut..."](https://github.com/langfuse/langfuse/commit/f32e115d8f026546718698059ff0671cb70b195c)</sub>

<!-- /greptile_comment -->



