### PR TITLE
refactor(filter-options): drop exact facet ranking from the scores scan

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/score-filter-options.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/score-filter-options.ts
@@ -8,9 +8,20 @@ import { createFilterFromFilterState } from "./factory";
 export const FILTER_OPTION_SCORE_NAME_LIMIT = 200;
 export const FILTER_OPTION_CATEGORICAL_VALUE_LIMIT = 20;
 
+// Transfer bound on (name, source, data_type) groups. The 200-name UI cap is
+// applied in TypeScript after summing across sources; this is only so a
+// project with thousands of distinct groups does not return all of them.
+const FILTER_OPTION_SCORE_GROUP_LIMIT = FILTER_OPTION_SCORE_NAME_LIMIT * 10;
+
 /**
  * One `scores` scan that materialises every event-table score-name facet
  * via conditional aggregation (numeric / boolean / categorical / level).
+ *
+ * Counts of returned groups are exact. Which groups are returned is not:
+ * ClickHouse keeps the most frequent (name, source, data_type) rows (ten
+ * times the UI name cap) and drops the rest. A name whose mass splits
+ * across sources or data types can fall out of a facet even when its
+ * summed count would have ranked in that facet's top 200.
  */
 export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
   projectId: string;
@@ -23,104 +34,41 @@ export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
   );
   const filterRes = new FilterList(chFilter).apply();
 
-  // The repository rolls these rows up into seven facets, each with a different
-  // pool and count measure, and caps each independently. One shared cap cannot
-  // reproduce all seven: a name outside one facet's top-N can top another, and a
-  // name whose measure splits across sources or across NUMERIC/BOOLEAN can lead
-  // its facet while trailing on every single (source, data_type) row. Rank each
-  // facet on its own measure and keep a row that survives ANY cap, so each
-  // roll-up reads a superset of its true top-N. Name-facet ranks partition per
-  // name so a name's rows share one rank; column facets rank rows directly.
-  const cap = FILTER_OPTION_SCORE_NAME_LIMIT;
   const query = `
-    WITH grouped AS (
-      SELECT
-        s.name AS name,
-        s.source AS source,
-        s.data_type AS data_type,
-        count() AS count,
-        countIf(isNull(s.observation_id)) AS trace_count,
-        countIf(isNotNull(s.observation_id)) AS observation_count,
-        groupUniqArrayIf(${FILTER_OPTION_CATEGORICAL_VALUE_LIMIT})(
-          s.string_value,
-          s.data_type = 'CATEGORICAL'
-        ) AS categorical_values,
-        groupUniqArrayIf(${FILTER_OPTION_CATEGORICAL_VALUE_LIMIT})(
-          s.string_value,
-          s.data_type = 'CATEGORICAL' AND isNull(s.observation_id)
-        ) AS trace_categorical_values,
-        countIf(
-          s.data_type = 'BOOLEAN'
-          AND s.string_value IS NOT NULL
-          AND s.string_value != ''
-        ) AS boolean_value_count,
-        countIf(
-          s.data_type = 'BOOLEAN'
-          AND s.string_value IS NOT NULL
-          AND s.string_value != ''
-          AND isNull(s.observation_id)
-        ) AS trace_boolean_value_count
-      FROM scores s
-      WHERE s.project_id = {projectId: String}
-        AND isNotNull(s.trace_id)
-        AND s.data_type IN ({dataTypes: Array(String)})
-        ${filterRes.query ? `AND ${filterRes.query}` : ""}
-      GROUP BY name, source, data_type
-    ),
-    name_totals AS (
-      SELECT
-        grouped.*,
-        sumIf(count, data_type IN ('NUMERIC', 'BOOLEAN'))
-          OVER (PARTITION BY name) AS numeric_name_total,
-        sum(boolean_value_count) OVER (PARTITION BY name) AS boolean_name_total,
-        sumIf(count, data_type = 'CATEGORICAL')
-          OVER (PARTITION BY name) AS categorical_name_total,
-        sumIf(trace_count, data_type = 'CATEGORICAL')
-          OVER (PARTITION BY name) AS trace_categorical_name_total,
-        sum(trace_boolean_value_count)
-          OVER (PARTITION BY name) AS trace_boolean_name_total
-      FROM grouped
-    ),
-    ranked AS (
-      SELECT
-        name_totals.*,
-        dense_rank() OVER (ORDER BY numeric_name_total DESC, name ASC)
-          AS numeric_name_rank,
-        dense_rank() OVER (ORDER BY boolean_name_total DESC, name ASC)
-          AS boolean_name_rank,
-        dense_rank() OVER (ORDER BY categorical_name_total DESC, name ASC)
-          AS categorical_name_rank,
-        dense_rank() OVER (ORDER BY trace_categorical_name_total DESC, name ASC)
-          AS trace_categorical_name_rank,
-        dense_rank() OVER (ORDER BY trace_boolean_name_total DESC, name ASC)
-          AS trace_boolean_name_rank,
-        dense_rank() OVER (
-          ORDER BY observation_count DESC, name ASC, source ASC, data_type ASC
-        ) AS observation_column_rank,
-        dense_rank() OVER (
-          ORDER BY trace_count DESC, name ASC, source ASC, data_type ASC
-        ) AS trace_column_rank
-      FROM name_totals
-    )
     SELECT
-      name,
-      source,
-      data_type,
-      count,
-      trace_count,
-      observation_count,
-      categorical_values,
-      trace_categorical_values,
-      boolean_value_count,
-      trace_boolean_value_count
-    FROM ranked
-    WHERE numeric_name_rank <= {cap: UInt32}
-      OR boolean_name_rank <= {cap: UInt32}
-      OR categorical_name_rank <= {cap: UInt32}
-      OR trace_categorical_name_rank <= {cap: UInt32}
-      OR trace_boolean_name_rank <= {cap: UInt32}
-      OR observation_column_rank <= {cap: UInt32}
-      OR trace_column_rank <= {cap: UInt32}
+      s.name AS name,
+      s.source AS source,
+      s.data_type AS data_type,
+      count() AS count,
+      countIf(isNull(s.observation_id)) AS trace_count,
+      countIf(isNotNull(s.observation_id)) AS observation_count,
+      groupUniqArrayIf(${FILTER_OPTION_CATEGORICAL_VALUE_LIMIT})(
+        s.string_value,
+        s.data_type = 'CATEGORICAL'
+      ) AS categorical_values,
+      groupUniqArrayIf(${FILTER_OPTION_CATEGORICAL_VALUE_LIMIT})(
+        s.string_value,
+        s.data_type = 'CATEGORICAL' AND isNull(s.observation_id)
+      ) AS trace_categorical_values,
+      countIf(
+        s.data_type = 'BOOLEAN'
+        AND s.string_value IS NOT NULL
+        AND s.string_value != ''
+      ) AS boolean_value_count,
+      countIf(
+        s.data_type = 'BOOLEAN'
+        AND s.string_value IS NOT NULL
+        AND s.string_value != ''
+        AND isNull(s.observation_id)
+      ) AS trace_boolean_value_count
+    FROM scores s
+    WHERE s.project_id = {projectId: String}
+      AND isNotNull(s.trace_id)
+      AND s.data_type IN ({dataTypes: Array(String)})
+      ${filterRes.query ? `AND ${filterRes.query}` : ""}
+    GROUP BY name, source, data_type
+    ORDER BY count DESC, name ASC, source ASC, data_type ASC
+    LIMIT {groupLimit: UInt32}
   `.trim();
 
   return {
@@ -128,7 +76,7 @@ export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
     params: {
       projectId: params.projectId,
       dataTypes: [...LISTABLE_SCORE_TYPES],
-      cap,
+      groupLimit: FILTER_OPTION_SCORE_GROUP_LIMIT,
       ...filterRes.params,
     },
   };

--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -1066,19 +1066,16 @@ describe("buildScoresFilterOptionsForEventFacetsQuery", () => {
     expect(built.query).toContain("countIf(isNull(s.observation_id))");
     expect(built.query).toContain("countIf(isNotNull(s.observation_id))");
     expect(built.query).toContain("GROUP BY name, source, data_type");
-    // Each facet is ranked on its own measure and a row is kept if it survives
-    // any cap, so no facet's roll-up can drop its true top-N.
     expect(built.query).toContain(
-      "sumIf(count, data_type IN ('NUMERIC', 'BOOLEAN'))",
+      "ORDER BY count DESC, name ASC, source ASC, data_type ASC",
     );
-    expect(built.query).toContain("numeric_name_rank <= {cap: UInt32}");
-    expect(built.query).toContain("trace_column_rank <= {cap: UInt32}");
-    expect(built.query.match(/dense_rank\(\) OVER \(/g)).toHaveLength(7);
+    expect(built.query).toContain("LIMIT {groupLimit: UInt32}");
+    expect(built.query).not.toContain("dense_rank");
     expect(built.query).not.toContain("FINAL");
     expect(built.query).not.toMatch(/\bJOIN\b/i);
     expect(built.params).toMatchObject({
       projectId: "test-project",
-      cap: FILTER_OPTION_SCORE_NAME_LIMIT,
+      groupLimit: FILTER_OPTION_SCORE_NAME_LIMIT * 10,
     });
     expect(built.params.dataTypes).toEqual([
       "NUMERIC",

--- a/web/src/__tests__/server/repositories/score-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/score-repository.servertest.ts
@@ -1686,8 +1686,8 @@ describe("Clickhouse Scores Repository Test", () => {
 
       // Cross the per-type cap: LIMIT_TOP names each seen twice (count 2) plus a
       // dozen extras seen once (count 1). count 2 > count 1 makes the top set
-      // unambiguous, so the SQL name-rank cap plus JS name cap must land on
-      // exactly the frequent names — the per-column helper is the oracle below.
+      // unambiguous, so the TypeScript name cap must land on exactly the
+      // frequent names — the per-column helper is the oracle below.
       const topNames = Array.from(
         { length: FILTER_OPTION_SCORE_NAME_LIMIT },
         (_, i) => `cap-top-${String(i).padStart(4, "0")}`,
@@ -1754,13 +1754,13 @@ describe("Clickhouse Scores Repository Test", () => {
         ...timestampFilter,
       ];
 
-      // The repository sums each name's count across sources before ranking, so
-      // the SQL must bound by summed count per name — not by raw per-source rows.
-      // Seed the adversarial shape: one NUMERIC name spread over all three
-      // sources (one row each, summed count 3), plus more single-source names
-      // (count 2 each) than the name cap. Every split row has a lower per-source
-      // count than every filler, so a per-source row cap drops the split name
-      // even though its summed count is the project's highest.
+      // The repository sums each name's count across sources before the UI cap.
+      // SQL only keeps the most frequent (name, source, data_type) groups as a
+      // transfer bound, so this fixture still returns the split name: one
+      // NUMERIC name spread over all three sources (one row each, summed count
+      // 3), plus more single-source names (count 2 each) than the name cap.
+      // A tight per-source row cap would drop it; the generous group limit
+      // does not.
       const singleSourceNames = Array.from(
         { length: FILTER_OPTION_SCORE_NAME_LIMIT * ScoreSourceArray.length },
         (_, i) => `split-filler-${String(i).padStart(4, "0")}`,
@@ -1797,7 +1797,8 @@ describe("Clickhouse Scores Repository Test", () => {
 
       // The old per-column helper groups by name before its own limit, so the
       // split name is the unambiguous #1 by summed count. The combined scan
-      // must agree — losing it means per-source truncation dropped it.
+      // still returns it because the group-limit is a transfer bound, not a
+      // per-source semantic cap.
       expect(oldNumeric[0]?.name).toBe("split-hot");
       expect(combined.numericNames.map((row) => row.name)).toContain(
         "split-hot",
@@ -1826,11 +1827,11 @@ describe("Clickhouse Scores Repository Test", () => {
       ];
 
       // numericNames pools NUMERIC and BOOLEAN and ranks names by their combined
-      // count. A name that exists as both types can sit outside each type's own
-      // top-N while its combined count is the project's highest, so a per-type
-      // cap drops it from both. Seed that: cross-hot with NUMERIC count 3 and
-      // BOOLEAN count 3 (combined 6), behind a full name cap of single-type
-      // fillers at count 4 in each type.
+      // count in TypeScript. A name that exists as both types can sit outside
+      // each type's own top-N while its combined count is the project's highest.
+      // Seed that: cross-hot with NUMERIC count 3 and BOOLEAN count 3 (combined
+      // 6), behind a full name cap of single-type fillers at count 4 in each
+      // type. The SQL group limit is large enough that both type-rows arrive.
       const fillerNames = (prefix: string) =>
         Array.from(
           { length: FILTER_OPTION_SCORE_NAME_LIMIT },
@@ -1876,7 +1877,8 @@ describe("Clickhouse Scores Repository Test", () => {
       ]);
 
       // The per-column helper ranks the merged NUMERIC+BOOLEAN pool, so cross-hot
-      // (combined 6) is the unambiguous #1. The combined scan must agree.
+      // (combined 6) is the unambiguous #1. TypeScript still agrees because SQL
+      // returned both type-rows.
       expect(oldNumeric[0]?.name).toBe("cross-hot");
       expect(combined.numericNames.map((row) => row.name)).toContain(
         "cross-hot",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17307 app preview](https://pr-17307.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Follow-up to #17279. Drops the seven `dense_rank()` windows from the combined scores filter-options scan.

The query still groups by `(name, source, data_type)`, then `ORDER BY count DESC` with `LIMIT {groupLimit: UInt32}` where `groupLimit = FILTER_OPTION_SCORE_NAME_LIMIT * 10` (2000). TypeScript still sums across sources and caps each facet at 200.

Counts of returned groups stay exact. A name whose mass splits across sources or types can fall out of a facet if none of its rows make that 2000. Filter options already skip `FINAL` for the same reason.

This does **not** change the scan (no `approx_top_k`). It only removes post-aggregation ranking. Retarget to `main` after #17279 lands. The same combine-plus-this-query also lives on #17314, which targets `main` directly.

Impacted packages: `@langfuse/shared`, `web`.

## How a name can miss the toplist

ClickHouse ranks **groups**, TypeScript ranks **names**. A name is the sum of up to a few groups:

| | |
| --- | --- |
| Group key | `(name, source, data_type)` |
| Sources | `API`, `EVAL`, `ANNOTATION` (3) |
| Listable types | `NUMERIC`, `BOOLEAN`, `CATEGORICAL`, `TEXT` (4) |
| Theoretical max groups / name | 12 |
| Realistic split | **one type, one source** for intended usage; multiple groups only via migration or accidental reuse |
| SQL bound | `ORDER BY count DESC LIMIT 2000` on groups |
| UI bound | top **200 names** after summing the groups that made it back |

TypeScript only sees rows ClickHouse returned. If every group for a name is outside those 2000, the name is gone from every facet (numeric / boolean / categorical / level columns). If *some* of its groups make the cut, the name still appears, but with an **undercount**, and that undercount can then lose the JS top-200.

### Example (complete miss)

Name `quality` is numeric and written from all three sources:

| Group | Count |
| --- | ---: |
| `(quality, ANNOTATION, NUMERIC)` | 80 |
| `(quality, API, NUMERIC)` | 80 |
| `(quality, EVAL, NUMERIC)` | 80 |
| **Summed name count** | **240** |

The project also has 2000 other groups, each a single-source name with count **81**.

SQL `ORDER BY count DESC LIMIT 2000` keeps those 2000 groups of 81 and drops all three `quality` rows (80 < 81). `topNamesByCount` never sees `quality`, so it is absent from the numeric-name filter even though 240 would have ranked well inside the UI's top 200.

#17279's per-facet ranking would keep `quality`: it ranks names (or each facet's own measure) after grouping, so the summed 240 competes with other names, not with other groups.

### Example (undercount, then miss the UI cap)

Same `quality` split 80/80/80. Only the `ANNOTATION` row makes the 2000 (the other two sit just below the cutoff). TypeScript records `quality` at **80** instead of 240. If names 1–200 in that facet all have summed counts > 80, `quality` is sliced off the UI list even though the true total was 240.

### How likely is this?

The miss needs **two independent conditions at once**, and the first one — a name whose mass splits across groups — is not a shape that supported usage produces.

**A name only splits across groups through accidental or migration data.** The mechanism needs one name spread over several `(source, data_type)` groups, but that is not how scores are meant to be organized:

- **Sources are meant to distinguish, not overlap.** To compare an automated judge against human review, the product pairs two *distinct* scores on the same parent — Score Analytics' "Matched Data" view computes agreement between, e.g., `correctness_llm` and `correctness_human` — not one `correctness` name overloaded across `EVAL` and `ANNOTATION`. A single name spanning sources is what you get from a *migration* (a name written via the API for months, then also emitted by a new evaluator), not from a designed workflow.
- **A name is one data type.** Overloading a name across `NUMERIC` / `CATEGORICAL` / `BOOLEAN` is unsupported — Score Analytics refuses to compare across types and drops `TEXT` entirely. A name carries two types only by accident: value-inferred typing on config-less writes, or a score-config type edited mid-window (old rows keep the old type).

So the split is a property of messy data, not of a project that uses scores as intended.

**Even given a split, the `LIMIT` is a no-op** until the project has **more than 2000 distinct `(name, source, data_type)` groups** in the lookback window — on the order of thousands of distinct score names, since a well-formed name is one group. Below that, every group is returned and every sum is exact. A name that lives in one group can never fall through: its group count *is* its name count, so if it belongs in the top 200 names it is far inside the 2000-group bound.

The miss therefore requires **both** accidental/migration fan-out on a name **and** thousands of names in one window — a narrow, self-inflicted tail. Filter options already skip `FINAL` because some count inaccuracy is acceptable; this is the same class of tradeoff: exact counts for whatever was transferred, and graceful degradation of the filter list for high-cardinality projects with messy score data, not a guarantee that every name that would have ranked in the top 200 after summing is present.

## Type of change

- [x] Refactor (restructures existing code without changing behavior, with a bounded correctness tradeoff on which names are transferred)

## Mandatory Tasks

- [x] Self-reviewed the query shape and the correctness tradeoff.

## Checklist

- Follows repo style (`pnpm run format` via pre-commit)
- No user-facing docs change (internal query shape only)
- Updates the SQL-shape unit test (no `dense_rank`, parameterized `groupLimit`)
- Existing adversarial cap tests in `score-repository.servertest.ts` still pass under LIMIT 2000

## Testing

- [x] Pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total`, `Cached: 0 cached, 7 total`
- [x] `pnpm exec turbo run typecheck --force --filter=web --filter=@langfuse/shared` — `Tasks: 5 successful, 5 total`, `Cached: 0 cached, 5 total`
- [x] `pnpm --filter web run test event-query-builder.servertest.ts` — `Tests 53 passed (53)`
- [x] `pnpm --filter web run test score-repository.servertest.ts -t getScoresFilterOptionsForEventFacets` — `Tests 5 passed | 37 skipped (42)`
- Skipped `knip` (no unused export; no new public symbols)
- Skipped browser / preview walkthrough: query-shape only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-759677df-9d49-418e-a73f-02ed971e5a79?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-759677df-9d49-418e-a73f-02ed971e5a79&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62732617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not safe to merge because the shared transfer limit can remove valid top filter options from otherwise independent facets.

<details open><summary><h3>Summary</h3></summary>

- Retains TypeScript aggregation and the 200-option facet caps.
- Updates SQL-shape assertions and fixture commentary.
- Introduces cross-facet starvation for sufficiently high-cardinality projects because the shared bound is applied before facet-specific ranking.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Scores grouped by name, source, and type] --> B[Global order by total count]
  B --> C[Limit to 2,000 groups]
  C --> D[TypeScript facet fan-out]
  D --> E[Numeric names]
  D --> F[Boolean names]
  D --> G[Categorical names]
  D --> H[Trace-level columns]
  D --> I[Observation-level columns]
  C -. omitted groups never reach their facet .-> J[Missing valid filter options]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["refactor(filter-options): drop exact fac..."](https://github.com/langfuse/langfuse/commit/034bc6a192ed5abd17bdbbb5643ae0671f306c06)</sub>

<!-- /greptile_comment -->
