### PR TITLE
perf(filter-options): combine facet scans with a group-count bound

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/event-filter-options.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-filter-options.ts
@@ -549,6 +549,50 @@ ORDER BY column ASC, tupleElement(option, 4) ASC, tupleElement(option, 2) ASC
   };
 };
 
+/**
+ * One ClickHouse round-trip of exact per-column GROUP BY / LIMIT scans.
+ * Used where filter-option values must stay exact (scores-view facets),
+ * instead of the approx_top_k multi-column sketch.
+ */
+export const buildEventsExactFilterOptionsForColumnsQuery = (params: {
+  projectId: string;
+  filter: FilterState;
+  columns: readonly EventFilterOptionColumn[];
+  limit: number;
+  scope?: EventFilterOptionScope;
+  sampleRows?: number;
+}): { query: string; params: Record<string, unknown> } | null => {
+  const columns = uniqueEventFilterOptionColumns(params.columns);
+  if (columns.length === 0 || params.limit <= 0) {
+    return null;
+  }
+
+  const built = columns.flatMap((column) => {
+    const queryWithParams = buildEventsFilterOptionColumnQuery({
+      projectId: params.projectId,
+      filter: params.filter,
+      column,
+      limit: params.limit,
+      scope: params.scope,
+      sampleRows: params.sampleRows,
+    });
+    return queryWithParams ? [queryWithParams] : [];
+  });
+
+  if (built.length === 0) {
+    return null;
+  }
+
+  if (built.length === 1) {
+    return built[0];
+  }
+
+  return {
+    query: built.map((part) => `(${part.query})`).join("\nUNION ALL\n"),
+    params: Object.assign({}, ...built.map((part) => part.params)),
+  };
+};
+
 /** buildEventsMetadataValuesQuery builds the top-N distinct value query for one metadata key on the events table. */
 export const buildEventsMetadataValuesQuery = (params: {
   projectId: string;

--- a/packages/shared/src/server/queries/clickhouse-sql/score-filter-options.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/score-filter-options.ts
@@ -1,4 +1,4 @@
-import { LISTABLE_SCORE_TYPES, ScoreSourceArray } from "../../../domain/scores";
+import { LISTABLE_SCORE_TYPES } from "../../../domain/scores";
 import { scoresTableCols } from "../../../tableDefinitions/scoresTable";
 import type { FilterState } from "../../../types";
 import { scoresColumnsTableUiColumnDefinitions } from "../../tableMappings/mapScoresColumnsTable";
@@ -7,10 +7,6 @@ import { createFilterFromFilterState } from "./factory";
 
 export const FILTER_OPTION_SCORE_NAME_LIMIT = 200;
 export const FILTER_OPTION_CATEGORICAL_VALUE_LIMIT = 20;
-// Enough (name, source) groups per data_type for the 200-name JS cap after
-// collapsing sources. LIMIT BY data_type keeps facets from starving each other.
-export const FILTER_OPTION_SCORE_GROUPS_PER_TYPE_LIMIT =
-  FILTER_OPTION_SCORE_NAME_LIMIT * ScoreSourceArray.length;
 
 /**
  * One `scores` scan that materialises every event-table score-name facet
@@ -27,41 +23,75 @@ export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
   );
   const filterRes = new FilterList(chFilter).apply();
 
+  // The repository sums each (name, source) group's count across sources before
+  // ranking names, so bound by the per-name summed count — not by raw per-source
+  // rows. Ranking rows before the roll-up would drop a name whose total is the
+  // project's highest but is split thinly across sources. Rank names within each
+  // data_type by summed count (name as the tiebreak, matching the JS cap), keep
+  // the top-N names, and return all their source rows for the roll-up.
   const query = `
+    WITH grouped AS (
+      SELECT
+        s.name AS name,
+        s.source AS source,
+        s.data_type AS data_type,
+        count() AS count,
+        countIf(isNull(s.observation_id)) AS trace_count,
+        countIf(isNotNull(s.observation_id)) AS observation_count,
+        groupUniqArrayIf(${FILTER_OPTION_CATEGORICAL_VALUE_LIMIT})(
+          s.string_value,
+          s.data_type = 'CATEGORICAL'
+        ) AS categorical_values,
+        groupUniqArrayIf(${FILTER_OPTION_CATEGORICAL_VALUE_LIMIT})(
+          s.string_value,
+          s.data_type = 'CATEGORICAL' AND isNull(s.observation_id)
+        ) AS trace_categorical_values,
+        countIf(
+          s.data_type = 'BOOLEAN'
+          AND s.string_value IS NOT NULL
+          AND s.string_value != ''
+        ) AS boolean_value_count,
+        countIf(
+          s.data_type = 'BOOLEAN'
+          AND s.string_value IS NOT NULL
+          AND s.string_value != ''
+          AND isNull(s.observation_id)
+        ) AS trace_boolean_value_count
+      FROM scores s
+      WHERE s.project_id = {projectId: String}
+        AND isNotNull(s.trace_id)
+        AND s.data_type IN ({dataTypes: Array(String)})
+        ${filterRes.query ? `AND ${filterRes.query}` : ""}
+      GROUP BY name, source, data_type
+    ),
+    with_name_total AS (
+      SELECT
+        grouped.*,
+        sum(count) OVER (PARTITION BY data_type, name) AS name_total
+      FROM grouped
+    ),
+    ranked AS (
+      SELECT
+        with_name_total.*,
+        dense_rank() OVER (
+          PARTITION BY data_type
+          ORDER BY name_total DESC, name ASC
+        ) AS name_rank
+      FROM with_name_total
+    )
     SELECT
-      s.name AS name,
-      s.source AS source,
-      s.data_type AS data_type,
-      count() AS count,
-      countIf(isNull(s.observation_id)) AS trace_count,
-      countIf(isNotNull(s.observation_id)) AS observation_count,
-      groupUniqArrayIf(${FILTER_OPTION_CATEGORICAL_VALUE_LIMIT})(
-        s.string_value,
-        s.data_type = 'CATEGORICAL'
-      ) AS categorical_values,
-      groupUniqArrayIf(${FILTER_OPTION_CATEGORICAL_VALUE_LIMIT})(
-        s.string_value,
-        s.data_type = 'CATEGORICAL' AND isNull(s.observation_id)
-      ) AS trace_categorical_values,
-      countIf(
-        s.data_type = 'BOOLEAN'
-        AND s.string_value IS NOT NULL
-        AND s.string_value != ''
-      ) AS boolean_value_count,
-      countIf(
-        s.data_type = 'BOOLEAN'
-        AND s.string_value IS NOT NULL
-        AND s.string_value != ''
-        AND isNull(s.observation_id)
-      ) AS trace_boolean_value_count
-    FROM scores s
-    WHERE s.project_id = {projectId: String}
-      AND isNotNull(s.trace_id)
-      AND s.data_type IN ({dataTypes: Array(String)})
-      ${filterRes.query ? `AND ${filterRes.query}` : ""}
-    GROUP BY name, source, data_type
-    ORDER BY count DESC
-    LIMIT {maxGroupsPerType: UInt32} BY data_type
+      name,
+      source,
+      data_type,
+      count,
+      trace_count,
+      observation_count,
+      categorical_values,
+      trace_categorical_values,
+      boolean_value_count,
+      trace_boolean_value_count
+    FROM ranked
+    WHERE name_rank <= {maxNamesPerType: UInt32}
   `.trim();
 
   return {
@@ -69,7 +99,7 @@ export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
     params: {
       projectId: params.projectId,
       dataTypes: [...LISTABLE_SCORE_TYPES],
-      maxGroupsPerType: FILTER_OPTION_SCORE_GROUPS_PER_TYPE_LIMIT,
+      maxNamesPerType: FILTER_OPTION_SCORE_NAME_LIMIT,
       ...filterRes.params,
     },
   };

--- a/packages/shared/src/server/queries/clickhouse-sql/score-filter-options.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/score-filter-options.ts
@@ -1,4 +1,4 @@
-import { LISTABLE_SCORE_TYPES } from "../../../domain/scores";
+import { LISTABLE_SCORE_TYPES, ScoreSourceArray } from "../../../domain/scores";
 import { scoresTableCols } from "../../../tableDefinitions/scoresTable";
 import type { FilterState } from "../../../types";
 import { scoresColumnsTableUiColumnDefinitions } from "../../tableMappings/mapScoresColumnsTable";
@@ -7,6 +7,10 @@ import { createFilterFromFilterState } from "./factory";
 
 export const FILTER_OPTION_SCORE_NAME_LIMIT = 200;
 export const FILTER_OPTION_CATEGORICAL_VALUE_LIMIT = 20;
+// Enough (name, source) groups per data_type for the 200-name JS cap after
+// collapsing sources. LIMIT BY data_type keeps facets from starving each other.
+export const FILTER_OPTION_SCORE_GROUPS_PER_TYPE_LIMIT =
+  FILTER_OPTION_SCORE_NAME_LIMIT * ScoreSourceArray.length;
 
 /**
  * One `scores` scan that materialises every event-table score-name facet
@@ -57,6 +61,7 @@ export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
       ${filterRes.query ? `AND ${filterRes.query}` : ""}
     GROUP BY name, source, data_type
     ORDER BY count DESC
+    LIMIT {maxGroupsPerType: UInt32} BY data_type
   `.trim();
 
   return {
@@ -64,6 +69,7 @@ export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
     params: {
       projectId: params.projectId,
       dataTypes: [...LISTABLE_SCORE_TYPES],
+      maxGroupsPerType: FILTER_OPTION_SCORE_GROUPS_PER_TYPE_LIMIT,
       ...filterRes.params,
     },
   };

--- a/packages/shared/src/server/queries/clickhouse-sql/score-filter-options.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/score-filter-options.ts
@@ -1,0 +1,70 @@
+import { LISTABLE_SCORE_TYPES } from "../../../domain/scores";
+import { scoresTableCols } from "../../../tableDefinitions/scoresTable";
+import type { FilterState } from "../../../types";
+import { scoresColumnsTableUiColumnDefinitions } from "../../tableMappings/mapScoresColumnsTable";
+import { FilterList } from "./clickhouse-filter";
+import { createFilterFromFilterState } from "./factory";
+
+export const FILTER_OPTION_SCORE_NAME_LIMIT = 200;
+export const FILTER_OPTION_CATEGORICAL_VALUE_LIMIT = 20;
+
+/**
+ * One `scores` scan that materialises every event-table score-name facet
+ * via conditional aggregation (numeric / boolean / categorical / level).
+ */
+export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
+  projectId: string;
+  timestampFilter: FilterState;
+}): { query: string; params: Record<string, unknown> } => {
+  const chFilter = createFilterFromFilterState(
+    params.timestampFilter,
+    scoresColumnsTableUiColumnDefinitions,
+    scoresTableCols,
+  );
+  const filterRes = new FilterList(chFilter).apply();
+
+  const query = `
+    SELECT
+      s.name AS name,
+      s.source AS source,
+      s.data_type AS data_type,
+      count() AS count,
+      countIf(isNull(s.observation_id)) AS trace_count,
+      countIf(isNotNull(s.observation_id)) AS observation_count,
+      groupUniqArrayIf(${FILTER_OPTION_CATEGORICAL_VALUE_LIMIT})(
+        s.string_value,
+        s.data_type = 'CATEGORICAL'
+      ) AS categorical_values,
+      groupUniqArrayIf(${FILTER_OPTION_CATEGORICAL_VALUE_LIMIT})(
+        s.string_value,
+        s.data_type = 'CATEGORICAL' AND isNull(s.observation_id)
+      ) AS trace_categorical_values,
+      countIf(
+        s.data_type = 'BOOLEAN'
+        AND s.string_value IS NOT NULL
+        AND s.string_value != ''
+      ) AS boolean_value_count,
+      countIf(
+        s.data_type = 'BOOLEAN'
+        AND s.string_value IS NOT NULL
+        AND s.string_value != ''
+        AND isNull(s.observation_id)
+      ) AS trace_boolean_value_count
+    FROM scores s
+    WHERE s.project_id = {projectId: String}
+      AND isNotNull(s.trace_id)
+      AND s.data_type IN ({dataTypes: Array(String)})
+      ${filterRes.query ? `AND ${filterRes.query}` : ""}
+    GROUP BY name, source, data_type
+    ORDER BY count DESC
+  `.trim();
+
+  return {
+    query,
+    params: {
+      projectId: params.projectId,
+      dataTypes: [...LISTABLE_SCORE_TYPES],
+      ...filterRes.params,
+    },
+  };
+};

--- a/packages/shared/src/server/queries/clickhouse-sql/score-filter-options.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/score-filter-options.ts
@@ -8,9 +8,20 @@ import { createFilterFromFilterState } from "./factory";
 export const FILTER_OPTION_SCORE_NAME_LIMIT = 200;
 export const FILTER_OPTION_CATEGORICAL_VALUE_LIMIT = 20;
 
+// Transfer bound on (name, source, data_type) groups. The 200-name UI cap is
+// applied in TypeScript after summing across sources; this is only so a
+// project with thousands of distinct groups does not return all of them.
+const FILTER_OPTION_SCORE_GROUP_LIMIT = FILTER_OPTION_SCORE_NAME_LIMIT * 10;
+
 /**
  * One `scores` scan that materialises every event-table score-name facet
  * via conditional aggregation (numeric / boolean / categorical / level).
+ *
+ * Counts of returned groups are exact. Which groups are returned is not:
+ * ClickHouse keeps the most frequent (name, source, data_type) rows (ten
+ * times the UI name cap) and drops the rest. A name whose mass splits
+ * across sources or data types can fall out of a facet even when its
+ * summed count would have ranked in that facet's top 200.
  */
 export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
   projectId: string;
@@ -23,104 +34,41 @@ export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
   );
   const filterRes = new FilterList(chFilter).apply();
 
-  // The repository rolls these rows up into seven facets, each with a different
-  // pool and count measure, and caps each independently. One shared cap cannot
-  // reproduce all seven: a name outside one facet's top-N can top another, and a
-  // name whose measure splits across sources or across NUMERIC/BOOLEAN can lead
-  // its facet while trailing on every single (source, data_type) row. Rank each
-  // facet on its own measure and keep a row that survives ANY cap, so each
-  // roll-up reads a superset of its true top-N. Name-facet ranks partition per
-  // name so a name's rows share one rank; column facets rank rows directly.
-  const cap = FILTER_OPTION_SCORE_NAME_LIMIT;
   const query = `
-    WITH grouped AS (
-      SELECT
-        s.name AS name,
-        s.source AS source,
-        s.data_type AS data_type,
-        count() AS count,
-        countIf(isNull(s.observation_id)) AS trace_count,
-        countIf(isNotNull(s.observation_id)) AS observation_count,
-        groupUniqArrayIf(${FILTER_OPTION_CATEGORICAL_VALUE_LIMIT})(
-          s.string_value,
-          s.data_type = 'CATEGORICAL'
-        ) AS categorical_values,
-        groupUniqArrayIf(${FILTER_OPTION_CATEGORICAL_VALUE_LIMIT})(
-          s.string_value,
-          s.data_type = 'CATEGORICAL' AND isNull(s.observation_id)
-        ) AS trace_categorical_values,
-        countIf(
-          s.data_type = 'BOOLEAN'
-          AND s.string_value IS NOT NULL
-          AND s.string_value != ''
-        ) AS boolean_value_count,
-        countIf(
-          s.data_type = 'BOOLEAN'
-          AND s.string_value IS NOT NULL
-          AND s.string_value != ''
-          AND isNull(s.observation_id)
-        ) AS trace_boolean_value_count
-      FROM scores s
-      WHERE s.project_id = {projectId: String}
-        AND isNotNull(s.trace_id)
-        AND s.data_type IN ({dataTypes: Array(String)})
-        ${filterRes.query ? `AND ${filterRes.query}` : ""}
-      GROUP BY name, source, data_type
-    ),
-    name_totals AS (
-      SELECT
-        grouped.*,
-        sumIf(count, data_type IN ('NUMERIC', 'BOOLEAN'))
-          OVER (PARTITION BY name) AS numeric_name_total,
-        sum(boolean_value_count) OVER (PARTITION BY name) AS boolean_name_total,
-        sumIf(count, data_type = 'CATEGORICAL')
-          OVER (PARTITION BY name) AS categorical_name_total,
-        sumIf(trace_count, data_type = 'CATEGORICAL')
-          OVER (PARTITION BY name) AS trace_categorical_name_total,
-        sum(trace_boolean_value_count)
-          OVER (PARTITION BY name) AS trace_boolean_name_total
-      FROM grouped
-    ),
-    ranked AS (
-      SELECT
-        name_totals.*,
-        dense_rank() OVER (ORDER BY numeric_name_total DESC, name ASC)
-          AS numeric_name_rank,
-        dense_rank() OVER (ORDER BY boolean_name_total DESC, name ASC)
-          AS boolean_name_rank,
-        dense_rank() OVER (ORDER BY categorical_name_total DESC, name ASC)
-          AS categorical_name_rank,
-        dense_rank() OVER (ORDER BY trace_categorical_name_total DESC, name ASC)
-          AS trace_categorical_name_rank,
-        dense_rank() OVER (ORDER BY trace_boolean_name_total DESC, name ASC)
-          AS trace_boolean_name_rank,
-        dense_rank() OVER (
-          ORDER BY observation_count DESC, name ASC, source ASC, data_type ASC
-        ) AS observation_column_rank,
-        dense_rank() OVER (
-          ORDER BY trace_count DESC, name ASC, source ASC, data_type ASC
-        ) AS trace_column_rank
-      FROM name_totals
-    )
     SELECT
-      name,
-      source,
-      data_type,
-      count,
-      trace_count,
-      observation_count,
-      categorical_values,
-      trace_categorical_values,
-      boolean_value_count,
-      trace_boolean_value_count
-    FROM ranked
-    WHERE numeric_name_rank <= {cap: UInt32}
-      OR boolean_name_rank <= {cap: UInt32}
-      OR categorical_name_rank <= {cap: UInt32}
-      OR trace_categorical_name_rank <= {cap: UInt32}
-      OR trace_boolean_name_rank <= {cap: UInt32}
-      OR observation_column_rank <= {cap: UInt32}
-      OR trace_column_rank <= {cap: UInt32}
+      s.name AS name,
+      s.source AS source,
+      s.data_type AS data_type,
+      count() AS count,
+      countIf(isNull(s.observation_id)) AS trace_count,
+      countIf(isNotNull(s.observation_id)) AS observation_count,
+      groupUniqArrayIf(${FILTER_OPTION_CATEGORICAL_VALUE_LIMIT})(
+        s.string_value,
+        s.data_type = 'CATEGORICAL'
+      ) AS categorical_values,
+      groupUniqArrayIf(${FILTER_OPTION_CATEGORICAL_VALUE_LIMIT})(
+        s.string_value,
+        s.data_type = 'CATEGORICAL' AND isNull(s.observation_id)
+      ) AS trace_categorical_values,
+      countIf(
+        s.data_type = 'BOOLEAN'
+        AND s.string_value IS NOT NULL
+        AND s.string_value != ''
+      ) AS boolean_value_count,
+      countIf(
+        s.data_type = 'BOOLEAN'
+        AND s.string_value IS NOT NULL
+        AND s.string_value != ''
+        AND isNull(s.observation_id)
+      ) AS trace_boolean_value_count
+    FROM scores s
+    WHERE s.project_id = {projectId: String}
+      AND isNotNull(s.trace_id)
+      AND s.data_type IN ({dataTypes: Array(String)})
+      ${filterRes.query ? `AND ${filterRes.query}` : ""}
+    GROUP BY name, source, data_type
+    ORDER BY count DESC, name ASC, source ASC, data_type ASC
+    LIMIT {groupLimit: UInt32}
   `.trim();
 
   return {
@@ -128,7 +76,7 @@ export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
     params: {
       projectId: params.projectId,
       dataTypes: [...LISTABLE_SCORE_TYPES],
-      cap,
+      groupLimit: FILTER_OPTION_SCORE_GROUP_LIMIT,
       ...filterRes.params,
     },
   };

--- a/packages/shared/src/server/queries/clickhouse-sql/score-filter-options.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/score-filter-options.ts
@@ -23,12 +23,15 @@ export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
   );
   const filterRes = new FilterList(chFilter).apply();
 
-  // The repository sums each (name, source) group's count across sources before
-  // ranking names, so bound by the per-name summed count — not by raw per-source
-  // rows. Ranking rows before the roll-up would drop a name whose total is the
-  // project's highest but is split thinly across sources. Rank names within each
-  // data_type by summed count (name as the tiebreak, matching the JS cap), keep
-  // the top-N names, and return all their source rows for the roll-up.
+  // The repository rolls these rows up into seven facets, each with a different
+  // pool and count measure, and caps each independently. One shared cap cannot
+  // reproduce all seven: a name outside one facet's top-N can top another, and a
+  // name whose measure splits across sources or across NUMERIC/BOOLEAN can lead
+  // its facet while trailing on every single (source, data_type) row. Rank each
+  // facet on its own measure and keep a row that survives ANY cap, so each
+  // roll-up reads a superset of its true top-N. Name-facet ranks partition per
+  // name so a name's rows share one rank; column facets rank rows directly.
+  const cap = FILTER_OPTION_SCORE_NAME_LIMIT;
   const query = `
     WITH grouped AS (
       SELECT
@@ -64,20 +67,40 @@ export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
         ${filterRes.query ? `AND ${filterRes.query}` : ""}
       GROUP BY name, source, data_type
     ),
-    with_name_total AS (
+    name_totals AS (
       SELECT
         grouped.*,
-        sum(count) OVER (PARTITION BY data_type, name) AS name_total
+        sumIf(count, data_type IN ('NUMERIC', 'BOOLEAN'))
+          OVER (PARTITION BY name) AS numeric_name_total,
+        sum(boolean_value_count) OVER (PARTITION BY name) AS boolean_name_total,
+        sumIf(count, data_type = 'CATEGORICAL')
+          OVER (PARTITION BY name) AS categorical_name_total,
+        sumIf(trace_count, data_type = 'CATEGORICAL')
+          OVER (PARTITION BY name) AS trace_categorical_name_total,
+        sum(trace_boolean_value_count)
+          OVER (PARTITION BY name) AS trace_boolean_name_total
       FROM grouped
     ),
     ranked AS (
       SELECT
-        with_name_total.*,
+        name_totals.*,
+        dense_rank() OVER (ORDER BY numeric_name_total DESC, name ASC)
+          AS numeric_name_rank,
+        dense_rank() OVER (ORDER BY boolean_name_total DESC, name ASC)
+          AS boolean_name_rank,
+        dense_rank() OVER (ORDER BY categorical_name_total DESC, name ASC)
+          AS categorical_name_rank,
+        dense_rank() OVER (ORDER BY trace_categorical_name_total DESC, name ASC)
+          AS trace_categorical_name_rank,
+        dense_rank() OVER (ORDER BY trace_boolean_name_total DESC, name ASC)
+          AS trace_boolean_name_rank,
         dense_rank() OVER (
-          PARTITION BY data_type
-          ORDER BY name_total DESC, name ASC
-        ) AS name_rank
-      FROM with_name_total
+          ORDER BY observation_count DESC, name ASC, source ASC, data_type ASC
+        ) AS observation_column_rank,
+        dense_rank() OVER (
+          ORDER BY trace_count DESC, name ASC, source ASC, data_type ASC
+        ) AS trace_column_rank
+      FROM name_totals
     )
     SELECT
       name,
@@ -91,7 +114,13 @@ export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
       boolean_value_count,
       trace_boolean_value_count
     FROM ranked
-    WHERE name_rank <= {maxNamesPerType: UInt32}
+    WHERE numeric_name_rank <= {cap: UInt32}
+      OR boolean_name_rank <= {cap: UInt32}
+      OR categorical_name_rank <= {cap: UInt32}
+      OR trace_categorical_name_rank <= {cap: UInt32}
+      OR trace_boolean_name_rank <= {cap: UInt32}
+      OR observation_column_rank <= {cap: UInt32}
+      OR trace_column_rank <= {cap: UInt32}
   `.trim();
 
   return {
@@ -99,7 +128,7 @@ export const buildScoresFilterOptionsForEventFacetsQuery = (params: {
     params: {
       projectId: params.projectId,
       dataTypes: [...LISTABLE_SCORE_TYPES],
-      maxNamesPerType: FILTER_OPTION_SCORE_NAME_LIMIT,
+      cap,
       ...filterRes.params,
     },
   };

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -86,7 +86,6 @@ export {
 } from "./clickhouse-sql/event-filter-options";
 export {
   buildScoresFilterOptionsForEventFacetsQuery,
-  FILTER_OPTION_SCORE_GROUPS_PER_TYPE_LIMIT,
   FILTER_OPTION_SCORE_NAME_LIMIT,
   FILTER_OPTION_CATEGORICAL_VALUE_LIMIT,
 } from "./clickhouse-sql/score-filter-options";

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -83,6 +83,7 @@ export {
   type EventFilterOptionColumn,
   type EventFilterOptionScope,
 } from "./clickhouse-sql/event-filter-options";
+export { buildScoresFilterOptionsForEventFacetsQuery } from "./clickhouse-sql/score-filter-options";
 export {
   eventsScoresAggregation,
   eventsSessionsAggregation,

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -87,6 +87,8 @@ export {
 export {
   buildScoresFilterOptionsForEventFacetsQuery,
   FILTER_OPTION_SCORE_GROUPS_PER_TYPE_LIMIT,
+  FILTER_OPTION_SCORE_NAME_LIMIT,
+  FILTER_OPTION_CATEGORICAL_VALUE_LIMIT,
 } from "./clickhouse-sql/score-filter-options";
 export {
   eventsScoresAggregation,

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -75,6 +75,7 @@ export {
 export {
   buildEventsFilterOptionColumnQuery,
   buildEventsFilterOptionsForColumnsQuery,
+  buildEventsExactFilterOptionsForColumnsQuery,
   buildEventsMetadataValuesQuery,
   EVENTS_FILTER_OPTION_TOP_N,
   EVENTS_APPROX_TOTAL_COUNT_MARKER,
@@ -83,7 +84,10 @@ export {
   type EventFilterOptionColumn,
   type EventFilterOptionScope,
 } from "./clickhouse-sql/event-filter-options";
-export { buildScoresFilterOptionsForEventFacetsQuery } from "./clickhouse-sql/score-filter-options";
+export {
+  buildScoresFilterOptionsForEventFacetsQuery,
+  FILTER_OPTION_SCORE_GROUPS_PER_TYPE_LIMIT,
+} from "./clickhouse-sql/score-filter-options";
 export {
   eventsScoresAggregation,
   eventsSessionsAggregation,

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2234,20 +2234,6 @@ const getSingleEventsFilterOptionColumn = async (
     sampleRows: EVENTS_FILTER_OPTION_SAMPLE_ROWS,
   });
 
-export const getEventsGroupedByTraceName = async (
-  projectId: string,
-  filter: FilterState,
-  opts?: GroupedEventsFilterOptions,
-) => {
-  const rows = await getSingleEventsFilterOptionColumn(
-    projectId,
-    filter,
-    "traceName",
-    opts,
-  );
-  return rows.map((row) => ({ traceName: row.value, count: row.count }));
-};
-
 export const getEventsGroupedByTraceTags = async (
   projectId: string,
   filter: FilterState,

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -117,6 +117,7 @@ import {
 import {
   buildEventsFilterOptionColumnQuery,
   buildEventsFilterOptionsForColumnsQuery,
+  buildEventsExactFilterOptionsForColumnsQuery,
   buildEventsMetadataValuesQuery,
   EVENTS_FILTER_OPTION_SAMPLE_ROWS,
   EVENTS_FILTER_OPTION_TOP_N,
@@ -2065,12 +2066,16 @@ type BuiltEventsFilterOptionColumnQuery = NonNullable<
 type BuiltEventsFilterOptionsForColumnsQuery = NonNullable<
   ReturnType<typeof buildEventsFilterOptionsForColumnsQuery>
 >;
+type BuiltEventsExactFilterOptionsForColumnsQuery = NonNullable<
+  ReturnType<typeof buildEventsExactFilterOptionsForColumnsQuery>
+>;
 
 const queryEventsFilterOptionRows = async (
   projectId: string,
   queryWithParams:
     | BuiltEventsFilterOptionColumnQuery
-    | BuiltEventsFilterOptionsForColumnsQuery,
+    | BuiltEventsFilterOptionsForColumnsQuery
+    | BuiltEventsExactFilterOptionsForColumnsQuery,
 ) => {
   return queryClickhouse<EventFilterOptionRow>({
     query: queryWithParams.query,
@@ -2143,6 +2148,30 @@ export const getEventsFilterOptionsForColumns = async (params: {
     ...params,
     limit: params.topN ?? EVENTS_FILTER_OPTION_TOP_N,
   });
+
+/** Exact GROUP BY / LIMIT per column in one ClickHouse round-trip (UNION ALL). */
+export const getEventsExactFilterOptionsForColumns = async (params: {
+  projectId: string;
+  filter: FilterState;
+  columns: readonly EventFilterOptionColumn[];
+  topN?: number;
+  scope?: EventFilterOptionScope;
+}) => {
+  const queryWithParams = buildEventsExactFilterOptionsForColumnsQuery({
+    projectId: params.projectId,
+    filter: params.filter,
+    columns: params.columns,
+    limit: params.topN ?? EVENTS_FILTER_OPTION_TOP_N,
+    scope: params.scope,
+    sampleRows: EVENTS_FILTER_OPTION_SAMPLE_ROWS,
+  });
+
+  if (!queryWithParams) {
+    return [];
+  }
+
+  return queryEventsFilterOptionRows(params.projectId, queryWithParams);
+};
 
 // Unsampled: the cursor contract lets MCP agents page the true distinct set.
 export const getEventsFilterOptionValuesPage = async (params: {

--- a/packages/shared/src/server/repositories/scoreEventFacets.ts
+++ b/packages/shared/src/server/repositories/scoreEventFacets.ts
@@ -1,0 +1,126 @@
+import { ScoreSourceType, ListableScoreDataType } from "../../domain/scores";
+import {
+  FILTER_OPTION_CATEGORICAL_VALUE_LIMIT,
+  FILTER_OPTION_SCORE_NAME_LIMIT,
+} from "../queries/clickhouse-sql/score-filter-options";
+
+/**
+ * One row of the combined score-name facet scan run by
+ * `getScoresFilterOptionsForEventFacets`. Counts arrive as strings from
+ * ClickHouse and are coerced by the callers that shape each facet.
+ */
+export type EventFilterScoreNameRow = {
+  name: string;
+  source: string;
+  data_type: string;
+  count: string;
+  trace_count: string;
+  observation_count: string;
+  categorical_values: string[];
+  trace_categorical_values: string[];
+  boolean_value_count: string;
+  trace_boolean_value_count: string;
+};
+
+type EventFilterScoreColumn = {
+  name: string;
+  source: ScoreSourceType;
+  dataType: ListableScoreDataType;
+};
+
+export type EventFilterScoreNameOptions = {
+  numericNames: { name: string }[];
+  booleanNames: { name: string }[];
+  categoricalNames: { label: string; values: string[] }[];
+  traceScoreColumns: EventFilterScoreColumn[];
+  traceCategoricalNames: { label: string; values: string[] }[];
+  traceBooleanNames: { name: string }[];
+  observationLevelScores: EventFilterScoreColumn[];
+  traceLevelScores: EventFilterScoreColumn[];
+};
+
+export const EMPTY_EVENT_FILTER_SCORE_NAME_OPTIONS: EventFilterScoreNameOptions =
+  {
+    numericNames: [],
+    booleanNames: [],
+    categoricalNames: [],
+    traceScoreColumns: [],
+    traceCategoricalNames: [],
+    traceBooleanNames: [],
+    observationLevelScores: [],
+    traceLevelScores: [],
+  };
+
+// Highest count first; name as a stable tiebreaker.
+const compareNameCount = (
+  left: { name: string; count: number },
+  right: { name: string; count: number },
+) => right.count - left.count || left.name.localeCompare(right.name);
+
+// Sum counts per name, then keep the top names.
+export const topNamesByCount = (
+  rows: { name: string; count: number }[],
+): { name: string }[] => {
+  const byName = new Map<string, number>();
+  for (const row of rows) {
+    byName.set(row.name, (byName.get(row.name) ?? 0) + row.count);
+  }
+
+  return [...byName.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort(compareNameCount)
+    .slice(0, FILTER_OPTION_SCORE_NAME_LIMIT)
+    .map(({ name }) => ({ name }));
+};
+
+// Like topNamesByCount, but unions the categorical values seen per name.
+export const topCategoricalByCount = (
+  rows: { name: string; count: number; values: string[] }[],
+): { label: string; values: string[] }[] => {
+  const byName = new Map<string, { count: number; values: Set<string> }>();
+  for (const row of rows) {
+    const existing = byName.get(row.name) ?? { count: 0, values: new Set() };
+    existing.count += row.count;
+    for (const value of row.values) {
+      existing.values.add(value);
+    }
+    byName.set(row.name, existing);
+  }
+
+  return [...byName.entries()]
+    .map(([name, aggregate]) => ({
+      name,
+      count: aggregate.count,
+      values: [...aggregate.values].slice(
+        0,
+        FILTER_OPTION_CATEGORICAL_VALUE_LIMIT,
+      ),
+    }))
+    .sort(compareNameCount)
+    .slice(0, FILTER_OPTION_SCORE_NAME_LIMIT)
+    .map(({ name, values }) => ({ label: name, values }));
+};
+
+const toScoreColumn = (
+  row: EventFilterScoreNameRow,
+): EventFilterScoreColumn => ({
+  name: row.name,
+  source: row.source as ScoreSourceType,
+  dataType: row.data_type as ListableScoreDataType,
+});
+
+// Top score columns keyed by the full name/source/data_type triple; rows are
+// already one per column, so no aggregation is needed.
+export const topScoreColumnsByCount = (
+  rows: { row: EventFilterScoreNameRow; count: number }[],
+): EventFilterScoreColumn[] =>
+  rows
+    .sort(
+      (left, right) =>
+        right.count - left.count ||
+        left.row.name.localeCompare(right.row.name) ||
+        left.row.source.localeCompare(right.row.source) ||
+        left.row.data_type.localeCompare(right.row.data_type),
+    )
+    .slice(0, FILTER_OPTION_SCORE_NAME_LIMIT)
+    .map(({ row }) => toScoreColumn(row));

--- a/packages/shared/src/server/repositories/scoreEventFacets.ts
+++ b/packages/shared/src/server/repositories/scoreEventFacets.ts
@@ -32,7 +32,6 @@ export type EventFilterScoreNameOptions = {
   numericNames: { name: string }[];
   booleanNames: { name: string }[];
   categoricalNames: { label: string; values: string[] }[];
-  traceScoreColumns: EventFilterScoreColumn[];
   traceCategoricalNames: { label: string; values: string[] }[];
   traceBooleanNames: { name: string }[];
   observationLevelScores: EventFilterScoreColumn[];
@@ -44,7 +43,6 @@ export const EMPTY_EVENT_FILTER_SCORE_NAME_OPTIONS: EventFilterScoreNameOptions 
     numericNames: [],
     booleanNames: [],
     categoricalNames: [],
-    traceScoreColumns: [],
     traceCategoricalNames: [],
     traceBooleanNames: [],
     observationLevelScores: [],

--- a/packages/shared/src/server/repositories/scoreEventFacets.ts
+++ b/packages/shared/src/server/repositories/scoreEventFacets.ts
@@ -7,7 +7,7 @@ import {
 /**
  * One row of the combined score-name facet scan run by
  * `getScoresFilterOptionsForEventFacets`. Counts arrive as strings from
- * ClickHouse and are coerced by the callers that shape each facet.
+ * ClickHouse and are coerced once by the caller before it shapes each facet.
  */
 export type EventFilterScoreNameRow = {
   name: string;

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1141,8 +1141,10 @@ const mergeCategoricalScoreConfigValues = async (
   projectId: string,
   rows: { label: string; values: string[] }[],
 ): Promise<{ label: string; values: string[] }[]> => {
+  // Get score names from ClickHouse results to query score configs
   const scoreNames = rows.map((row) => row.label);
 
+  // Query score_configs table for categorical configurations
   const scoreConfigs =
     scoreNames.length > 0
       ? await prisma.scoreConfig.findMany({
@@ -1161,18 +1163,23 @@ const mergeCategoricalScoreConfigValues = async (
         })
       : [];
 
+  // Create a map of score configs for easy lookup
   const configMap = new Map(
     scoreConfigs.map((config) => [config.name, config.categories]),
   );
 
+  // Enhance the results with all possible category values from score configs
   return rows.map((row) => {
     const configCategories = configMap.get(row.label);
 
     if (configCategories && Array.isArray(configCategories)) {
+      // Extract all possible category labels from the score config
       const allPossibleValues = (
         configCategories as Array<{ label: string; value: number }>
       ).map((category) => category.label);
 
+      // Merge actual values from ClickHouse with all possible values from config
+      // Use Set to ensure uniqueness
       const mergedValues = Array.from(
         new Set([...row.values, ...allPossibleValues]),
       ).slice(0, FILTER_OPTION_CATEGORICAL_VALUE_LIMIT);
@@ -1183,6 +1190,7 @@ const mergeCategoricalScoreConfigValues = async (
       };
     }
 
+    // If no config found, return original values
     return row;
   });
 };

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1294,7 +1294,6 @@ export const getScoresFilterOptionsForEventFacets = async ({
     numericNames,
     booleanNames,
     categoricalNames: mergedCategoricalNames,
-    traceScoreColumns: traceLevelScores,
     traceCategoricalNames: mergedTraceCategoricalNames,
     traceBooleanNames,
     observationLevelScores,

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -84,6 +84,14 @@ import {
   FILTER_OPTION_CATEGORICAL_VALUE_LIMIT,
   FILTER_OPTION_SCORE_NAME_LIMIT,
 } from "../queries/clickhouse-sql/score-filter-options";
+import {
+  EMPTY_EVENT_FILTER_SCORE_NAME_OPTIONS,
+  EventFilterScoreNameOptions,
+  EventFilterScoreNameRow,
+  topCategoricalByCount,
+  topNamesByCount,
+  topScoreColumnsByCount,
+} from "./scoreEventFacets";
 
 export const searchExistingAnnotationScore = async (
   projectId: string,
@@ -1194,116 +1202,6 @@ const mergeCategoricalScoreConfigValues = async (
     return row;
   });
 };
-
-type EventFilterScoreNameRow = {
-  name: string;
-  source: string;
-  data_type: string;
-  count: string;
-  trace_count: string;
-  observation_count: string;
-  categorical_values: string[];
-  trace_categorical_values: string[];
-  boolean_value_count: string;
-  trace_boolean_value_count: string;
-};
-
-type EventFilterScoreColumn = {
-  name: string;
-  source: ScoreSourceType;
-  dataType: ListableScoreDataType;
-};
-
-type EventFilterScoreNameOptions = {
-  numericNames: { name: string }[];
-  booleanNames: { name: string }[];
-  categoricalNames: { label: string; values: string[] }[];
-  traceScoreColumns: EventFilterScoreColumn[];
-  traceCategoricalNames: { label: string; values: string[] }[];
-  traceBooleanNames: { name: string }[];
-  observationLevelScores: EventFilterScoreColumn[];
-  traceLevelScores: EventFilterScoreColumn[];
-};
-
-const EMPTY_EVENT_FILTER_SCORE_NAME_OPTIONS: EventFilterScoreNameOptions = {
-  numericNames: [],
-  booleanNames: [],
-  categoricalNames: [],
-  traceScoreColumns: [],
-  traceCategoricalNames: [],
-  traceBooleanNames: [],
-  observationLevelScores: [],
-  traceLevelScores: [],
-};
-
-const compareNameCount = (
-  left: { name: string; count: number },
-  right: { name: string; count: number },
-) => right.count - left.count || left.name.localeCompare(right.name);
-
-const topNamesByCount = (
-  rows: { name: string; count: number }[],
-): { name: string }[] => {
-  const byName = new Map<string, number>();
-  for (const row of rows) {
-    byName.set(row.name, (byName.get(row.name) ?? 0) + row.count);
-  }
-
-  return [...byName.entries()]
-    .map(([name, count]) => ({ name, count }))
-    .sort(compareNameCount)
-    .slice(0, FILTER_OPTION_SCORE_NAME_LIMIT)
-    .map(({ name }) => ({ name }));
-};
-
-const topCategoricalByCount = (
-  rows: { name: string; count: number; values: string[] }[],
-): { label: string; values: string[] }[] => {
-  const byName = new Map<string, { count: number; values: Set<string> }>();
-  for (const row of rows) {
-    const existing = byName.get(row.name) ?? { count: 0, values: new Set() };
-    existing.count += row.count;
-    for (const value of row.values) {
-      existing.values.add(value);
-    }
-    byName.set(row.name, existing);
-  }
-
-  return [...byName.entries()]
-    .map(([name, aggregate]) => ({
-      name,
-      count: aggregate.count,
-      values: [...aggregate.values].slice(
-        0,
-        FILTER_OPTION_CATEGORICAL_VALUE_LIMIT,
-      ),
-    }))
-    .sort(compareNameCount)
-    .slice(0, FILTER_OPTION_SCORE_NAME_LIMIT)
-    .map(({ name, values }) => ({ label: name, values }));
-};
-
-const toScoreColumn = (
-  row: EventFilterScoreNameRow,
-): EventFilterScoreColumn => ({
-  name: row.name,
-  source: row.source as ScoreSourceType,
-  dataType: row.data_type as ListableScoreDataType,
-});
-
-const topScoreColumnsByCount = (
-  rows: { row: EventFilterScoreNameRow; count: number }[],
-): EventFilterScoreColumn[] =>
-  rows
-    .sort(
-      (left, right) =>
-        right.count - left.count ||
-        left.row.name.localeCompare(right.row.name) ||
-        left.row.source.localeCompare(right.row.source) ||
-        left.row.data_type.localeCompare(right.row.data_type),
-    )
-    .slice(0, FILTER_OPTION_SCORE_NAME_LIMIT)
-    .map(({ row }) => toScoreColumn(row));
 
 /**
  * One ClickHouse round-trip for every score-name facet used by

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -79,9 +79,11 @@ import {
   findUiColumnMapping,
   matchesUiColumnMapping,
 } from "../../tableDefinitions";
-
-const FILTER_OPTION_SCORE_NAME_LIMIT = 200;
-const FILTER_OPTION_CATEGORICAL_VALUE_LIMIT = 20;
+import {
+  buildScoresFilterOptionsForEventFacetsQuery,
+  FILTER_OPTION_CATEGORICAL_VALUE_LIMIT,
+  FILTER_OPTION_SCORE_NAME_LIMIT,
+} from "../queries/clickhouse-sql/score-filter-options";
 
 export const searchExistingAnnotationScore = async (
   projectId: string,
@@ -1132,10 +1134,15 @@ export const getCategoricalScoresGroupedByName = async (
     preferredClickhouseService: "ReadOnly",
   });
 
-  // Get score names from ClickHouse results to query score configs
+  return mergeCategoricalScoreConfigValues(projectId, rows);
+};
+
+const mergeCategoricalScoreConfigValues = async (
+  projectId: string,
+  rows: { label: string; values: string[] }[],
+): Promise<{ label: string; values: string[] }[]> => {
   const scoreNames = rows.map((row) => row.label);
 
-  // Query score_configs table for categorical configurations
   const scoreConfigs =
     scoreNames.length > 0
       ? await prisma.scoreConfig.findMany({
@@ -1154,23 +1161,18 @@ export const getCategoricalScoresGroupedByName = async (
         })
       : [];
 
-  // Create a map of score configs for easy lookup
   const configMap = new Map(
     scoreConfigs.map((config) => [config.name, config.categories]),
   );
 
-  // Enhance the results with all possible category values from score configs
   return rows.map((row) => {
     const configCategories = configMap.get(row.label);
 
     if (configCategories && Array.isArray(configCategories)) {
-      // Extract all possible category labels from the score config
       const allPossibleValues = (
         configCategories as Array<{ label: string; value: number }>
       ).map((category) => category.label);
 
-      // Merge actual values from ClickHouse with all possible values from config
-      // Use Set to ensure uniqueness
       const mergedValues = Array.from(
         new Set([...row.values, ...allPossibleValues]),
       ).slice(0, FILTER_OPTION_CATEGORICAL_VALUE_LIMIT);
@@ -1181,9 +1183,217 @@ export const getCategoricalScoresGroupedByName = async (
       };
     }
 
-    // If no config found, return original values
     return row;
   });
+};
+
+type EventFilterScoreNameRow = {
+  name: string;
+  source: string;
+  data_type: string;
+  count: string;
+  trace_count: string;
+  observation_count: string;
+  categorical_values: string[];
+  trace_categorical_values: string[];
+  boolean_value_count: string;
+  trace_boolean_value_count: string;
+};
+
+type EventFilterScoreColumn = {
+  name: string;
+  source: ScoreSourceType;
+  dataType: ListableScoreDataType;
+};
+
+type EventFilterScoreNameOptions = {
+  numericNames: { name: string }[];
+  booleanNames: { name: string }[];
+  categoricalNames: { label: string; values: string[] }[];
+  traceScoreColumns: EventFilterScoreColumn[];
+  traceCategoricalNames: { label: string; values: string[] }[];
+  traceBooleanNames: { name: string }[];
+  observationLevelScores: EventFilterScoreColumn[];
+  traceLevelScores: EventFilterScoreColumn[];
+};
+
+const EMPTY_EVENT_FILTER_SCORE_NAME_OPTIONS: EventFilterScoreNameOptions = {
+  numericNames: [],
+  booleanNames: [],
+  categoricalNames: [],
+  traceScoreColumns: [],
+  traceCategoricalNames: [],
+  traceBooleanNames: [],
+  observationLevelScores: [],
+  traceLevelScores: [],
+};
+
+const compareNameCount = (
+  left: { name: string; count: number },
+  right: { name: string; count: number },
+) => right.count - left.count || left.name.localeCompare(right.name);
+
+const topNamesByCount = (
+  rows: { name: string; count: number }[],
+): { name: string }[] => {
+  const byName = new Map<string, number>();
+  for (const row of rows) {
+    byName.set(row.name, (byName.get(row.name) ?? 0) + row.count);
+  }
+
+  return [...byName.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort(compareNameCount)
+    .slice(0, FILTER_OPTION_SCORE_NAME_LIMIT)
+    .map(({ name }) => ({ name }));
+};
+
+const topCategoricalByCount = (
+  rows: { name: string; count: number; values: string[] }[],
+): { label: string; values: string[] }[] => {
+  const byName = new Map<string, { count: number; values: Set<string> }>();
+  for (const row of rows) {
+    const existing = byName.get(row.name) ?? { count: 0, values: new Set() };
+    existing.count += row.count;
+    for (const value of row.values) {
+      existing.values.add(value);
+    }
+    byName.set(row.name, existing);
+  }
+
+  return [...byName.entries()]
+    .map(([name, aggregate]) => ({
+      name,
+      count: aggregate.count,
+      values: [...aggregate.values].slice(
+        0,
+        FILTER_OPTION_CATEGORICAL_VALUE_LIMIT,
+      ),
+    }))
+    .sort(compareNameCount)
+    .slice(0, FILTER_OPTION_SCORE_NAME_LIMIT)
+    .map(({ name, values }) => ({ label: name, values }));
+};
+
+const toScoreColumn = (
+  row: EventFilterScoreNameRow,
+): EventFilterScoreColumn => ({
+  name: row.name,
+  source: row.source as ScoreSourceType,
+  dataType: row.data_type as ListableScoreDataType,
+});
+
+const topScoreColumnsByCount = (
+  rows: { row: EventFilterScoreNameRow; count: number }[],
+): EventFilterScoreColumn[] =>
+  rows
+    .sort(
+      (left, right) =>
+        right.count - left.count ||
+        left.row.name.localeCompare(right.row.name) ||
+        left.row.source.localeCompare(right.row.source) ||
+        left.row.data_type.localeCompare(right.row.data_type),
+    )
+    .slice(0, FILTER_OPTION_SCORE_NAME_LIMIT)
+    .map(({ row }) => toScoreColumn(row));
+
+/**
+ * One ClickHouse round-trip for every score-name facet used by
+ * `events.filterOptions`. Callers split the returned groups.
+ */
+export const getScoresFilterOptionsForEventFacets = async ({
+  projectId,
+  timestampFilter,
+}: {
+  projectId: string;
+  timestampFilter: FilterState;
+}): Promise<EventFilterScoreNameOptions> => {
+  const queryWithParams = buildScoresFilterOptionsForEventFacetsQuery({
+    projectId,
+    timestampFilter,
+  });
+
+  const rows = await queryClickhouse<EventFilterScoreNameRow>({
+    query: queryWithParams.query,
+    params: queryWithParams.params,
+    tags: { projectId },
+    preferredClickhouseService: "ReadOnly",
+  });
+
+  if (rows.length === 0) {
+    return EMPTY_EVENT_FILTER_SCORE_NAME_OPTIONS;
+  }
+
+  const numericNames = topNamesByCount(
+    rows
+      .filter(
+        (row) => row.data_type === "NUMERIC" || row.data_type === "BOOLEAN",
+      )
+      .map((row) => ({ name: row.name, count: Number(row.count) })),
+  );
+  const booleanNames = topNamesByCount(
+    rows
+      .filter((row) => Number(row.boolean_value_count) > 0)
+      .map((row) => ({
+        name: row.name,
+        count: Number(row.boolean_value_count),
+      })),
+  );
+  const categoricalNames = topCategoricalByCount(
+    rows
+      .filter((row) => row.data_type === "CATEGORICAL")
+      .map((row) => ({
+        name: row.name,
+        count: Number(row.count),
+        values: row.categorical_values,
+      })),
+  );
+  const traceCategoricalNames = topCategoricalByCount(
+    rows
+      .filter(
+        (row) => row.data_type === "CATEGORICAL" && Number(row.trace_count) > 0,
+      )
+      .map((row) => ({
+        name: row.name,
+        count: Number(row.trace_count),
+        values: row.trace_categorical_values,
+      })),
+  );
+  const traceBooleanNames = topNamesByCount(
+    rows
+      .filter((row) => Number(row.trace_boolean_value_count) > 0)
+      .map((row) => ({
+        name: row.name,
+        count: Number(row.trace_boolean_value_count),
+      })),
+  );
+  const observationLevelScores = topScoreColumnsByCount(
+    rows
+      .filter((row) => Number(row.observation_count) > 0)
+      .map((row) => ({ row, count: Number(row.observation_count) })),
+  );
+  const traceLevelScores = topScoreColumnsByCount(
+    rows
+      .filter((row) => Number(row.trace_count) > 0)
+      .map((row) => ({ row, count: Number(row.trace_count) })),
+  );
+
+  const [mergedCategoricalNames, mergedTraceCategoricalNames] =
+    await Promise.all([
+      mergeCategoricalScoreConfigValues(projectId, categoricalNames),
+      mergeCategoricalScoreConfigValues(projectId, traceCategoricalNames),
+    ]);
+
+  return {
+    numericNames,
+    booleanNames,
+    categoricalNames: mergedCategoricalNames,
+    traceScoreColumns: traceLevelScores,
+    traceCategoricalNames: mergedTraceCategoricalNames,
+    traceBooleanNames,
+    observationLevelScores,
+    traceLevelScores,
+  };
 };
 
 export const getScoresUiCount = async (props: {

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1230,58 +1230,66 @@ export const getScoresFilterOptionsForEventFacets = async ({
     return EMPTY_EVENT_FILTER_SCORE_NAME_OPTIONS;
   }
 
+  // Counts arrive as strings from ClickHouse; coerce them once here so each
+  // facet below reads plain numbers. Keep the raw row for the score-column
+  // facets, which also need source and data_type.
+  const stats = rows.map((row) => ({
+    row,
+    name: row.name,
+    dataType: row.data_type,
+    count: Number(row.count),
+    traceCount: Number(row.trace_count),
+    observationCount: Number(row.observation_count),
+    booleanValueCount: Number(row.boolean_value_count),
+    traceBooleanValueCount: Number(row.trace_boolean_value_count),
+    categoricalValues: row.categorical_values,
+    traceCategoricalValues: row.trace_categorical_values,
+  }));
+
   const numericNames = topNamesByCount(
-    rows
+    stats
       .filter(
-        (row) => row.data_type === "NUMERIC" || row.data_type === "BOOLEAN",
+        (stat) => stat.dataType === "NUMERIC" || stat.dataType === "BOOLEAN",
       )
-      .map((row) => ({ name: row.name, count: Number(row.count) })),
+      .map((stat) => ({ name: stat.name, count: stat.count })),
   );
   const booleanNames = topNamesByCount(
-    rows
-      .filter((row) => Number(row.boolean_value_count) > 0)
-      .map((row) => ({
-        name: row.name,
-        count: Number(row.boolean_value_count),
-      })),
+    stats
+      .filter((stat) => stat.booleanValueCount > 0)
+      .map((stat) => ({ name: stat.name, count: stat.booleanValueCount })),
   );
   const categoricalNames = topCategoricalByCount(
-    rows
-      .filter((row) => row.data_type === "CATEGORICAL")
-      .map((row) => ({
-        name: row.name,
-        count: Number(row.count),
-        values: row.categorical_values,
+    stats
+      .filter((stat) => stat.dataType === "CATEGORICAL")
+      .map((stat) => ({
+        name: stat.name,
+        count: stat.count,
+        values: stat.categoricalValues,
       })),
   );
   const traceCategoricalNames = topCategoricalByCount(
-    rows
-      .filter(
-        (row) => row.data_type === "CATEGORICAL" && Number(row.trace_count) > 0,
-      )
-      .map((row) => ({
-        name: row.name,
-        count: Number(row.trace_count),
-        values: row.trace_categorical_values,
+    stats
+      .filter((stat) => stat.dataType === "CATEGORICAL" && stat.traceCount > 0)
+      .map((stat) => ({
+        name: stat.name,
+        count: stat.traceCount,
+        values: stat.traceCategoricalValues,
       })),
   );
   const traceBooleanNames = topNamesByCount(
-    rows
-      .filter((row) => Number(row.trace_boolean_value_count) > 0)
-      .map((row) => ({
-        name: row.name,
-        count: Number(row.trace_boolean_value_count),
-      })),
+    stats
+      .filter((stat) => stat.traceBooleanValueCount > 0)
+      .map((stat) => ({ name: stat.name, count: stat.traceBooleanValueCount })),
   );
   const observationLevelScores = topScoreColumnsByCount(
-    rows
-      .filter((row) => Number(row.observation_count) > 0)
-      .map((row) => ({ row, count: Number(row.observation_count) })),
+    stats
+      .filter((stat) => stat.observationCount > 0)
+      .map((stat) => ({ row: stat.row, count: stat.observationCount })),
   );
   const traceLevelScores = topScoreColumnsByCount(
-    rows
-      .filter((row) => Number(row.trace_count) > 0)
-      .map((row) => ({ row, count: Number(row.trace_count) })),
+    stats
+      .filter((stat) => stat.traceCount > 0)
+      .map((stat) => ({ row: stat.row, count: stat.traceCount })),
   );
 
   const [mergedCategoricalNames, mergedTraceCategoricalNames] =

--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -2,6 +2,7 @@ import {
   buildEventsFilterOptionColumnQuery,
   buildEventsFilterOptionsForColumnsQuery,
   buildEventsMetadataValuesQuery,
+  buildScoresFilterOptionsForEventFacetsQuery,
   CTEQueryBuilder,
   createFilterFromFilterState,
   EventsAggregationQueryBuilder,
@@ -269,6 +270,47 @@ describe("buildEventsFilterOptionsForColumnsQuery", () => {
     expect(built.query).toContain("LEFT JOIN trace_scores_agg AS ts");
     expect(built.query).toContain("FROM events_full e");
     expect(Object.values(built.params)).toContain("quality");
+  });
+
+  it("combines scores-view event facets into one events_core scan", () => {
+    const built = buildEventsFilterOptionsForColumnsQuery({
+      projectId: "test-project",
+      filter: [
+        {
+          column: "startTime",
+          operator: ">=",
+          value: new Date("2026-01-01T00:00:00.000Z"),
+          type: "datetime",
+        },
+      ],
+      columns: ["traceTags", "traceName", "userId"],
+      limit: 1000,
+      scope: {
+        type: "scoredTraces",
+        fromTime: {
+          operator: ">=",
+          value: new Date("2026-01-01T00:00:00.000Z"),
+        },
+        toTime: {
+          operator: "<=",
+          value: new Date("2026-01-01T00:30:00.000Z"),
+        },
+      },
+    });
+
+    expect(built).not.toBeNull();
+    if (!built) throw new Error("expected query");
+
+    expect(built.query.match(/FROM events_core e/g)).toHaveLength(1);
+    expect(built.query).toContain("approx_top_kIf");
+    expect(built.query).toContain("approx_top_kArray");
+    expect(built.query).toContain("tuple('traceTags'");
+    expect(built.query).toContain("tuple('traceName'");
+    expect(built.query).toContain("tuple('userId'");
+    expect(built.query).toContain(
+      "e.trace_id IN (SELECT DISTINCT trace_id FROM scores WHERE project_id = {projectId: String} AND timestamp >= {scoredTracesFromTime: DateTime64(3, 'UTC')} AND timestamp <= {scoredTracesToTime: DateTime64(3, 'UTC')})",
+    );
+    expect(built.query).not.toContain("GROUP BY value");
   });
 
   it("bounds the scored traces scope by the view's both-sided window", () => {
@@ -992,5 +1034,40 @@ describe("ExperimentsAggregationQueryBuilder", () => {
       projectId: "test-project",
       startTimeFrom: "2026-01-01 00:00:00.000",
     });
+  });
+});
+
+describe("buildScoresFilterOptionsForEventFacetsQuery", () => {
+  it("builds one scores scan with conditional facet aggregations", () => {
+    const built = buildScoresFilterOptionsForEventFacetsQuery({
+      projectId: "test-project",
+      timestampFilter: [
+        {
+          column: "Timestamp",
+          type: "datetime",
+          operator: ">=",
+          value: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      ],
+    });
+
+    expect(built.query.match(/FROM scores s/g)).toHaveLength(1);
+    expect(built.query).toContain("s.project_id = {projectId: String}");
+    expect(built.query).toContain("isNotNull(s.trace_id)");
+    expect(built.query).toContain("groupUniqArrayIf(20)");
+    expect(built.query).toContain("countIf(isNull(s.observation_id))");
+    expect(built.query).toContain("countIf(isNotNull(s.observation_id))");
+    expect(built.query).toContain("GROUP BY name, source, data_type");
+    expect(built.query).not.toContain("FINAL");
+    expect(built.query).not.toMatch(/\bJOIN\b/i);
+    expect(built.params).toMatchObject({
+      projectId: "test-project",
+    });
+    expect(built.params.dataTypes).toEqual([
+      "NUMERIC",
+      "BOOLEAN",
+      "CATEGORICAL",
+      "TEXT",
+    ]);
   });
 });

--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -1066,19 +1066,16 @@ describe("buildScoresFilterOptionsForEventFacetsQuery", () => {
     expect(built.query).toContain("countIf(isNull(s.observation_id))");
     expect(built.query).toContain("countIf(isNotNull(s.observation_id))");
     expect(built.query).toContain("GROUP BY name, source, data_type");
-    // Each facet is ranked on its own measure and a row is kept if it survives
-    // any cap, so no facet's roll-up can drop its true top-N.
     expect(built.query).toContain(
-      "sumIf(count, data_type IN ('NUMERIC', 'BOOLEAN'))",
+      "ORDER BY count DESC, name ASC, source ASC, data_type ASC",
     );
-    expect(built.query).toContain("numeric_name_rank <= {cap: UInt32}");
-    expect(built.query).toContain("trace_column_rank <= {cap: UInt32}");
-    expect(built.query.match(/dense_rank\(\) OVER \(/g)).toHaveLength(7);
+    expect(built.query).toContain("LIMIT {groupLimit: UInt32}");
+    expect(built.query).not.toContain("dense_rank");
     expect(built.query).not.toContain("FINAL");
     expect(built.query).not.toMatch(/\bJOIN\b/i);
     expect(built.params).toMatchObject({
       projectId: "test-project",
-      cap: FILTER_OPTION_SCORE_NAME_LIMIT,
+      groupLimit: FILTER_OPTION_SCORE_NAME_LIMIT * 10,
     });
     expect(built.params.dataTypes).toEqual([
       "NUMERIC",

--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -1,8 +1,10 @@
 import {
   buildEventsFilterOptionColumnQuery,
   buildEventsFilterOptionsForColumnsQuery,
+  buildEventsExactFilterOptionsForColumnsQuery,
   buildEventsMetadataValuesQuery,
   buildScoresFilterOptionsForEventFacetsQuery,
+  FILTER_OPTION_SCORE_GROUPS_PER_TYPE_LIMIT,
   CTEQueryBuilder,
   createFilterFromFilterState,
   EventsAggregationQueryBuilder,
@@ -272,8 +274,8 @@ describe("buildEventsFilterOptionsForColumnsQuery", () => {
     expect(Object.values(built.params)).toContain("quality");
   });
 
-  it("combines scores-view event facets into one events_core scan", () => {
-    const built = buildEventsFilterOptionsForColumnsQuery({
+  it("combines scores-view event facets into one exact UNION ALL query", () => {
+    const built = buildEventsExactFilterOptionsForColumnsQuery({
       projectId: "test-project",
       filter: [
         {
@@ -301,16 +303,22 @@ describe("buildEventsFilterOptionsForColumnsQuery", () => {
     expect(built).not.toBeNull();
     if (!built) throw new Error("expected query");
 
-    expect(built.query.match(/FROM events_core e/g)).toHaveLength(1);
-    expect(built.query).toContain("approx_top_kIf");
-    expect(built.query).toContain("approx_top_kArray");
-    expect(built.query).toContain("tuple('traceTags'");
-    expect(built.query).toContain("tuple('traceName'");
-    expect(built.query).toContain("tuple('userId'");
+    expect(built.query.match(/UNION ALL/g)).toHaveLength(2);
+    expect(built.query.match(/FROM events_core e/g)).toHaveLength(3);
+    expect(built.query.match(/GROUP BY value/g)).toHaveLength(3);
+    expect(built.query).not.toContain("approx_top_k");
+    expect(built.query).toContain("'traceTags' AS column");
+    expect(built.query).toContain("'traceName' AS column");
+    expect(built.query).toContain("'userId' AS column");
     expect(built.query).toContain(
       "e.trace_id IN (SELECT DISTINCT trace_id FROM scores WHERE project_id = {projectId: String} AND timestamp >= {scoredTracesFromTime: DateTime64(3, 'UTC')} AND timestamp <= {scoredTracesToTime: DateTime64(3, 'UTC')})",
     );
-    expect(built.query).not.toContain("GROUP BY value");
+    expect(built.params).toMatchObject({
+      projectId: "test-project",
+      limit: 1000,
+      scoredTracesFromTime: "2026-01-01 00:00:00.000",
+      scoredTracesToTime: "2026-01-01 00:30:00.000",
+    });
   });
 
   it("bounds the scored traces scope by the view's both-sided window", () => {
@@ -1058,10 +1066,14 @@ describe("buildScoresFilterOptionsForEventFacetsQuery", () => {
     expect(built.query).toContain("countIf(isNull(s.observation_id))");
     expect(built.query).toContain("countIf(isNotNull(s.observation_id))");
     expect(built.query).toContain("GROUP BY name, source, data_type");
+    expect(built.query).toContain(
+      "LIMIT {maxGroupsPerType: UInt32} BY data_type",
+    );
     expect(built.query).not.toContain("FINAL");
     expect(built.query).not.toMatch(/\bJOIN\b/i);
     expect(built.params).toMatchObject({
       projectId: "test-project",
+      maxGroupsPerType: FILTER_OPTION_SCORE_GROUPS_PER_TYPE_LIMIT,
     });
     expect(built.params.dataTypes).toEqual([
       "NUMERIC",

--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -1066,20 +1066,19 @@ describe("buildScoresFilterOptionsForEventFacetsQuery", () => {
     expect(built.query).toContain("countIf(isNull(s.observation_id))");
     expect(built.query).toContain("countIf(isNotNull(s.observation_id))");
     expect(built.query).toContain("GROUP BY name, source, data_type");
-    // Names are ranked by summed count across sources, then capped — bounding by
-    // raw per-source rows would drop a split name whose total is the highest.
+    // Each facet is ranked on its own measure and a row is kept if it survives
+    // any cap, so no facet's roll-up can drop its true top-N.
     expect(built.query).toContain(
-      "sum(count) OVER (PARTITION BY data_type, name)",
+      "sumIf(count, data_type IN ('NUMERIC', 'BOOLEAN'))",
     );
-    expect(built.query).toContain("dense_rank() OVER (");
-    expect(built.query).toContain(
-      "WHERE name_rank <= {maxNamesPerType: UInt32}",
-    );
+    expect(built.query).toContain("numeric_name_rank <= {cap: UInt32}");
+    expect(built.query).toContain("trace_column_rank <= {cap: UInt32}");
+    expect(built.query.match(/dense_rank\(\) OVER \(/g)).toHaveLength(7);
     expect(built.query).not.toContain("FINAL");
     expect(built.query).not.toMatch(/\bJOIN\b/i);
     expect(built.params).toMatchObject({
       projectId: "test-project",
-      maxNamesPerType: FILTER_OPTION_SCORE_NAME_LIMIT,
+      cap: FILTER_OPTION_SCORE_NAME_LIMIT,
     });
     expect(built.params.dataTypes).toEqual([
       "NUMERIC",

--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -4,7 +4,7 @@ import {
   buildEventsExactFilterOptionsForColumnsQuery,
   buildEventsMetadataValuesQuery,
   buildScoresFilterOptionsForEventFacetsQuery,
-  FILTER_OPTION_SCORE_GROUPS_PER_TYPE_LIMIT,
+  FILTER_OPTION_SCORE_NAME_LIMIT,
   CTEQueryBuilder,
   createFilterFromFilterState,
   EventsAggregationQueryBuilder,
@@ -1066,14 +1066,20 @@ describe("buildScoresFilterOptionsForEventFacetsQuery", () => {
     expect(built.query).toContain("countIf(isNull(s.observation_id))");
     expect(built.query).toContain("countIf(isNotNull(s.observation_id))");
     expect(built.query).toContain("GROUP BY name, source, data_type");
+    // Names are ranked by summed count across sources, then capped — bounding by
+    // raw per-source rows would drop a split name whose total is the highest.
     expect(built.query).toContain(
-      "LIMIT {maxGroupsPerType: UInt32} BY data_type",
+      "sum(count) OVER (PARTITION BY data_type, name)",
+    );
+    expect(built.query).toContain("dense_rank() OVER (");
+    expect(built.query).toContain(
+      "WHERE name_rank <= {maxNamesPerType: UInt32}",
     );
     expect(built.query).not.toContain("FINAL");
     expect(built.query).not.toMatch(/\bJOIN\b/i);
     expect(built.params).toMatchObject({
       projectId: "test-project",
-      maxGroupsPerType: FILTER_OPTION_SCORE_GROUPS_PER_TYPE_LIMIT,
+      maxNamesPerType: FILTER_OPTION_SCORE_NAME_LIMIT,
     });
     expect(built.params.dataTypes).toEqual([
       "NUMERIC",

--- a/web/src/__tests__/server/repositories/score-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/score-repository.servertest.ts
@@ -1686,8 +1686,8 @@ describe("Clickhouse Scores Repository Test", () => {
 
       // Cross the per-type cap: LIMIT_TOP names each seen twice (count 2) plus a
       // dozen extras seen once (count 1). count 2 > count 1 makes the top set
-      // unambiguous, so the SQL name-rank cap plus JS name cap must land on
-      // exactly the frequent names — the per-column helper is the oracle below.
+      // unambiguous, so the TypeScript name cap must land on exactly the
+      // frequent names — the per-column helper is the oracle below.
       const topNames = Array.from(
         { length: FILTER_OPTION_SCORE_NAME_LIMIT },
         (_, i) => `cap-top-${String(i).padStart(4, "0")}`,
@@ -1754,13 +1754,13 @@ describe("Clickhouse Scores Repository Test", () => {
         ...timestampFilter,
       ];
 
-      // The repository sums each name's count across sources before ranking, so
-      // the SQL must bound by summed count per name — not by raw per-source rows.
-      // Seed the adversarial shape: one NUMERIC name spread over all three
-      // sources (one row each, summed count 3), plus more single-source names
-      // (count 2 each) than the name cap. Every split row has a lower per-source
-      // count than every filler, so a per-source row cap drops the split name
-      // even though its summed count is the project's highest.
+      // The repository sums each name's count across sources before the UI cap.
+      // SQL only keeps the most frequent (name, source, data_type) groups as a
+      // transfer bound, so this fixture still returns the split name: one
+      // NUMERIC name spread over all three sources (one row each, summed count
+      // 3), plus more single-source names (count 2 each) than the name cap.
+      // A tight per-source row cap would drop it; the generous group limit
+      // does not.
       const singleSourceNames = Array.from(
         { length: FILTER_OPTION_SCORE_NAME_LIMIT * ScoreSourceArray.length },
         (_, i) => `split-filler-${String(i).padStart(4, "0")}`,
@@ -1797,7 +1797,8 @@ describe("Clickhouse Scores Repository Test", () => {
 
       // The old per-column helper groups by name before its own limit, so the
       // split name is the unambiguous #1 by summed count. The combined scan
-      // must agree — losing it means per-source truncation dropped it.
+      // still returns it because the group-limit is a transfer bound, not a
+      // per-source semantic cap.
       expect(oldNumeric[0]?.name).toBe("split-hot");
       expect(combined.numericNames.map((row) => row.name)).toContain(
         "split-hot",
@@ -1826,11 +1827,11 @@ describe("Clickhouse Scores Repository Test", () => {
       ];
 
       // numericNames pools NUMERIC and BOOLEAN and ranks names by their combined
-      // count. A name that exists as both types can sit outside each type's own
-      // top-N while its combined count is the project's highest, so a per-type
-      // cap drops it from both. Seed that: cross-hot with NUMERIC count 3 and
-      // BOOLEAN count 3 (combined 6), behind a full name cap of single-type
-      // fillers at count 4 in each type.
+      // count in TypeScript. A name that exists as both types can sit outside
+      // each type's own top-N while its combined count is the project's highest.
+      // Seed that: cross-hot with NUMERIC count 3 and BOOLEAN count 3 (combined
+      // 6), behind a full name cap of single-type fillers at count 4 in each
+      // type. The SQL group limit is large enough that both type-rows arrive.
       const fillerNames = (prefix: string) =>
         Array.from(
           { length: FILTER_OPTION_SCORE_NAME_LIMIT },
@@ -1876,7 +1877,8 @@ describe("Clickhouse Scores Repository Test", () => {
       ]);
 
       // The per-column helper ranks the merged NUMERIC+BOOLEAN pool, so cross-hot
-      // (combined 6) is the unambiguous #1. The combined scan must agree.
+      // (combined 6) is the unambiguous #1. TypeScript still agrees because SQL
+      // returned both type-rows.
       expect(oldNumeric[0]?.name).toBe("cross-hot");
       expect(combined.numericNames.map((row) => row.name)).toContain(
         "cross-hot",

--- a/web/src/__tests__/server/repositories/score-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/score-repository.servertest.ts
@@ -33,7 +33,7 @@ import {
   FILTER_OPTION_SCORE_NAME_LIMIT,
   FILTER_OPTION_CATEGORICAL_VALUE_LIMIT,
 } from "@langfuse/shared/src/server";
-import type { FilterState } from "@langfuse/shared";
+import { type FilterState, ScoreSourceArray } from "@langfuse/shared";
 import { v4 } from "uuid";
 
 describe("Clickhouse Scores Repository Test", () => {
@@ -1686,8 +1686,8 @@ describe("Clickhouse Scores Repository Test", () => {
 
       // Cross the per-type cap: LIMIT_TOP names each seen twice (count 2) plus a
       // dozen extras seen once (count 1). count 2 > count 1 makes the top set
-      // unambiguous, so the SQL `LIMIT BY data_type` + JS name cap must land on
-      // exactly the frequent names, same as the old `LIMIT` per query.
+      // unambiguous, so the SQL name-rank cap plus JS name cap must land on
+      // exactly the frequent names — the per-column helper is the oracle below.
       const topNames = Array.from(
         { length: FILTER_OPTION_SCORE_NAME_LIMIT },
         (_, i) => `cap-top-${String(i).padStart(4, "0")}`,
@@ -1732,6 +1732,77 @@ describe("Clickhouse Scores Repository Test", () => {
       for (const overflow of overflowNames) {
         expect(combinedSet).not.toContain(overflow);
       }
+    });
+
+    it("keeps a name split across sources whose summed count is the project's highest", async () => {
+      const isolatedProjectId = v4();
+      const timestampFilter: FilterState = [
+        {
+          column: "Timestamp",
+          type: "datetime",
+          operator: ">=",
+          value: new Date(Date.now() - 60 * 60 * 1000),
+        },
+      ];
+      const traceScopedFilter: FilterState = [
+        {
+          type: "null",
+          column: "traceId",
+          operator: "is not null",
+          value: "",
+        },
+        ...timestampFilter,
+      ];
+
+      // The repository sums each name's count across sources before ranking, so
+      // the SQL must bound by summed count per name — not by raw per-source rows.
+      // Seed the adversarial shape: one NUMERIC name spread over all three
+      // sources (one row each, summed count 3), plus more single-source names
+      // (count 2 each) than the name cap. Every split row has a lower per-source
+      // count than every filler, so a per-source row cap drops the split name
+      // even though its summed count is the project's highest.
+      const singleSourceNames = Array.from(
+        { length: FILTER_OPTION_SCORE_NAME_LIMIT * ScoreSourceArray.length },
+        (_, i) => `split-filler-${String(i).padStart(4, "0")}`,
+      );
+      const numericScore = (
+        name: string,
+        source: "API" | "EVAL" | "ANNOTATION",
+      ) =>
+        createTraceScore({
+          project_id: isolatedProjectId,
+          name,
+          data_type: "NUMERIC",
+          value: 1,
+          source,
+        });
+
+      await createScoresCh([
+        numericScore("split-hot", "API"),
+        numericScore("split-hot", "EVAL"),
+        numericScore("split-hot", "ANNOTATION"),
+        ...singleSourceNames.flatMap((name) => [
+          numericScore(name, "API"),
+          numericScore(name, "API"),
+        ]),
+      ]);
+
+      const [combined, oldNumeric] = await Promise.all([
+        getScoresFilterOptionsForEventFacets({
+          projectId: isolatedProjectId,
+          timestampFilter,
+        }),
+        getNumericScoresGroupedByName(isolatedProjectId, traceScopedFilter),
+      ]);
+
+      // The old per-column helper groups by name before its own limit, so the
+      // split name is the unambiguous #1 by summed count. The combined scan
+      // must agree — losing it means per-source truncation dropped it.
+      expect(oldNumeric[0]?.name).toBe("split-hot");
+      expect(combined.numericNames.map((row) => row.name)).toContain(
+        "split-hot",
+      );
+      expect(combined.numericNames[0]?.name).toBe("split-hot");
     });
 
     it("truncates categorical values at the value limit like the per-column helper", async () => {

--- a/web/src/__tests__/server/repositories/score-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/score-repository.servertest.ts
@@ -1805,6 +1805,85 @@ describe("Clickhouse Scores Repository Test", () => {
       expect(combined.numericNames[0]?.name).toBe("split-hot");
     });
 
+    it("keeps a name split across NUMERIC and BOOLEAN whose combined count is the project's highest", async () => {
+      const isolatedProjectId = v4();
+      const timestampFilter: FilterState = [
+        {
+          column: "Timestamp",
+          type: "datetime",
+          operator: ">=",
+          value: new Date(Date.now() - 60 * 60 * 1000),
+        },
+      ];
+      const traceScopedFilter: FilterState = [
+        {
+          type: "null",
+          column: "traceId",
+          operator: "is not null",
+          value: "",
+        },
+        ...timestampFilter,
+      ];
+
+      // numericNames pools NUMERIC and BOOLEAN and ranks names by their combined
+      // count. A name that exists as both types can sit outside each type's own
+      // top-N while its combined count is the project's highest, so a per-type
+      // cap drops it from both. Seed that: cross-hot with NUMERIC count 3 and
+      // BOOLEAN count 3 (combined 6), behind a full name cap of single-type
+      // fillers at count 4 in each type.
+      const fillerNames = (prefix: string) =>
+        Array.from(
+          { length: FILTER_OPTION_SCORE_NAME_LIMIT },
+          (_, i) => `${prefix}-${String(i).padStart(4, "0")}`,
+        );
+      const numericFillers = fillerNames("cross-num");
+      const booleanFillers = fillerNames("cross-bool");
+      const numericScore = (name: string) =>
+        createTraceScore({
+          project_id: isolatedProjectId,
+          name,
+          data_type: "NUMERIC",
+          value: 1,
+          source: "API",
+        });
+      const booleanScore = (name: string) =>
+        createTraceScore({
+          project_id: isolatedProjectId,
+          name,
+          data_type: "BOOLEAN",
+          value: 1,
+          string_value: "true",
+          source: "API",
+        });
+
+      await createScoresCh([
+        ...Array.from({ length: 3 }, () => numericScore("cross-hot")),
+        ...Array.from({ length: 3 }, () => booleanScore("cross-hot")),
+        ...numericFillers.flatMap((name) =>
+          Array.from({ length: 4 }, () => numericScore(name)),
+        ),
+        ...booleanFillers.flatMap((name) =>
+          Array.from({ length: 4 }, () => booleanScore(name)),
+        ),
+      ]);
+
+      const [combined, oldNumeric] = await Promise.all([
+        getScoresFilterOptionsForEventFacets({
+          projectId: isolatedProjectId,
+          timestampFilter,
+        }),
+        getNumericScoresGroupedByName(isolatedProjectId, traceScopedFilter),
+      ]);
+
+      // The per-column helper ranks the merged NUMERIC+BOOLEAN pool, so cross-hot
+      // (combined 6) is the unambiguous #1. The combined scan must agree.
+      expect(oldNumeric[0]?.name).toBe("cross-hot");
+      expect(combined.numericNames.map((row) => row.name)).toContain(
+        "cross-hot",
+      );
+      expect(combined.numericNames[0]?.name).toBe("cross-hot");
+    });
+
     it("truncates categorical values at the value limit like the per-column helper", async () => {
       const isolatedProjectId = v4();
       const timestampFilter: FilterState = [

--- a/web/src/__tests__/server/repositories/score-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/score-repository.servertest.ts
@@ -30,6 +30,8 @@ import {
   createSessionScore,
   createOrgProjectAndApiKey,
   getScoreStringValues,
+  FILTER_OPTION_SCORE_NAME_LIMIT,
+  FILTER_OPTION_CATEGORICAL_VALUE_LIMIT,
 } from "@langfuse/shared/src/server";
 import type { FilterState } from "@langfuse/shared";
 import { v4 } from "uuid";
@@ -1642,6 +1644,15 @@ describe("Clickhouse Scores Repository Test", () => {
       expect(byColumn(combined.traceLevelScores)).toEqual(
         byColumn(traceLevelScores),
       );
+      // Order-sensitive: the byName/byLabel/byColumn helpers above sort before
+      // comparing, so they only prove set-equality. The UI renders the raw
+      // top-N order, so pin count-desc with a name-asc tiebreak too: accuracy
+      // rolls up two sources to count 2; empty-bool and thumbs tie at 1.
+      expect(combined.numericNames.map((row) => row.name)).toEqual([
+        "accuracy",
+        "empty-bool",
+        "thumbs",
+      ]);
       expect(combined.numericNames.map((row) => row.name)).not.toContain(
         "session-only",
       );
@@ -1651,6 +1662,144 @@ describe("Clickhouse Scores Repository Test", () => {
       expect(combined.numericNames.map((row) => row.name)).toContain(
         "empty-bool",
       );
+    });
+
+    it("caps score names per data_type like the per-column helper at the name limit", async () => {
+      const isolatedProjectId = v4();
+      const timestampFilter: FilterState = [
+        {
+          column: "Timestamp",
+          type: "datetime",
+          operator: ">=",
+          value: new Date(Date.now() - 60 * 60 * 1000),
+        },
+      ];
+      const traceScopedFilter: FilterState = [
+        {
+          type: "null",
+          column: "traceId",
+          operator: "is not null",
+          value: "",
+        },
+        ...timestampFilter,
+      ];
+
+      // Cross the per-type cap: LIMIT_TOP names each seen twice (count 2) plus a
+      // dozen extras seen once (count 1). count 2 > count 1 makes the top set
+      // unambiguous, so the SQL `LIMIT BY data_type` + JS name cap must land on
+      // exactly the frequent names, same as the old `LIMIT` per query.
+      const topNames = Array.from(
+        { length: FILTER_OPTION_SCORE_NAME_LIMIT },
+        (_, i) => `cap-top-${String(i).padStart(4, "0")}`,
+      );
+      const overflowNames = Array.from(
+        { length: 12 },
+        (_, i) => `cap-over-${String(i).padStart(2, "0")}`,
+      );
+      const numericScore = (name: string) =>
+        createTraceScore({
+          project_id: isolatedProjectId,
+          name,
+          data_type: "NUMERIC",
+          value: 1,
+          source: "API",
+        });
+
+      await createScoresCh([
+        ...topNames.flatMap((name) => [numericScore(name), numericScore(name)]),
+        ...overflowNames.map((name) => numericScore(name)),
+      ]);
+
+      const [combined, oldNumeric] = await Promise.all([
+        getScoresFilterOptionsForEventFacets({
+          projectId: isolatedProjectId,
+          timestampFilter,
+        }),
+        getNumericScoresGroupedByName(isolatedProjectId, traceScopedFilter),
+      ]);
+
+      // Cap engaged: seeded more distinct names than the limit.
+      expect(topNames.length + overflowNames.length).toBeGreaterThan(
+        FILTER_OPTION_SCORE_NAME_LIMIT,
+      );
+      expect(combined.numericNames).toHaveLength(
+        FILTER_OPTION_SCORE_NAME_LIMIT,
+      );
+
+      const combinedSet = combined.numericNames.map((row) => row.name).sort();
+      expect(combinedSet).toEqual([...topNames].sort());
+      expect(combinedSet).toEqual(oldNumeric.map((row) => row.name).sort());
+      for (const overflow of overflowNames) {
+        expect(combinedSet).not.toContain(overflow);
+      }
+    });
+
+    it("truncates categorical values at the value limit like the per-column helper", async () => {
+      const isolatedProjectId = v4();
+      const timestampFilter: FilterState = [
+        {
+          column: "Timestamp",
+          type: "datetime",
+          operator: ">=",
+          value: new Date(Date.now() - 60 * 60 * 1000),
+        },
+      ];
+      const traceScopedFilter: FilterState = [
+        {
+          type: "null",
+          column: "traceId",
+          operator: "is not null",
+          value: "",
+        },
+        ...timestampFilter,
+      ];
+
+      // One categorical name with more distinct values than the cap allows.
+      const seededValues = Array.from(
+        { length: FILTER_OPTION_CATEGORICAL_VALUE_LIMIT + 5 },
+        (_, i) => `val-${String(i).padStart(2, "0")}`,
+      );
+      await createScoresCh(
+        seededValues.map((value) =>
+          createTraceScore({
+            project_id: isolatedProjectId,
+            name: "cap-cat",
+            data_type: "CATEGORICAL",
+            value: 0,
+            string_value: value,
+            source: "API",
+          }),
+        ),
+      );
+
+      const [combined, oldCategorical] = await Promise.all([
+        getScoresFilterOptionsForEventFacets({
+          projectId: isolatedProjectId,
+          timestampFilter,
+        }),
+        getCategoricalScoresGroupedByName(isolatedProjectId, traceScopedFilter),
+      ]);
+
+      const combinedCat = combined.categoricalNames.find(
+        (row) => row.label === "cap-cat",
+      );
+      const oldCat = oldCategorical.find((row) => row.label === "cap-cat");
+      expect(combinedCat).toBeDefined();
+      expect(oldCat).toBeDefined();
+
+      // Cap engaged and identical to the old helper. groupUniqArray truncation
+      // picks an arbitrary subset, so assert the count and membership, not which
+      // specific values survive.
+      expect(seededValues.length).toBeGreaterThan(
+        FILTER_OPTION_CATEGORICAL_VALUE_LIMIT,
+      );
+      expect(combinedCat!.values).toHaveLength(
+        FILTER_OPTION_CATEGORICAL_VALUE_LIMIT,
+      );
+      expect(oldCat!.values).toHaveLength(combinedCat!.values.length);
+      for (const value of combinedCat!.values) {
+        expect(seededValues).toContain(value);
+      }
     });
   });
 });

--- a/web/src/__tests__/server/repositories/score-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/score-repository.servertest.ts
@@ -3,7 +3,10 @@ import {
   createScoresCh,
   getScoreById,
   getScoresByIds,
+  getBooleanScoresGroupedByName,
   getCategoricalScoresGroupedByName,
+  getNumericScoresGroupedByName,
+  getScoresFilterOptionsForEventFacets,
   getScoresGroupedByNameSourceType,
   getScoresUiTable,
   getScoresForTraces,
@@ -1476,6 +1479,177 @@ describe("Clickhouse Scores Repository Test", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].dataType).toBe("BOOLEAN");
+    });
+  });
+
+  describe("getScoresFilterOptionsForEventFacets", () => {
+    it("matches the per-column score-name helpers on the same fixture", async () => {
+      const isolatedProjectId = v4();
+      const observationId = v4();
+      const timestampFilter = [
+        {
+          column: "Timestamp" as const,
+          type: "datetime" as const,
+          operator: ">=" as const,
+          value: new Date(Date.now() - 60 * 60 * 1000),
+        },
+      ];
+      const traceScopedFilter = [
+        {
+          type: "null" as const,
+          column: "traceId",
+          operator: "is not null" as const,
+          value: "",
+        },
+        ...timestampFilter,
+      ];
+      const traceLevelFilter = [
+        ...traceScopedFilter,
+        {
+          type: "null" as const,
+          column: "observationId",
+          operator: "is null" as const,
+          value: "",
+        },
+      ];
+      const observationLevelFilter = [
+        ...traceScopedFilter,
+        {
+          type: "null" as const,
+          column: "observationId",
+          operator: "is not null" as const,
+          value: "",
+        },
+      ];
+
+      await createScoresCh([
+        createTraceScore({
+          project_id: isolatedProjectId,
+          name: "accuracy",
+          data_type: "NUMERIC",
+          value: 0.9,
+          source: "API",
+        }),
+        createTraceScore({
+          project_id: isolatedProjectId,
+          observation_id: observationId,
+          name: "accuracy",
+          data_type: "NUMERIC",
+          value: 0.8,
+          source: "EVAL",
+        }),
+        createTraceScore({
+          project_id: isolatedProjectId,
+          name: "thumbs",
+          data_type: "BOOLEAN",
+          value: 1,
+          string_value: "True",
+          source: "API",
+        }),
+        createTraceScore({
+          project_id: isolatedProjectId,
+          observation_id: observationId,
+          name: "empty-bool",
+          data_type: "BOOLEAN",
+          value: 0,
+          string_value: "",
+          source: "API",
+        }),
+        createTraceScore({
+          project_id: isolatedProjectId,
+          name: "sentiment",
+          data_type: "CATEGORICAL",
+          value: 1,
+          string_value: "positive",
+          source: "API",
+        }),
+        createTraceScore({
+          project_id: isolatedProjectId,
+          observation_id: observationId,
+          name: "sentiment",
+          data_type: "CATEGORICAL",
+          value: 0,
+          string_value: "negative",
+          source: "EVAL",
+        }),
+        createSessionScore({
+          project_id: isolatedProjectId,
+          name: "session-only",
+          data_type: "NUMERIC",
+          value: 1,
+          source: "API",
+        }),
+      ]);
+
+      const [
+        combined,
+        numericNames,
+        booleanNames,
+        categoricalNames,
+        traceCategoricalNames,
+        traceBooleanNames,
+        observationLevelScores,
+        traceLevelScores,
+      ] = await Promise.all([
+        getScoresFilterOptionsForEventFacets({
+          projectId: isolatedProjectId,
+          timestampFilter,
+        }),
+        getNumericScoresGroupedByName(isolatedProjectId, traceScopedFilter),
+        getBooleanScoresGroupedByName(isolatedProjectId, traceScopedFilter),
+        getCategoricalScoresGroupedByName(isolatedProjectId, traceScopedFilter),
+        getCategoricalScoresGroupedByName(isolatedProjectId, traceLevelFilter),
+        getBooleanScoresGroupedByName(isolatedProjectId, traceLevelFilter),
+        getScoresGroupedByNameSourceType({
+          projectId: isolatedProjectId,
+          filter: observationLevelFilter,
+        }),
+        getScoresGroupedByNameSourceType({
+          projectId: isolatedProjectId,
+          filter: traceLevelFilter,
+        }),
+      ]);
+
+      const byName = (rows: { name: string }[]) =>
+        rows.map((row) => row.name).sort();
+      const byLabel = (rows: { label: string; values: string[] }[]) =>
+        rows
+          .map((row) => ({
+            label: row.label,
+            values: [...row.values].sort(),
+          }))
+          .sort((left, right) => left.label.localeCompare(right.label));
+      const byColumn = (
+        rows: { name: string; source: string; dataType: string }[],
+      ) =>
+        rows.map((row) => `${row.name}:${row.source}:${row.dataType}`).sort();
+
+      expect(byName(combined.numericNames)).toEqual(byName(numericNames));
+      expect(byName(combined.booleanNames)).toEqual(byName(booleanNames));
+      expect(byLabel(combined.categoricalNames)).toEqual(
+        byLabel(categoricalNames),
+      );
+      expect(byLabel(combined.traceCategoricalNames)).toEqual(
+        byLabel(traceCategoricalNames),
+      );
+      expect(byName(combined.traceBooleanNames)).toEqual(
+        byName(traceBooleanNames),
+      );
+      expect(byColumn(combined.observationLevelScores)).toEqual(
+        byColumn(observationLevelScores),
+      );
+      expect(byColumn(combined.traceLevelScores)).toEqual(
+        byColumn(traceLevelScores),
+      );
+      expect(combined.numericNames.map((row) => row.name)).not.toContain(
+        "session-only",
+      );
+      expect(combined.booleanNames.map((row) => row.name)).not.toContain(
+        "empty-bool",
+      );
+      expect(combined.numericNames.map((row) => row.name)).toContain(
+        "empty-bool",
+      );
     });
   });
 });

--- a/web/src/__tests__/server/repositories/score-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/score-repository.servertest.ts
@@ -31,6 +31,7 @@ import {
   createOrgProjectAndApiKey,
   getScoreStringValues,
 } from "@langfuse/shared/src/server";
+import type { FilterState } from "@langfuse/shared";
 import { v4 } from "uuid";
 
 describe("Clickhouse Scores Repository Test", () => {
@@ -1486,38 +1487,38 @@ describe("Clickhouse Scores Repository Test", () => {
     it("matches the per-column score-name helpers on the same fixture", async () => {
       const isolatedProjectId = v4();
       const observationId = v4();
-      const timestampFilter = [
+      const timestampFilter: FilterState = [
         {
-          column: "Timestamp" as const,
-          type: "datetime" as const,
-          operator: ">=" as const,
+          column: "Timestamp",
+          type: "datetime",
+          operator: ">=",
           value: new Date(Date.now() - 60 * 60 * 1000),
         },
       ];
-      const traceScopedFilter = [
+      const traceScopedFilter: FilterState = [
         {
-          type: "null" as const,
+          type: "null",
           column: "traceId",
-          operator: "is not null" as const,
+          operator: "is not null",
           value: "",
         },
         ...timestampFilter,
       ];
-      const traceLevelFilter = [
+      const traceLevelFilter: FilterState = [
         ...traceScopedFilter,
         {
-          type: "null" as const,
+          type: "null",
           column: "observationId",
-          operator: "is null" as const,
+          operator: "is null",
           value: "",
         },
       ];
-      const observationLevelFilter = [
+      const observationLevelFilter: FilterState = [
         ...traceScopedFilter,
         {
-          type: "null" as const,
+          type: "null",
           column: "observationId",
-          operator: "is not null" as const,
+          operator: "is not null",
           value: "",
         },
       ];

--- a/web/src/__tests__/server/scores-trpc.servertest.ts
+++ b/web/src/__tests__/server/scores-trpc.servertest.ts
@@ -1,11 +1,11 @@
 const {
   mockAddScoreDelete,
   mockAddBatchAction,
-  mockGetEventsFilterOptionsForColumns,
+  mockGetEventsExactFilterOptionsForColumns,
 } = vi.hoisted(() => ({
   mockAddScoreDelete: vi.fn(),
   mockAddBatchAction: vi.fn(),
-  mockGetEventsFilterOptionsForColumns: vi.fn(async () => []),
+  mockGetEventsExactFilterOptionsForColumns: vi.fn(async () => []),
 }));
 
 vi.mock("@langfuse/shared/src/server", async () => {
@@ -22,7 +22,8 @@ vi.mock("@langfuse/shared/src/server", async () => {
         add: mockAddBatchAction,
       })),
     },
-    getEventsFilterOptionsForColumns: mockGetEventsFilterOptionsForColumns,
+    getEventsExactFilterOptionsForColumns:
+      mockGetEventsExactFilterOptionsForColumns,
   };
 });
 
@@ -65,7 +66,7 @@ describe("scores trpc", () => {
     orgId = setup.orgId;
     mockAddScoreDelete.mockClear();
     mockAddBatchAction.mockClear();
-    mockGetEventsFilterOptionsForColumns.mockClear();
+    mockGetEventsExactFilterOptionsForColumns.mockClear();
 
     const session: Session = {
       expires: "1",

--- a/web/src/__tests__/server/scores-trpc.servertest.ts
+++ b/web/src/__tests__/server/scores-trpc.servertest.ts
@@ -1,15 +1,11 @@
 const {
   mockAddScoreDelete,
   mockAddBatchAction,
-  mockGetEventsGroupedByTraceTags,
-  mockGetEventsGroupedByTraceName,
-  mockGetEventsGroupedByUserId,
+  mockGetEventsFilterOptionsForColumns,
 } = vi.hoisted(() => ({
   mockAddScoreDelete: vi.fn(),
   mockAddBatchAction: vi.fn(),
-  mockGetEventsGroupedByTraceTags: vi.fn(async () => []),
-  mockGetEventsGroupedByTraceName: vi.fn(async () => []),
-  mockGetEventsGroupedByUserId: vi.fn(async () => []),
+  mockGetEventsFilterOptionsForColumns: vi.fn(async () => []),
 }));
 
 vi.mock("@langfuse/shared/src/server", async () => {
@@ -26,9 +22,7 @@ vi.mock("@langfuse/shared/src/server", async () => {
         add: mockAddBatchAction,
       })),
     },
-    getEventsGroupedByTraceTags: mockGetEventsGroupedByTraceTags,
-    getEventsGroupedByTraceName: mockGetEventsGroupedByTraceName,
-    getEventsGroupedByUserId: mockGetEventsGroupedByUserId,
+    getEventsFilterOptionsForColumns: mockGetEventsFilterOptionsForColumns,
   };
 });
 
@@ -71,9 +65,7 @@ describe("scores trpc", () => {
     orgId = setup.orgId;
     mockAddScoreDelete.mockClear();
     mockAddBatchAction.mockClear();
-    mockGetEventsGroupedByTraceTags.mockClear();
-    mockGetEventsGroupedByTraceName.mockClear();
-    mockGetEventsGroupedByUserId.mockClear();
+    mockGetEventsFilterOptionsForColumns.mockClear();
 
     const session: Session = {
       expires: "1",

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -10,14 +10,11 @@ import {
 import {
   getObservationsCountsFromEventsTable,
   getObservationsWithModelDataFromEventsTable,
-  getCategoricalScoresGroupedByName,
   getEventsFilterOptionsForColumns,
   getEventsFilterOptionValuesPage,
   getEventsMetadataValues,
   getEventsNumericStatsByFilterColumn,
-  getNumericScoresGroupedByName,
-  getBooleanScoresGroupedByName,
-  getScoresGroupedByNameSourceType,
+  getScoresFilterOptionsForEventFacets,
   getObservationsBatchIOFromEventsTable,
   getScoresForObservations,
   getScoresForTraces,
@@ -30,51 +27,6 @@ import {
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
 
 type TimeFilter = z.infer<typeof timeFilter>;
-
-const TRACE_SCORE_SCOPE_FILTER: FilterCondition[] = [
-  {
-    type: "null",
-    column: "traceId",
-    operator: "is not null",
-    value: "",
-  },
-  {
-    type: "null",
-    column: "observationId",
-    operator: "is null",
-    value: "",
-  },
-];
-
-const OBSERVATION_SCORE_SCOPE_FILTER: FilterCondition[] = [
-  {
-    type: "null",
-    column: "traceId",
-    operator: "is not null",
-    value: "",
-  },
-  {
-    type: "null",
-    column: "observationId",
-    operator: "is not null",
-    value: "",
-  },
-];
-
-// The level-agnostic "Scores" groups (`scores_avg` / `score_categories`) match a
-// score whether it sits at observation or trace level, but only if it rolls up
-// into a trace — i.e. `trace_id IS NOT NULL`. Session-level and dataset-run
-// scores (`trace_id IS NULL`) can never match the events union, so scope
-// discovery to trace-attached scores to keep offered-set == matchable-set
-// (LFE-10596). Mirrors `scoreFilters.forTraceScopedAggregates`.
-const TRACE_SCOPED_SCORE_FILTER: FilterCondition[] = [
-  {
-    type: "null",
-    column: "traceId",
-    operator: "is not null",
-    value: "",
-  },
-];
 
 interface GetObservationsListBaseParams {
   projectId: string;
@@ -597,15 +549,10 @@ const getEventFilterOptionsScope = (
     startTimeFilter,
     "Timestamp",
   );
-  const traceScoreTimestampFilters = toScoreTimestampFilters(
-    startTimeFilter,
-    "timestamp",
-  );
 
   return {
     eventsFilter,
     traceTimestampFilters,
-    traceScoreTimestampFilters,
   };
 };
 
@@ -684,7 +631,7 @@ export async function getEventFilterOptions(
   const { participatingFilter, omitCounts } = partitionEventFilterOptionsFilter(
     scopedParams.filter,
   );
-  const { eventsFilter, traceTimestampFilters, traceScoreTimestampFilters } =
+  const { eventsFilter, traceTimestampFilters } =
     getEventFilterOptionsScope(scopedParams);
   const refinedEventsFilter = eventsFilter.concat(participatingFilter);
   const requestedColumns = new Set<EventFilterOptionsColumn>(columns);
@@ -706,77 +653,28 @@ export async function getEventFilterOptions(
   // with its level (ScoreTag, LFE-10596). Loaded with the agnostic groups.
   const shouldLoadScoreNameLevels =
     shouldLoadScoresAvg || shouldLoadScoreCategories || shouldLoadScoreBooleans;
+  const shouldLoadAnyScores =
+    shouldLoadScoreNameLevels ||
+    shouldLoadTraceScores ||
+    shouldLoadTraceScoreCategories ||
+    shouldLoadTraceScoreBooleans;
 
   // The `scores_avg` / `score_categories` / `score_booleans` groups are
   // level-agnostic (their filter matches observation- OR trace-level scores;
   // see `toLevelAgnosticScoreFilter` in events-observation-row-selection.ts),
   // so they offer every score that rolls up into a trace — matchable-set ==
-  // offered-set (LFE-10596). Scoping to trace-attached scores (`trace_id IS
+  // offered-set. Scoping to trace-attached scores (`trace_id IS
   // NOT NULL`) excludes session-/dataset-run scores the union can never match.
   // The trace-scoped discovery below stays trace-only to back the search bar's
-  // `traceScores.` escape hatch.
-  const [
-    numericScoreNames,
-    booleanScoreNames,
-    categoricalScoreNames,
-    traceScoreColumns,
-    traceCategoricalScoreColumns,
-    traceBooleanScoreColumns,
-    observationLevelScoreNames,
-    traceLevelScoreNames,
-    eventFilterOptions,
-  ] = await Promise.all([
-    shouldLoadScoresAvg
-      ? getNumericScoresGroupedByName(projectId, [
-          ...TRACE_SCOPED_SCORE_FILTER,
-          ...traceTimestampFilters,
-        ])
-      : Promise.resolve([]),
-    shouldLoadScoreBooleans
-      ? getBooleanScoresGroupedByName(projectId, [
-          ...TRACE_SCOPED_SCORE_FILTER,
-          ...traceTimestampFilters,
-        ])
-      : Promise.resolve([]),
-    shouldLoadScoreCategories
-      ? getCategoricalScoresGroupedByName(projectId, [
-          ...TRACE_SCOPED_SCORE_FILTER,
-          ...traceTimestampFilters,
-        ])
-      : Promise.resolve([]),
-    shouldLoadTraceScores
-      ? getScoresGroupedByNameSourceType({
+  // `traceScores.` escape hatch. All of those score-name scans share one
+  // `scores` pass with conditional aggregation.
+  const [scoreNameOptions, eventFilterOptions] = await Promise.all([
+    shouldLoadAnyScores
+      ? getScoresFilterOptionsForEventFacets({
           projectId,
-          filter: [...TRACE_SCORE_SCOPE_FILTER, ...traceScoreTimestampFilters],
+          timestampFilter: traceTimestampFilters,
         })
-      : Promise.resolve([]),
-    shouldLoadTraceScoreCategories
-      ? getCategoricalScoresGroupedByName(projectId, [
-          ...TRACE_SCORE_SCOPE_FILTER,
-          ...traceTimestampFilters,
-        ])
-      : Promise.resolve([]),
-    shouldLoadTraceScoreBooleans
-      ? getBooleanScoresGroupedByName(projectId, [
-          ...TRACE_SCORE_SCOPE_FILTER,
-          ...traceTimestampFilters,
-        ])
-      : Promise.resolve([]),
-    shouldLoadScoreNameLevels
-      ? getScoresGroupedByNameSourceType({
-          projectId,
-          filter: [
-            ...OBSERVATION_SCORE_SCOPE_FILTER,
-            ...traceScoreTimestampFilters,
-          ],
-        })
-      : Promise.resolve([]),
-    shouldLoadScoreNameLevels
-      ? getScoresGroupedByNameSourceType({
-          projectId,
-          filter: [...TRACE_SCORE_SCOPE_FILTER, ...traceScoreTimestampFilters],
-        })
-      : Promise.resolve([]),
+      : Promise.resolve(undefined),
     eventColumns.length > 0
       ? getEventsFilterOptionsForColumns({
           projectId,
@@ -789,6 +687,16 @@ export async function getEventFilterOptions(
         })
       : Promise.resolve([]),
   ]);
+  const numericScoreNames = scoreNameOptions?.numericNames ?? [];
+  const booleanScoreNames = scoreNameOptions?.booleanNames ?? [];
+  const categoricalScoreNames = scoreNameOptions?.categoricalNames ?? [];
+  const traceScoreColumns = scoreNameOptions?.traceScoreColumns ?? [];
+  const traceCategoricalScoreColumns =
+    scoreNameOptions?.traceCategoricalNames ?? [];
+  const traceBooleanScoreColumns = scoreNameOptions?.traceBooleanNames ?? [];
+  const observationLevelScoreNames =
+    scoreNameOptions?.observationLevelScores ?? [];
+  const traceLevelScoreNames = scoreNameOptions?.traceLevelScores ?? [];
   const traceNumericScoreNames = Array.from(
     new Set(
       traceScoreColumns

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -690,7 +690,6 @@ export async function getEventFilterOptions(
   const numericScoreNames = scoreNameOptions?.numericNames ?? [];
   const booleanScoreNames = scoreNameOptions?.booleanNames ?? [];
   const categoricalScoreNames = scoreNameOptions?.categoricalNames ?? [];
-  const traceScoreColumns = scoreNameOptions?.traceScoreColumns ?? [];
   const traceCategoricalScoreColumns =
     scoreNameOptions?.traceCategoricalNames ?? [];
   const traceBooleanScoreColumns = scoreNameOptions?.traceBooleanNames ?? [];
@@ -699,7 +698,7 @@ export async function getEventFilterOptions(
   const traceLevelScoreNames = scoreNameOptions?.traceLevelScores ?? [];
   const traceNumericScoreNames = Array.from(
     new Set(
-      traceScoreColumns
+      traceLevelScoreNames
         .filter(
           (score) =>
             score.dataType === "NUMERIC" || score.dataType === "BOOLEAN",

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -45,9 +45,7 @@ import {
   getTracesGroupedByTags,
   getTracesGroupedByName,
   getTracesGroupedByUsers,
-  getEventsGroupedByTraceName,
-  getEventsGroupedByTraceTags,
-  getEventsGroupedByUserId,
+  getEventsFilterOptionsForColumns,
   tracesTableUiColumnDefinitions,
   upsertScore,
   logger,
@@ -426,32 +424,34 @@ export const scoresRouter = createTRPCRouter({
         toTime: upperBound,
       };
 
-      const [names, tags, traceNames, userIds, stringValues] =
-        await Promise.all([
-          getScoreNames(input.projectId, timestampFilter ?? []),
-          getEventsGroupedByTraceTags(input.projectId, eventsFilter, {
-            scope,
-          }),
-          getEventsGroupedByTraceName(input.projectId, eventsFilter, {
-            scope,
-          }),
-          getEventsGroupedByUserId(input.projectId, eventsFilter, {
-            scope,
-          }),
-          getScoreStringValues(input.projectId, timestampFilter ?? []),
-        ]);
+      const [names, eventFacets, stringValues] = await Promise.all([
+        getScoreNames(input.projectId, timestampFilter ?? []),
+        getEventsFilterOptionsForColumns({
+          projectId: input.projectId,
+          filter: eventsFilter,
+          columns: ["traceTags", "traceName", "userId"],
+          scope,
+        }),
+        getScoreStringValues(input.projectId, timestampFilter ?? []),
+      ]);
 
       return {
         name: names.map((i) => ({ value: i.name, count: i.count })),
-        tags: tags.map((t) => ({ value: t.tag })),
-        traceName: traceNames.map((tn) => ({
-          value: tn.traceName,
-          count: Number(tn.count),
-        })),
-        userId: userIds.map((u) => ({
-          value: u.userId,
-          count: Number(u.count),
-        })),
+        tags: eventFacets
+          .filter((row) => row.column === "traceTags")
+          .map((row) => ({ value: row.value })),
+        traceName: eventFacets
+          .filter((row) => row.column === "traceName")
+          .map((row) => ({
+            value: row.value,
+            count: Number(row.count),
+          })),
+        userId: eventFacets
+          .filter((row) => row.column === "userId")
+          .map((row) => ({
+            value: row.value,
+            count: Number(row.count),
+          })),
         stringValue: stringValues,
         booleanValue: BOOLEAN_SCORE_VALUE_OPTIONS,
       };

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -45,7 +45,7 @@ import {
   getTracesGroupedByTags,
   getTracesGroupedByName,
   getTracesGroupedByUsers,
-  getEventsFilterOptionsForColumns,
+  getEventsExactFilterOptionsForColumns,
   tracesTableUiColumnDefinitions,
   upsertScore,
   logger,
@@ -426,7 +426,7 @@ export const scoresRouter = createTRPCRouter({
 
       const [names, eventFacets, stringValues] = await Promise.all([
         getScoreNames(input.projectId, timestampFilter ?? []),
-        getEventsFilterOptionsForColumns({
+        getEventsExactFilterOptionsForColumns({
           projectId: input.projectId,
           filter: eventsFilter,
           columns: ["traceTags", "traceName", "userId"],


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17314 app preview](https://pr-17314.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Same combine as #17279, with a simpler scores query: no per-facet `dense_rank()` windows.

Filter-option endpoints were issuing several independent `scores` / `events_core` scans in one `Promise.all`, all landing on a single ClickHouse replica. This collapses each group into one pass:

- `scores.filterOptionsFromEvents`: the three `events_core` facets (trace tags / name / user id) ride one exact `UNION ALL` of per-column `GROUP BY` / `LIMIT` queries.
- `events.filterOptions`: the score-name toplists become one `scores` scan with conditional aggregation (`countIf` / `groupUniqArrayIf`), then TypeScript splits the facets and merges categorical score-config values.

The combined scores query groups by `(name, source, data_type)`, orders by that group's `count()`, and keeps the top 2000 groups (`FILTER_OPTION_SCORE_NAME_LIMIT * 10`). TypeScript still sums across sources and caps each facet at 200 names.

#17279 keeps seven `dense_rank()` windows so SQL capping matches each facet's exact top-200. This PR drops those windows. Scan cost is unchanged; only post-aggregation CPU and SQL complexity change. #17307 is the same ranking-drop as a stacked delta on #17279 — left in place.

Returned filter-option *shapes* are unchanged (same name caps, same categorical value cap, same trace-attached scope, same config merge). Event-facet *counts* on the events-table path still follow `approx_top_k`. Parallel `Promise.all` remains elsewhere.

Impacted packages: `@langfuse/shared`, `web`.

## How a name can miss the toplist

ClickHouse ranks **groups**, TypeScript ranks **names**. A name is the sum of up to a few groups:

| | |
| --- | --- |
| Group key | `(name, source, data_type)` |
| Sources | `API`, `EVAL`, `ANNOTATION` (3) |
| Listable types | `NUMERIC`, `BOOLEAN`, `CATEGORICAL`, `TEXT` (4) |
| Theoretical max groups / name | 12 |
| Realistic split | **one type, one source** for intended usage; multiple groups only via migration or accidental reuse |
| SQL bound | `ORDER BY count DESC LIMIT 2000` on groups |
| UI bound | top **200 names** after summing the groups that made it back |

TypeScript only sees rows ClickHouse returned. If every group for a name is outside those 2000, the name is gone from every facet (numeric / boolean / categorical / level columns). If *some* of its groups make the cut, the name still appears, but with an **undercount**, and that undercount can then lose the JS top-200.

### Example (complete miss)

Name `quality` is numeric and written from all three sources:

| Group | Count |
| --- | ---: |
| `(quality, ANNOTATION, NUMERIC)` | 80 |
| `(quality, API, NUMERIC)` | 80 |
| `(quality, EVAL, NUMERIC)` | 80 |
| **Summed name count** | **240** |

The project also has 2000 other groups, each a single-source name with count **81**.

SQL `ORDER BY count DESC LIMIT 2000` keeps those 2000 groups of 81 and drops all three `quality` rows (80 < 81). `topNamesByCount` never sees `quality`, so it is absent from the numeric-name filter even though 240 would have ranked well inside the UI's top 200.

#17279's per-facet ranking would keep `quality`: it ranks names (or each facet's own measure) after grouping, so the summed 240 competes with other names, not with other groups.

### Example (undercount, then miss the UI cap)

Same `quality` split 80/80/80. Only the `ANNOTATION` row makes the 2000 (the other two sit just below the cutoff). TypeScript records `quality` at **80** instead of 240. If names 1–200 in that facet all have summed counts > 80, `quality` is sliced off the UI list even though the true total was 240.

### How likely is this?

The miss needs **two independent conditions at once**, and the first one — a name whose mass splits across groups — is not a shape that supported usage produces.

**A name only splits across groups through accidental or migration data.** The mechanism needs one name spread over several `(source, data_type)` groups, but that is not how scores are meant to be organized:

- **Sources are meant to distinguish, not overlap.** To compare an automated judge against human review, the product pairs two *distinct* scores on the same parent — Score Analytics' "Matched Data" view computes agreement between, e.g., `correctness_llm` and `correctness_human` — not one `correctness` name overloaded across `EVAL` and `ANNOTATION`. A single name spanning sources is what you get from a *migration* (a name written via the API for months, then also emitted by a new evaluator), not from a designed workflow.
- **A name is one data type.** Overloading a name across `NUMERIC` / `CATEGORICAL` / `BOOLEAN` is unsupported — Score Analytics refuses to compare across types and drops `TEXT` entirely. A name carries two types only by accident: value-inferred typing on config-less writes, or a score-config type edited mid-window (old rows keep the old type).

So the split is a property of messy data, not of a project that uses scores as intended.

**Even given a split, the `LIMIT` is a no-op** until the project has **more than 2000 distinct `(name, source, data_type)` groups** in the lookback window — on the order of thousands of distinct score names, since a well-formed name is one group. Below that, every group is returned and every sum is exact. A name that lives in one group can never fall through: its group count *is* its name count, so if it belongs in the top 200 names it is far inside the 2000-group bound.

The miss therefore requires **both** accidental/migration fan-out on a name **and** thousands of names in one window — a narrow, self-inflicted tail. Filter options already skip `FINAL` because some count inaccuracy is acceptable; this is the same class of tradeoff: exact counts for whatever was transferred, and graceful degradation of the filter list for high-cardinality projects with messy score data, not a guarantee that every name that would have ranked in the top 200 after summing is present.

## Type of change

- [x] Refactor (restructures existing code without changing behavior, with a bounded correctness tradeoff on which names are transferred)

## Mandatory Tasks

- [x] Self-reviewed the query shapes against the existing per-column helpers.

## Checklist

- Follows repo style (`pnpm run format` via pre-commit)
- No user-facing docs change (internal query shape only)
- SQL-shape unit test: one `FROM scores` / one `FROM events_core`; no `dense_rank`; parameterized `groupLimit`
- Repository comparison against the per-column helpers, including adversarial cap cases under LIMIT 2000

## Testing

- [x] Pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total`, `Cached: 0 cached, 7 total`
- [x] `pnpm exec turbo run typecheck --force --filter=web --filter=@langfuse/shared` — `Tasks: 5 successful, 5 total`, `Cached: 0 cached, 5 total`
- [x] `pnpm --filter web run test event-query-builder.servertest.ts` — `Tests 53 passed (53)`
- [x] `pnpm --filter web run test score-repository.servertest.ts -t getScoresFilterOptionsForEventFacets` — `Tests 5 passed | 37 skipped (42)`
- Skipped `knip` (no unused export; no new public symbols)
- Skipped browser / preview walkthrough: query-shape only

**How to test:**

1. Open a project with scores on events.
2. Open Observations filters and Scores filters.
3. Confirm score-name / source / data-type / categorical-value options still populate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-759677df-9d49-418e-a73f-02ed971e5a79?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-759677df-9d49-418e-a73f-02ed971e5a79&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62979856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not safe to merge until the score query preserves each facet's top options instead of applying one unrelated global group ranking.

<details open><summary><h3>Summary</h3></summary>

- Combines exact `events_core` facet queries through `UNION ALL`.
- Replaces multiple score scans with one conditional-aggregation query.
- Splits and ranks the returned score groups in TypeScript.
- Introduces a global group cap that can starve one facet with unrelated groups from another facet.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  S[(scores)] --> G[Group by name, source, data_type]
  G --> C[Order globally by total count]
  C --> L[Keep 2,000 groups]
  L --> N[Numeric names]
  L --> B[Boolean names]
  L --> K[Categorical names]
  L --> T[Trace-level facets]
  N --> U[Event filter options]
  B --> U
  K --> U
  T --> U
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["refactor(filter-options): drop exact fac..."](https://github.com/langfuse/langfuse/commit/034bc6a192ed5abd17bdbbb5643ae0671f306c06)</sub>

<!-- /greptile_comment -->
