### PR TITLE
chore(clickhouse): attribute SSR trace-redirect query outcomes

### DIFF
--- a/packages/shared/src/server/clickhouse/queryOutcome.test.ts
+++ b/packages/shared/src/server/clickhouse/queryOutcome.test.ts
@@ -58,6 +58,7 @@ describe("ClickHouse query outcome metric", () => {
     it.each([
       ["events.all", "events.all"],
       ["listObservations", "listObservations"],
+      ["trace_redirect", "trace_redirect"],
     ])("labels the bare route %s verbatim", (route, expected) => {
       expect(clickHouseQueryOutcomeRouteLabel(route)).toBe(expected);
     });

--- a/packages/shared/src/server/clickhouse/queryOutcome.ts
+++ b/packages/shared/src/server/clickhouse/queryOutcome.ts
@@ -53,7 +53,11 @@ const LABELLED_ROUTES = new Set([
  * do not need the method/path parsing REST routes get. Add one when it gains an
  * SLO or drives a meaningful share of timeouts.
  */
-const LABELLED_BARE_ROUTES = new Set(["events.all", "listObservations"]);
+const LABELLED_BARE_ROUTES = new Set([
+  "events.all",
+  "listObservations",
+  "trace_redirect",
+]);
 
 const OTHER_ROUTE_LABEL = "other";
 

--- a/packages/shared/src/server/clickhouse/queryTags.ts
+++ b/packages/shared/src/server/clickhouse/queryTags.ts
@@ -8,6 +8,7 @@ export const clickHouseQuerySurfaces = [
   "worker",
   "publicapi",
   "mcp",
+  "ssr",
 ] as const;
 
 export type ClickHouseQuerySurface = (typeof clickHouseQuerySurfaces)[number];

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1385,6 +1385,7 @@ export const getTracesByIdsForAnyProject = async (traceIds: string[]) => {
     params: {
       traceIds,
     },
+    tags: { surface: "ssr", route: "trace_redirect" },
   });
 
   return records.map((record) => ({


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17317 app preview](https://pr-17317.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

The legacy `/trace/[traceId]` redirect page (`web/src/pages/trace/[traceId].tsx`) looks up a trace's project via `getTracesByIdsForAnyProject` — a deliberate full-table scan of `traces` by id. It runs in `getServerSideProps`, outside the tRPC / public-API / MCP context that populates ClickHouse query tags, so its query-outcome telemetry landed in the catch-all `surface:unknown, route:other` buckets.

In prod-us this path is the dominant contributor to `langfuse.clickhouse.query.outcome{outcome IN (timeout,memory_limit,overcommit)}` for `route:other, surface:unknown` — a real, repeatedly timing-out query the attribution layer could not name.

This tags the query at its single call site so the metric carries real dimensions:
- Add `"ssr"` to `clickHouseQuerySurfaces` (the surface allowlist).
- Add `"trace_redirect"` to `LABELLED_BARE_ROUTES` so it survives the metric's cardinality bounding instead of collapsing to `other`.
- Pass `{ surface: "ssr", route: "trace_redirect" }` from `getTracesByIdsForAnyProject`, following the existing single-purpose-repo-function convention (`getTracesForBlobStorageExportParquet`, `getTracesForAnalyticsIntegrations`).

No behavior change to the query itself — the underlying unbounded full-table scan is tracked separately.

## Type of change

- [x] Chore / internal (observability attribution; no user-facing change)

## Checklist

- [x] Targeted tests pass (`queryOutcome.test.ts`, `queryTags.test.ts` — 33 passed)
- [x] Lint + typecheck pass across shared/web/worker/ee (11 tasks, executed not cached)
- [x] Pinned `trace_redirect` in the existing bare-route label test

🤖 Written by Claude (an AI agent) on behalf of Niklas

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62988307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge and correctly attributes the existing SSR trace-redirect query without changing its behavior.

<details open><summary><h3>Summary</h3></summary>

- Adds `ssr` to the supported ClickHouse query surfaces.
- Preserves `trace_redirect` as a first-class query-outcome route.
- Applies both tags to the redirect’s single-purpose trace lookup.
- Extends route-label coverage for the new route.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  SSR[Legacy trace redirect SSR] --> Lookup[getTracesByIdsForAnyProject]
  Lookup --> Tags["surface: ssr<br/>route: trace_redirect"]
  Tags --> CH[ClickHouse query]
  CH --> Outcome[Query outcome metric]
  Outcome --> Label["ssr / trace_redirect"]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["chore(clickhouse): attribute SSR trace-r..."](https://github.com/langfuse/langfuse/commit/e615b7701fb860b96bd1361b8f57325640e291f4)</sub>

<!-- /greptile_comment -->