### PR TITLE
fix(gateway): remove duplicate table borders

### DIFF
--- a/web/src/features/ai-gateway/components/GatewayApiKeysPage/components/GatewayApiKeysView/GatewayApiKeysView.tsx
+++ b/web/src/features/ai-gateway/components/GatewayApiKeysPage/components/GatewayApiKeysView/GatewayApiKeysView.tsx
@@ -85,7 +85,7 @@ export function GatewayApiKeysView({
       <p className="text-muted-foreground text-sm">
         These organization keys authenticate requests to the AI Gateway only.
       </p>
-      <div className="flex max-h-[60dvh] flex-col overflow-hidden rounded-md border">
+      <div className="flex max-h-[60dvh] flex-col overflow-hidden rounded-md border [&>:first-child>:first-child]:border-t-0">
         <DataTable
           tableName="gatewayApiKeys"
           columns={columns}

--- a/web/src/features/ai-gateway/components/GatewayProvidersPage/components/GatewayProvidersView/GatewayProvidersView.tsx
+++ b/web/src/features/ai-gateway/components/GatewayProvidersPage/components/GatewayProvidersView/GatewayProvidersView.tsx
@@ -291,7 +291,7 @@ function SortableGatewayProvidersView({
           items={orderedConnections.map((connection) => connection.id)}
           strategy={verticalListSortingStrategy}
         >
-          <div className="flex max-h-[60dvh] flex-col overflow-hidden rounded-md border">
+          <div className="flex max-h-[60dvh] flex-col overflow-hidden rounded-md border [&>:first-child>:first-child]:border-t-0">
             <DataTable
               tableName={TABLE_NAME}
               columns={columns}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17306 app preview](https://pr-17306.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- remove the duplicate top border from the AI Gateway provider table
- apply the same fix to the AI Gateway API key table
- reuse the existing settings-table border treatment

## Impacted package

- `web`

## Verification

- `pnpm --filter web run lint`
- `git diff --check`

## Test steps

Preview: `https://pr-17306.preview.langfuse.com`

1. Open an organization with AI Gateway enabled.
2. Go to **Organization settings → AI Gateway → Providers** and confirm the table has one top border.
3. Go to **API keys** and confirm its table also has one top border.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62711940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable issues identified.

<details open><summary><h3>Summary</h3></summary>

- Applies the established nested border override to both table wrappers.
- Preserves the wrappers’ outer rounded borders.
- Introduces no security-sensitive behavior.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(gateway): remove duplicate table bor..."](https://github.com/langfuse/langfuse/commit/0720b75ef9260f782abed4784eecb4328725ee60)</sub>

<!-- /greptile_comment -->