### PR TITLE
docs: fix redirecting README links and restore careers page

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -9,10 +9,10 @@
       <a href="https://cloud.langfuse.com">
         <strong>Langfuse Cloud</strong>
       </a> · 
-      <a href="https://langfuse.com/docs/deployment/self-host">
+      <a href="https://langfuse.com/self-hosting">
         <strong>自托管</strong>
       </a> · 
-      <a href="https://langfuse.com/demo">
+      <a href="https://langfuse.com/docs/demo">
         <strong>演示</strong>
       </a>
     </h3>
@@ -23,7 +23,7 @@
     <a href="https://langfuse.com/issues"><strong>报告问题</strong></a> ·
     <a href="https://langfuse.com/ideas"><strong>功能请求</strong></a> ·
     <a href="https://langfuse.com/changelog"><strong>更新日志</strong></a> ·
-    <a href="https://langfuse.com/roadmap"><strong>路线图</strong></a> ·
+    <a href="https://langfuse.com/docs/roadmap"><strong>路线图</strong></a> ·
   </div>
   <br/>
   <span>Langfuse 使用 <a href="https://github.com/orgs/langfuse/discussions"><strong>GitHub Discussions</strong></a> 作为支持和功能请求的平台。</span>
@@ -84,22 +84,22 @@
 
 Langfuse 是一个 **开源 LLM 工程** 平台。它帮助团队协作 **开发、监控、评估** 以及 **调试** AI 应用。Langfuse 可在几分钟内 **自托管**，并且经过 **实战考验**。
 
-[![Langfuse 概览视频](https://github.com/user-attachments/assets/3926b288-ff61-4b95-8aa1-45d041c70866)](https://langfuse.com/watch-demo)
+[![Langfuse 概览视频](https://github.com/user-attachments/assets/3926b288-ff61-4b95-8aa1-45d041c70866)](https://langfuse.com/docs/demo)
 
 ## ✨ 核心特性
 
 ![Langfuse 概览](https://langfuse.com/images/docs/github-readme/github-feature-overview.png)
 
-- [LLM 应用可观察性](https://langfuse.com/docs/tracing)：为你的应用插入仪表代码，并开始将追踪数据传送到 Langfuse，从而追踪 LLM 调用及应用中其他相关逻辑（如检索、嵌入或代理操作）。检查并调试复杂日志及用户会话。试试互动的 [演示](https://langfuse.com/docs/demo) 看看效果。
+- [LLM 应用可观察性](https://langfuse.com/docs/observability/overview)：为你的应用插入仪表代码，并开始将追踪数据传送到 Langfuse，从而追踪 LLM 调用及应用中其他相关逻辑（如检索、嵌入或代理操作）。检查并调试复杂日志及用户会话。试试互动的 [演示](https://langfuse.com/docs/demo) 看看效果。
 - [提示管理](https://langfuse.com/docs/prompt-management/get-started) 帮助你集中管理、版本控制并协作迭代提示。得益于服务器和客户端的高效缓存，你可以在不增加延迟的情况下反复迭代提示。
 
 - [评估](https://langfuse.com/docs/evaluation/overview) 是 LLM 应用开发流程的关键组成部分，Langfuse 能够满足你的多样需求。它支持 LLM 作为"裁判"、用户反馈收集、手动标注以及通过 API/SDK 实现自定义评估流程。
 
-- [数据集](https://langfuse.com/docs/evaluation/dataset-runs/datasets) 为评估你的 LLM 应用提供测试集和基准。它们支持持续改进、部署前测试、结构化实验、灵活评估，并能与 LangChain、LlamaIndex 等框架无缝整合。
+- [数据集](https://langfuse.com/docs/evaluation/experiments/datasets) 为评估你的 LLM 应用提供测试集和基准。它们支持持续改进、部署前测试、结构化实验、灵活评估，并能与 LangChain、LlamaIndex 等框架无缝整合。
 
-- [LLM 试玩平台](https://langfuse.com/docs/playground) 是用于测试和迭代提示及模型配置的工具，缩短反馈周期，加速开发。当你在追踪中发现异常结果时，可以直接跳转至试玩平台进行调整。
+- [LLM 试玩平台](https://langfuse.com/docs/prompt-management/features/playground) 是用于测试和迭代提示及模型配置的工具，缩短反馈周期，加速开发。当你在追踪中发现异常结果时，可以直接跳转至试玩平台进行调整。
 
-- [综合 API](https://langfuse.com/docs/api)：Langfuse 常用于驱动定制化的 LLMOps 工作流程，同时利用 Langfuse 提供的构建模块和 API。我们提供 OpenAPI 规格、Postman 集合以及针对 Python 和 JS/TS 的类型化 SDK。
+- [综合 API](https://langfuse.com/docs/api-and-data-platform/features/public-api)：Langfuse 常用于驱动定制化的 LLMOps 工作流程，同时利用 Langfuse 提供的构建模块和 API。我们提供 OpenAPI 规格、Postman 集合以及针对 Python 和 JS/TS 的类型化 SDK。
 
 ## 📦 部署 Langfuse
 
@@ -119,7 +119,7 @@ Langfuse 是一个 **开源 LLM 工程** 平台。它帮助团队协作 **开发
 
 在你自己的基础设施上运行 Langfuse：
 
-- [本地（docker compose）](https://langfuse.com/self-hosting/local)：使用 Docker Compose 在你的机器上于 5 分钟内运行 Langfuse。
+- [本地（docker compose）](https://langfuse.com/self-hosting/deployment/docker-compose)：使用 Docker Compose 在你的机器上于 5 分钟内运行 Langfuse。
 
   ```bash:README.md/docker-compose
   # 获取最新的 Langfuse 仓库副本
@@ -130,11 +130,11 @@ Langfuse 是一个 **开源 LLM 工程** 平台。它帮助团队协作 **开发
   docker compose up
   ```
 
-- [Kubernetes（Helm）](https://langfuse.com/self-hosting/kubernetes-helm)：使用 Helm 在 Kubernetes 集群上部署 Langfuse。这是推荐的生产环境部署方式。
+- [Kubernetes（Helm）](https://langfuse.com/self-hosting/deployment/kubernetes-helm)：使用 Helm 在 Kubernetes 集群上部署 Langfuse。这是推荐的生产环境部署方式。
 
-- [虚拟机](https://langfuse.com/self-hosting/docker-compose)：使用 Docker Compose 在单台虚拟机上部署 Langfuse。
+- [虚拟机](https://langfuse.com/self-hosting/deployment/docker-compose)：使用 Docker Compose 在单台虚拟机上部署 Langfuse。
 
-- Terraform 模板: [AWS](https://langfuse.com/self-hosting/aws)、[Azure](https://langfuse.com/self-hosting/azure)、[GCP](https://langfuse.com/self-hosting/gcp)
+- Terraform 模板: [AWS](https://langfuse.com/self-hosting/deployment/aws)、[Azure](https://langfuse.com/self-hosting/deployment/azure)、[GCP](https://langfuse.com/self-hosting/deployment/gcp)
 
 请参阅 [自托管文档](https://langfuse.com/self-hosting) 了解更多关于架构和配置选项的信息。
 
@@ -144,40 +144,40 @@ Langfuse 是一个 **开源 LLM 工程** 平台。它帮助团队协作 **开发
 
 ### 主要集成：
 
-| 集成                                                                                 | 支持语言/平台          | 描述                                                                                                                             |
-| ------------------------------------------------------------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| [SDK](https://langfuse.com/docs/sdk)                                                 | Python, JS/TS          | 使用 SDK 进行手动仪表化，实现全面灵活性。                                                                                        |
-| [OpenAI](https://langfuse.com/integrations/model-providers/openai-py)                | Python, JS/TS          | 通过直接替换 OpenAI SDK 实现自动仪表化。                                                                                         |
-| [Langchain](https://langfuse.com/docs/integrations/langchain)                        | Python, JS/TS          | 通过传入回调处理器至 Langchain 应用实现自动仪表化。                                                                              |
-| [LlamaIndex](https://langfuse.com/docs/integrations/llama-index/get-started)         | Python                 | 通过 LlamaIndex 回调系统实现自动仪表化。                                                                                         |
-| [Haystack](https://langfuse.com/docs/integrations/haystack)                          | Python                 | 通过 Haystack 内容追踪系统实现自动仪表化。                                                                                       |
-| [LiteLLM](https://langfuse.com/docs/integrations/litellm)                            | Python, JS/TS (仅代理) | 允许使用任何 LLM 替代 GPT。支持 Azure、OpenAI、Cohere、Anthropic、Ollama、VLLM、Sagemaker、HuggingFace、Replicate（100+ LLMs）。 |
-| [Vercel AI SDK](https://langfuse.com/docs/integrations/vercel-ai-sdk)                | JS/TS                  | 基于 TypeScript 的工具包，帮助开发者使用 React、Next.js、Vue、Svelte 和 Node.js 构建 AI 驱动的应用。                             |
-| [API](https://langfuse.com/docs/api)                                                 |                        | 直接调用公共 API。提供 OpenAPI 规格。                                                                                            |
-| [Google VertexAI 和 Gemini](https://langfuse.com/docs/integrations/google-vertex-ai) | 模型                   | 在 Google 上运行基础模型和微调模型。                                                                                             |
+| 集成                                                                                            | 支持语言/平台          | 描述                                                                                                                             |
+| ----------------------------------------------------------------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| [SDK](https://langfuse.com/docs/observability/sdk/overview)                                     | Python, JS/TS          | 使用 SDK 进行手动仪表化，实现全面灵活性。                                                                                        |
+| [OpenAI](https://langfuse.com/integrations/model-providers/openai-py)                           | Python, JS/TS          | 通过直接替换 OpenAI SDK 实现自动仪表化。                                                                                         |
+| [Langchain](https://langfuse.com/integrations/frameworks/langchain)                             | Python, JS/TS          | 通过传入回调处理器至 Langchain 应用实现自动仪表化。                                                                              |
+| [LlamaIndex](https://langfuse.com/integrations/frameworks/llamaindex)                           | Python                 | 通过 LlamaIndex 回调系统实现自动仪表化。                                                                                         |
+| [Haystack](https://langfuse.com/integrations/frameworks/haystack)                               | Python                 | 通过 Haystack 内容追踪系统实现自动仪表化。                                                                                       |
+| [LiteLLM](https://langfuse.com/integrations/gateways/litellm)                                   | Python, JS/TS (仅代理) | 允许使用任何 LLM 替代 GPT。支持 Azure、OpenAI、Cohere、Anthropic、Ollama、VLLM、Sagemaker、HuggingFace、Replicate（100+ LLMs）。 |
+| [Vercel AI SDK](https://langfuse.com/integrations/frameworks/vercel-ai-sdk)                     | JS/TS                  | 基于 TypeScript 的工具包，帮助开发者使用 React、Next.js、Vue、Svelte 和 Node.js 构建 AI 驱动的应用。                             |
+| [API](https://langfuse.com/docs/api-and-data-platform/features/public-api)                      |                        | 直接调用公共 API。提供 OpenAPI 规格。                                                                                            |
+| [Google VertexAI 和 Gemini](https://langfuse.com/integrations/model-providers/google-vertex-ai) | 模型                   | 在 Google 上运行基础模型和微调模型。                                                                                             |
 
 ### 与 Langfuse 集成的软件包：
 
-| 名称                                                                    | 类型          | 描述                                                                                    |
-| ----------------------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------- |
-| [Instructor](https://langfuse.com/docs/integrations/instructor)         | 库            | 用于获取结构化 LLM 输出（JSON、Pydantic）的库。                                         |
-| [DSPy](https://langfuse.com/docs/integrations/dspy)                     | 库            | 一个系统性优化语言模型提示和权重的框架。                                                |
-| [Amazon Bedrock](https://langfuse.com/docs/integrations/amazon-bedrock) | 模型          | 在 AWS 上运行基础模型和微调模型。                                                       |
-| [Mirascope](https://langfuse.com/docs/integrations/mirascope)           | 库            | 构建 LLM 应用的 Python 工具包。                                                         |
-| [Ollama](https://langfuse.com/docs/integrations/ollama)                 | 模型（本地）  | 在你的机器上轻松运行开源 LLM。                                                          |
-| [AutoGen](https://langfuse.com/docs/integrations/autogen)               | 代理框架      | 用于构建分布式代理的开源 LLM 平台。                                                     |
-| [Flowise](https://langfuse.com/docs/integrations/flowise)               | 聊天/代理界面 | 基于 JS/TS 的无代码构建器，用于定制化 LLM 流程。                                        |
-| [Langflow](https://langfuse.com/docs/integrations/langflow)             | 聊天/代理界面 | 基于 Python 的 LangChain 用户界面，采用 react-flow 设计，提供便捷的实验与原型构建体验。 |
-| [Dify](https://langfuse.com/docs/integrations/dify)                     | 聊天/代理界面 | 带有无代码构建器的开源 LLM 应用开发平台。                                               |
-| [OpenWebUI](https://langfuse.com/docs/integrations/openwebui)           | 聊天/代理界面 | 自托管的 LLM 聊天网页界面，支持包括自托管和本地模型在内的多种 LLM 运行器。              |
-| [Promptfoo](https://langfuse.com/docs/integrations/promptfoo)           | 工具          | 开源 LLM 测试平台。                                                                     |
-| [LobeChat](https://langfuse.com/docs/integrations/lobechat)             | 聊天/代理界面 | 开源聊天机器人平台。                                                                    |
-| [Vapi](https://langfuse.com/docs/integrations/vapi)                     | 平台          | 开源语音 AI 平台。                                                                      |
-| [Inferable](https://langfuse.com/docs/integrations/other/inferable)     | 代理          | 构建分布式代理的开源 LLM 平台。                                                         |
-| [Gradio](https://langfuse.com/docs/integrations/other/gradio)           | 聊天/代理界面 | 开源 Python 库，可用于构建类似聊天 UI 的网页界面。                                      |
-| [Goose](https://langfuse.com/docs/integrations/goose)                   | 代理          | 构建分布式代理的开源 LLM 平台。                                                         |
-| [smolagents](https://langfuse.com/docs/integrations/smolagents)         | 代理          | 开源 AI 代理框架。                                                                      |
-| [CrewAI](https://langfuse.com/docs/integrations/crewai)                 | 代理          | 多代理框架，用于实现代理之间的协作与工具调用。                                          |
+| 名称                                                                               | 类型          | 描述                                                                                    |
+| ---------------------------------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------- |
+| [Instructor](https://langfuse.com/integrations/frameworks/instructor)              | 库            | 用于获取结构化 LLM 输出（JSON、Pydantic）的库。                                         |
+| [DSPy](https://langfuse.com/integrations/frameworks/dspy)                          | 库            | 一个系统性优化语言模型提示和权重的框架。                                                |
+| [Amazon Bedrock](https://langfuse.com/integrations/model-providers/amazon-bedrock) | 模型          | 在 AWS 上运行基础模型和微调模型。                                                       |
+| [Mirascope](https://langfuse.com/integrations/frameworks/mirascope)                | 库            | 构建 LLM 应用的 Python 工具包。                                                         |
+| [Ollama](https://langfuse.com/integrations/model-providers/ollama)                 | 模型（本地）  | 在你的机器上轻松运行开源 LLM。                                                          |
+| [AutoGen](https://langfuse.com/integrations/frameworks/autogen)                    | 代理框架      | 用于构建分布式代理的开源 LLM 平台。                                                     |
+| [Flowise](https://langfuse.com/integrations/no-code/flowise)                       | 聊天/代理界面 | 基于 JS/TS 的无代码构建器，用于定制化 LLM 流程。                                        |
+| [Langflow](https://langfuse.com/integrations/no-code/langflow)                     | 聊天/代理界面 | 基于 Python 的 LangChain 用户界面，采用 react-flow 设计，提供便捷的实验与原型构建体验。 |
+| [Dify](https://langfuse.com/integrations/no-code/dify)                             | 聊天/代理界面 | 带有无代码构建器的开源 LLM 应用开发平台。                                               |
+| [OpenWebUI](https://langfuse.com/integrations/no-code/openwebui)                   | 聊天/代理界面 | 自托管的 LLM 聊天网页界面，支持包括自托管和本地模型在内的多种 LLM 运行器。              |
+| [Promptfoo](https://langfuse.com/integrations/other/promptfoo)                     | 工具          | 开源 LLM 测试平台。                                                                     |
+| [LobeChat](https://langfuse.com/integrations/no-code/lobechat)                     | 聊天/代理界面 | 开源聊天机器人平台。                                                                    |
+| [Vapi](https://langfuse.com/integrations/no-code/vapi)                             | 平台          | 开源语音 AI 平台。                                                                      |
+| [Inferable](https://langfuse.com/integrations/other/inferable)                     | 代理          | 构建分布式代理的开源 LLM 平台。                                                         |
+| [Gradio](https://langfuse.com/integrations/other/gradio)                           | 聊天/代理界面 | 开源 Python 库，可用于构建类似聊天 UI 的网页界面。                                      |
+| [Goose](https://langfuse.com/integrations/no-code/goose)                           | 代理          | 构建分布式代理的开源 LLM 平台。                                                         |
+| [smolagents](https://langfuse.com/integrations/frameworks/smolagents)              | 代理          | 开源 AI 代理框架。                                                                      |
+| [CrewAI](https://langfuse.com/integrations/frameworks/crewai)                      | 代理          | 多代理框架，用于实现代理之间的协作与工具调用。                                          |
 
 ## 🚀 快速入门
 
@@ -191,10 +191,10 @@ Langfuse 是一个 **开源 LLM 工程** 平台。它帮助团队协作 **开发
 
 ### 2️⃣ 记录你的第一个 LLM 调用
 
-使用 [<code>@observe()</code> 装饰器](https://langfuse.com/docs/sdk/python/decorators) 可轻松跟踪任何 Python LLM 应用。在本快速入门中，我们还使用了 Langfuse 的 [OpenAI 集成](https://langfuse.com/integrations/model-providers/openai-py) 来自动捕获所有模型参数。
+使用 [<code>@observe()</code> 装饰器](https://langfuse.com/docs/observability/sdk/instrumentation#observe-wrapper) 可轻松跟踪任何 Python LLM 应用。在本快速入门中，我们还使用了 Langfuse 的 [OpenAI 集成](https://langfuse.com/integrations/model-providers/openai-py) 来自动捕获所有模型参数。
 
 > [!提示]
-> 不使用 OpenAI？请访问 [我们的文档](https://langfuse.com/docs/get-started#log-your-first-llm-call-to-langfuse) 了解如何记录其他模型和框架。
+> 不使用 OpenAI？请访问 [我们的文档](https://langfuse.com/docs/observability/get-started) 了解如何记录其他模型和框架。
 
 安装依赖：
 
@@ -241,7 +241,7 @@ _[Langfuse 中的公共示例追踪](https://cloud.langfuse.com/project/cloramnk
 
 > [!提示]
 >
-> [了解更多](https://langfuse.com/docs/tracing) 关于 Langfuse 中的追踪，或试试 [互动演示](https://langfuse.com/docs/demo)。
+> [了解更多](https://langfuse.com/docs/observability/overview) 关于 Langfuse 中的追踪，或试试 [互动演示](https://langfuse.com/docs/demo)。
 
 ## ⭐️ 给我们加星
 
@@ -272,7 +272,7 @@ _[Langfuse 中的公共示例追踪](https://cloud.langfuse.com/project/cloramnk
 
 ## 🥇 许可证
 
-除 `ee` 文件夹外，本仓库采用 MIT 许可证。详情请参见 [LICENSE](LICENSE) 以及 [文档](https://langfuse.com/docs/open-source)。
+除 `ee` 文件夹外，本仓库采用 MIT 许可证。详情请参见 [LICENSE](LICENSE) 以及 [文档](https://langfuse.com/handbook/chapters/open-source)。
 
 ## ⭐️ 星标历史
 
@@ -286,7 +286,7 @@ _[Langfuse 中的公共示例追踪](https://cloud.langfuse.com/project/cloramnk
 
 ## ❤️ 使用 Langfuse 的开源项目
 
-以下是使用 Langfuse 的顶级开源 Python 项目，按星标数排名（[来源](https://github.com/langfuse/langfuse-docs/blob/main/components-mdx/dependents)）：
+以下是使用 Langfuse 的顶级开源 Python 项目，按星标数排名（[来源](https://github.com/langfuse/langfuse-docs/tree/main/components-mdx/dependents)）：
 
 | 仓库                                                                                                                                                                                                                                                                |  星数 |
 | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----: |

--- a/README.ja.md
+++ b/README.ja.md
@@ -3,16 +3,16 @@
 <div align="center">
    <div>
       <h3>
-          <a href="https://langfuse.com/jp">
+          <a href="https://langfuse.com/japan">
             <strong>🇯🇵 🤝 🪢</strong>
          </a> · 
          <a href="https://cloud.langfuse.com">
             <strong>Langfuse Cloud</strong>
          </a> · 
-         <a href="https://langfuse.com/docs/deployment/self-host">
+         <a href="https://langfuse.com/self-hosting">
             <strong>セルフホスティング</strong>
          </a> · 
-         <a href="https://langfuse.com/demo">
+         <a href="https://langfuse.com/docs/demo">
             <strong>デモ</strong>
          </a>
       </h3>
@@ -23,7 +23,7 @@
       <a href="https://langfuse.com/issues"><strong>バグ報告</strong></a> ·
       <a href="https://langfuse.com/ideas"><strong>機能リクエスト</strong></a> ·
       <a href="https://langfuse.com/changelog"><strong>変更履歴</strong></a> ·
-      <a href="https://langfuse.com/roadmap"><strong>ロードマップ</strong></a> ·
+      <a href="https://langfuse.com/docs/roadmap"><strong>ロードマップ</strong></a> ·
    </div>
    <br/>
    <span>Langfuseは、サポートと機能リクエストのために <a href="https://github.com/orgs/langfuse/discussions"><strong>GitHub Discussions</strong></a> を利用しています。</span>
@@ -73,13 +73,13 @@ Langfuseは**オープンソースのLLMエンジニアリング**プラット�
 チームが共同でAIアプリケーションを**開発、監視、評価**、および**デバッグ**するのを支援します。  
 Langfuseは**数分でセルフホスト可能**で、**多くの実績を持つ**システムです。
 
-[![Langfuse Overview Video](https://github.com/user-attachments/assets/3926b288-ff61-4b95-8aa1-45d041c70866)](https://langfuse.com/watch-demo)
+[![Langfuse Overview Video](https://github.com/user-attachments/assets/3926b288-ff61-4b95-8aa1-45d041c70866)](https://langfuse.com/docs/demo)
 
 ## ✨ コア機能
 
 ![Langfuse Overview](https://langfuse.com/images/docs/github-readme/github-feature-overview.png)
 
-- **[LLMアプリケーションの可観測性](https://langfuse.com/docs/tracing):**  
+- **[LLMアプリケーションの可観測性](https://langfuse.com/docs/observability/overview):**  
   アプリケーションにインストゥルメンテーションを導入し、Langfuseへトレースを取り込むことで、LLM呼び出しやリトリーバル、埋め込み、エージェントアクションなどの関連ロジックを追跡できます。  
   複雑なログやユーザーセッションを解析・デバッグできます。  
   インタラクティブな[デモ](https://langfuse.com/docs/demo)で動作を確認してください。
@@ -92,15 +92,15 @@ Langfuseは**数分でセルフホスト可能**で、**多くの実績を持つ
   評価はLLMアプリケーション開発ワークフローの要であり、Langfuseは多様なニーズに対応します。  
   LLMを判定者として用いる方法、ユーザーフィードバックの収集、手動によるラベリング、API/SDKを通じたカスタム評価パイプラインをサポートします。
 
-- **[データセット](https://langfuse.com/docs/evaluation/dataset-runs/datasets):**  
+- **[データセット](https://langfuse.com/docs/evaluation/experiments/datasets):**  
   LLMアプリケーション評価用のテストセットやベンチマークを構築できます。  
   継続的な改善、事前デプロイテスト、構造化された実験、柔軟な評価、さらにLangChainやLlamaIndexなどとのシームレスな統合をサポートします。
 
-- **[LLMプレイグラウンド](https://langfuse.com/docs/playground):**  
+- **[LLMプレイグラウンド](https://langfuse.com/docs/prompt-management/features/playground):**  
   プロンプトやモデル設定のテスト・反復作業を支援するツールで、フィードバックループを短縮し開発を加速します。  
   トレースで不具合が見つかった場合、直接プレイグラウンドへ飛び、迅速に改善できます。
 
-- **[包括的なAPI](https://langfuse.com/docs/api):**  
+- **[包括的なAPI](https://langfuse.com/docs/api-and-data-platform/features/public-api):**  
   LangfuseはAPIを通じて提供されるビルディングブロックを用い、カスタムLLMOpsワークフローの基盤として頻繁に利用されます。  
   OpenAPI仕様、Postmanコレクション、PythonやJS/TS向けの型付きSDKが利用可能です。
 
@@ -122,7 +122,7 @@ Langfuseチームによるマネージドデプロイメント。充実した無
 
 自身のインフラ上でLangfuseを実行できます:
 
-- **[Local (docker compose)](https://langfuse.com/self-hosting/local):**  
+- **[Local (docker compose)](https://langfuse.com/self-hosting/deployment/docker-compose):**  
   Docker Composeを使用して、たった5分で自分のマシン上でLangfuseを実行できます.
 
   ```bash
@@ -134,14 +134,14 @@ Langfuseチームによるマネージドデプロイメント。充実した無
   docker compose up
   ```
 
-- **[Kubernetes (Helm)](https://langfuse.com/self-hosting/kubernetes-helm):**  
+- **[Kubernetes (Helm)](https://langfuse.com/self-hosting/deployment/kubernetes-helm):**  
   Helmを使用してKubernetesクラスター上でLangfuseを実行します。  
   こちらが推奨される本番環境でのデプロイ方法です。
 
-- **[VM](https://langfuse.com/self-hosting/docker-compose):**  
+- **[VM](https://langfuse.com/self-hosting/deployment/docker-compose):**  
   Docker Composeを使用して、単一の仮想マシン上でLangfuseを実行します。
 
-- Terraform テンプレート: [AWS](https://langfuse.com/self-hosting/aws), [Azure](https://langfuse.com/self-hosting/azure), [GCP](https://langfuse.com/self-hosting/gcp)
+- Terraform テンプレート: [AWS](https://langfuse.com/self-hosting/deployment/aws), [Azure](https://langfuse.com/self-hosting/deployment/azure), [GCP](https://langfuse.com/self-hosting/deployment/gcp)
 
 [セルフホスティングのドキュメント](https://langfuse.com/self-hosting)を参照し、アーキテクチャや設定オプションの詳細をご確認ください。
 
@@ -151,40 +151,40 @@ Langfuseチームによるマネージドデプロイメント。充実した無
 
 ### 主なインテグレーション:
 
-| インテグレーション                                                           | 対応言語・環境             | 説明                                                                                                                                                      |
-| ---------------------------------------------------------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [SDK](https://langfuse.com/docs/sdk)                                         | Python, JS/TS              | SDKを利用して手動でインストゥルメンテーションを実装し、完全な柔軟性を提供します。                                                                         |
-| [OpenAI](https://langfuse.com/integrations/model-providers/openai-py)        | Python, JS/TS              | OpenAI SDKのドロップイン置換による自動インストゥルメンテーションを実現します。                                                                            |
-| [Langchain](https://langfuse.com/docs/integrations/langchain)                | Python, JS/TS              | Langchainアプリケーションにコールバックハンドラーを渡すことで自動的に計測します。                                                                         |
-| [LlamaIndex](https://langfuse.com/docs/integrations/llama-index/get-started) | Python                     | LlamaIndexのコールバックシステムを介して自動的にインストゥルメントします。                                                                                |
-| [Haystack](https://langfuse.com/docs/integrations/haystack)                  | Python                     | Haystackのコンテンツトレースシステムを利用した自動インストゥルメンテーションを実現します。                                                                |
-| [LiteLLM](https://langfuse.com/docs/integrations/litellm)                    | Python, JS/TS (proxy only) | GPTのドロップイン置換として任意のLLMを使用できます。Azure、OpenAI、Cohere、Anthropic、Ollama、VLLM、Sagemaker、HuggingFace、Replicate（100+ LLM）に対応。 |
-| [Vercel AI SDK](https://langfuse.com/docs/integrations/vercel-ai-sdk)        | JS/TS                      | React、Next.js、Vue、Svelte、Node.jsを使用してAI搭載アプリケーションの構築を支援するTypeScriptツールキットです。                                          |
-| [API](https://langfuse.com/docs/api)                                         |                            | 公開APIを直接呼び出すことが可能です。OpenAPI仕様も利用できます。                                                                                          |
+| インテグレーション                                                          | 対応言語・環境             | 説明                                                                                                                                                      |
+| --------------------------------------------------------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [SDK](https://langfuse.com/docs/observability/sdk/overview)                 | Python, JS/TS              | SDKを利用して手動でインストゥルメンテーションを実装し、完全な柔軟性を提供します。                                                                         |
+| [OpenAI](https://langfuse.com/integrations/model-providers/openai-py)       | Python, JS/TS              | OpenAI SDKのドロップイン置換による自動インストゥルメンテーションを実現します。                                                                            |
+| [Langchain](https://langfuse.com/integrations/frameworks/langchain)         | Python, JS/TS              | Langchainアプリケーションにコールバックハンドラーを渡すことで自動的に計測します。                                                                         |
+| [LlamaIndex](https://langfuse.com/integrations/frameworks/llamaindex)       | Python                     | LlamaIndexのコールバックシステムを介して自動的にインストゥルメントします。                                                                                |
+| [Haystack](https://langfuse.com/integrations/frameworks/haystack)           | Python                     | Haystackのコンテンツトレースシステムを利用した自動インストゥルメンテーションを実現します。                                                                |
+| [LiteLLM](https://langfuse.com/integrations/gateways/litellm)               | Python, JS/TS (proxy only) | GPTのドロップイン置換として任意のLLMを使用できます。Azure、OpenAI、Cohere、Anthropic、Ollama、VLLM、Sagemaker、HuggingFace、Replicate（100+ LLM）に対応。 |
+| [Vercel AI SDK](https://langfuse.com/integrations/frameworks/vercel-ai-sdk) | JS/TS                      | React、Next.js、Vue、Svelte、Node.jsを使用してAI搭載アプリケーションの構築を支援するTypeScriptツールキットです。                                          |
+| [API](https://langfuse.com/docs/api-and-data-platform/features/public-api)  |                            | 公開APIを直接呼び出すことが可能です。OpenAPI仕様も利用できます。                                                                                          |
 
 ### Langfuseと統合されているパッケージ:
 
-| 名前                                                                                  | タイプ                     | 説明                                                                                |
-| ------------------------------------------------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------- |
-| [Instructor](https://langfuse.com/docs/integrations/instructor)                       | ライブラリ                 | 構造化されたLLM出力（JSON、Pydantic）を取得するためのライブラリ                     |
-| [DSPy](https://langfuse.com/docs/integrations/dspy)                                   | ライブラリ                 | LLMプロンプトや重み付けを体系的に最適化するためのフレームワーク                     |
-| [Mirascope](https://langfuse.com/docs/integrations/mirascope)                         | ライブラリ                 | LLMアプリケーション構築用のPythonツールキット                                       |
-| [Ollama](https://langfuse.com/docs/integrations/ollama)                               | モデル（ローカル）         | オープンソースLLMを手軽にローカルで実行するためのツール                             |
-| [Amazon Bedrock](https://langfuse.com/docs/integrations/amazon-bedrock)               | モデル                     | AWS上でファウンデーションモデルやファインチューニング済みモデルを実行               |
-| [Google VertexAI and Gemini](https://langfuse.com/docs/integrations/google-vertex-ai) | モデル                     | Google上でファウンデーションモデルやファインチューニング済みモデルを実行            |
-| [AutoGen](https://langfuse.com/docs/integrations/autogen)                             | エージェントフレームワーク | 分散型エージェント構築のためのオープンソースLLMプラットフォーム                     |
-| [Flowise](https://langfuse.com/docs/integrations/flowise)                             | チャット/エージェント UI   | JS/TSのノーコードビルダーで、カスタマイズ可能なLLMフローを構築                      |
-| [Langflow](https://langfuse.com/docs/integrations/langflow)                           | チャット/エージェント UI   | PythonベースのUIで、react-flowを用いてLangChainの実験やプロトタイピングを容易に実現 |
-| [Dify](https://langfuse.com/docs/integrations/dify)                                   | チャット/エージェント UI   | ノーコードでLLMアプリ開発が可能なオープンソースプラットフォーム                     |
-| [OpenWebUI](https://langfuse.com/docs/integrations/openwebui)                         | チャット/エージェント UI   | 自前ホストおよびローカルモデルに対応するLLMチャットWeb UI                           |
-| [Promptfoo](https://langfuse.com/docs/integrations/promptfoo)                         | ツール                     | オープンソースのLLMテストプラットフォーム                                           |
-| [LobeChat](https://langfuse.com/docs/integrations/lobechat)                           | チャット/エージェント UI   | オープンソースのチャットボットプラットフォーム                                      |
-| [Vapi](https://langfuse.com/docs/integrations/vapi)                                   | プラットフォーム           | オープンソースの音声AIプラットフォーム                                              |
-| [Inferable](https://langfuse.com/docs/integrations/other/inferable)                   | エージェント               | 分散型エージェント構築のためのオープンソースLLMプラットフォーム                     |
-| [Gradio](https://langfuse.com/docs/integrations/other/gradio)                         | チャット/エージェント UI   | チャットUIなどのWebインターフェース構築のためのオープンソースPythonライブラリ       |
-| [Goose](https://langfuse.com/docs/integrations/goose)                                 | エージェント               | 分散型エージェント構築のためのオープンソースLLMプラットフォーム                     |
-| [smolagents](https://langfuse.com/docs/integrations/smolagents)                       | エージェント               | オープンソースのAIエージェントフレームワーク                                        |
-| [CrewAI](https://langfuse.com/docs/integrations/crewai)                               | エージェント               | エージェントの協調とツール利用を実現するマルチエージェントフレームワーク            |
+| 名前                                                                                             | タイプ                     | 説明                                                                                |
+| ------------------------------------------------------------------------------------------------ | -------------------------- | ----------------------------------------------------------------------------------- |
+| [Instructor](https://langfuse.com/integrations/frameworks/instructor)                            | ライブラリ                 | 構造化されたLLM出力（JSON、Pydantic）を取得するためのライブラリ                     |
+| [DSPy](https://langfuse.com/integrations/frameworks/dspy)                                        | ライブラリ                 | LLMプロンプトや重み付けを体系的に最適化するためのフレームワーク                     |
+| [Mirascope](https://langfuse.com/integrations/frameworks/mirascope)                              | ライブラリ                 | LLMアプリケーション構築用のPythonツールキット                                       |
+| [Ollama](https://langfuse.com/integrations/model-providers/ollama)                               | モデル（ローカル）         | オープンソースLLMを手軽にローカルで実行するためのツール                             |
+| [Amazon Bedrock](https://langfuse.com/integrations/model-providers/amazon-bedrock)               | モデル                     | AWS上でファウンデーションモデルやファインチューニング済みモデルを実行               |
+| [Google VertexAI and Gemini](https://langfuse.com/integrations/model-providers/google-vertex-ai) | モデル                     | Google上でファウンデーションモデルやファインチューニング済みモデルを実行            |
+| [AutoGen](https://langfuse.com/integrations/frameworks/autogen)                                  | エージェントフレームワーク | 分散型エージェント構築のためのオープンソースLLMプラットフォーム                     |
+| [Flowise](https://langfuse.com/integrations/no-code/flowise)                                     | チャット/エージェント UI   | JS/TSのノーコードビルダーで、カスタマイズ可能なLLMフローを構築                      |
+| [Langflow](https://langfuse.com/integrations/no-code/langflow)                                   | チャット/エージェント UI   | PythonベースのUIで、react-flowを用いてLangChainの実験やプロトタイピングを容易に実現 |
+| [Dify](https://langfuse.com/integrations/no-code/dify)                                           | チャット/エージェント UI   | ノーコードでLLMアプリ開発が可能なオープンソースプラットフォーム                     |
+| [OpenWebUI](https://langfuse.com/integrations/no-code/openwebui)                                 | チャット/エージェント UI   | 自前ホストおよびローカルモデルに対応するLLMチャットWeb UI                           |
+| [Promptfoo](https://langfuse.com/integrations/other/promptfoo)                                   | ツール                     | オープンソースのLLMテストプラットフォーム                                           |
+| [LobeChat](https://langfuse.com/integrations/no-code/lobechat)                                   | チャット/エージェント UI   | オープンソースのチャットボットプラットフォーム                                      |
+| [Vapi](https://langfuse.com/integrations/no-code/vapi)                                           | プラットフォーム           | オープンソースの音声AIプラットフォーム                                              |
+| [Inferable](https://langfuse.com/integrations/other/inferable)                                   | エージェント               | 分散型エージェント構築のためのオープンソースLLMプラットフォーム                     |
+| [Gradio](https://langfuse.com/integrations/other/gradio)                                         | チャット/エージェント UI   | チャットUIなどのWebインターフェース構築のためのオープンソースPythonライブラリ       |
+| [Goose](https://langfuse.com/integrations/no-code/goose)                                         | エージェント               | 分散型エージェント構築のためのオープンソースLLMプラットフォーム                     |
+| [smolagents](https://langfuse.com/integrations/frameworks/smolagents)                            | エージェント               | オープンソースのAIエージェントフレームワーク                                        |
+| [CrewAI](https://langfuse.com/integrations/frameworks/crewai)                                    | エージェント               | エージェントの協調とツール利用を実現するマルチエージェントフレームワーク            |
 
 ## 🚀 クイックスタート
 
@@ -199,11 +199,11 @@ Langfuseチームによるマネージドデプロイメント。充実した無
 
 ### 2️⃣ 初めてのLLM呼び出しのログ記録
 
-[`@observe()` デコレーター](https://langfuse.com/docs/sdk/python/decorators)を利用することで、任意のPython製LLMアプリケーションのトレースが簡単に行えます。  
+[`@observe()` デコレーター](https://langfuse.com/docs/observability/sdk/instrumentation#observe-wrapper)を利用することで、任意のPython製LLMアプリケーションのトレースが簡単に行えます。  
 このクイックスタートでは、Langfuseの[OpenAI統合](https://langfuse.com/integrations/model-providers/openai-py)を使用して、全てのモデルパラメータを自動で取得します。
 
 > [!TIP]
-> OpenAIを利用していない場合は、[こちらのドキュメント](https://langfuse.com/docs/get-started#log-your-first-llm-call-to-langfuse)で、他のモデルやフレームワークのログ記録方法をご確認ください。
+> OpenAIを利用していない場合は、[こちらのドキュメント](https://langfuse.com/docs/observability/get-started)で、他のモデルやフレームワークのログ記録方法をご確認ください。
 
 ```bash
 pip install langfuse openai
@@ -244,7 +244,7 @@ _[Langfuseの公開トレース例](https://cloud.langfuse.com/project/cloramnkj
 
 > [!TIP]
 >
-> Langfuseでのトレースの詳細については、[こちら](https://langfuse.com/docs/tracing)をご参照いただくか、[インタラクティブデモ](https://langfuse.com/docs/demo)でお試しください。
+> Langfuseでのトレースの詳細については、[こちら](https://langfuse.com/docs/observability/overview)をご参照いただくか、[インタラクティブデモ](https://langfuse.com/docs/demo)でお試しください。
 
 ## ⭐️ Star Langfuse
 
@@ -278,7 +278,7 @@ _[Langfuseの公開トレース例](https://cloud.langfuse.com/project/cloramnkj
 ## 🥇 ライセンス
 
 このリポジトリは、`ee`フォルダを除き、MITライセンスの下で公開されています。  
-詳細は[LICENSE](LICENSE)および[オープンソースに関するドキュメント](https://langfuse.com/docs/open-source)をご確認ください。
+詳細は[LICENSE](LICENSE)および[オープンソースに関するドキュメント](https://langfuse.com/handbook/chapters/open-source)をご確認ください。
 
 ## ⭐️ スターの履歴
 
@@ -292,7 +292,7 @@ _[Langfuseの公開トレース例](https://cloud.langfuse.com/project/cloramnkj
 
 ## ❤️ Langfuseを利用しているオープンソースプロジェクト
 
-Langfuseを利用している主要なオープンソースPythonプロジェクト（スター数順）: ([出典](https://github.com/langfuse/langfuse-docs/blob/main/components-mdx/dependents))
+Langfuseを利用している主要なオープンソースPythonプロジェクト（スター数順）: ([出典](https://github.com/langfuse/langfuse-docs/tree/main/components-mdx/dependents))
 
 | リポジトリ                                                                                                                                                                                                                                                          | スター |
 | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -----: |

--- a/README.kr.md
+++ b/README.kr.md
@@ -9,10 +9,10 @@
          <a href="https://cloud.langfuse.com">
             <strong>Langfuse Cloud</strong>
          </a> · 
-         <a href="https://langfuse.com/docs/deployment/self-host">
+         <a href="https://langfuse.com/self-hosting">
             <strong>셀프 호스트</strong>
          </a> · 
-         <a href="https://langfuse.com/demo">
+         <a href="https://langfuse.com/docs/demo">
             <strong>데모</strong>
          </a>
       </h3>
@@ -23,7 +23,7 @@
       <a href="https://langfuse.com/issues"><strong>버그 신고</strong></a> ·
       <a href="https://langfuse.com/ideas"><strong>기능 요청</strong></a> ·
       <a href="https://langfuse.com/changelog"><strong>변경 내역</strong></a> ·
-      <a href="https://langfuse.com/roadmap"><strong>로드맵</strong></a> ·
+      <a href="https://langfuse.com/docs/roadmap"><strong>로드맵</strong></a> ·
    </div>
    <br/>
    <span>Langfuse는 지원 및 기능 요청을 위해 <a href="https://github.com/orgs/langfuse/discussions"><strong>GitHub Discussions</strong></a>를 사용합니다.</span>
@@ -73,7 +73,7 @@ Langfuse는 **오픈 소스 LLM 엔지니어링** 플랫폼입니다.
 팀이 협업하여 AI 애플리케이션을 **개발, 모니터링, 평가** 및 **디버그**할 수 있도록 도와줍니다.  
 Langfuse는 몇 분 안에 셀프 호스팅할 수 있으며, 검증된(battle-tested) 솔루션입니다.
 
-[![Langfuse Overview Video](https://github.com/user-attachments/assets/3926b288-ff61-4b95-8aa1-45d041c70866)](https://langfuse.com/watch-demo)
+[![Langfuse Overview Video](https://github.com/user-attachments/assets/3926b288-ff61-4b95-8aa1-45d041c70866)](https://langfuse.com/docs/demo)
 
 ## ✨ 주요 기능
 
@@ -115,7 +115,7 @@ Langfuse 팀이 관리하는 배포 방식으로, 후한 무료 플랜(취미 �
 
 자체 인프라에서 Langfuse를 실행하세요:
 
-- [로컬 (docker compose)](https://langfuse.com/self-hosting/local): Docker Compose를 사용하여 본인의 컴퓨터에서 5분 안에 Langfuse를 실행할 수 있습니다.
+- [로컬 (docker compose)](https://langfuse.com/self-hosting/deployment/docker-compose): Docker Compose를 사용하여 본인의 컴퓨터에서 5분 안에 Langfuse를 실행할 수 있습니다.
 
   ```bash
   # 최신 Langfuse 저장소 클론
@@ -126,9 +126,9 @@ Langfuse 팀이 관리하는 배포 방식으로, 후한 무료 플랜(취미 �
   docker compose up
   ```
 
-- [Kubernetes (Helm)](https://langfuse.com/self-hosting/kubernetes-helm): Helm을 사용해 Kubernetes 클러스터에서 Langfuse를 실행합니다. 이는 권장되는 프로덕션 배포 방식입니다.
-- [VM](https://langfuse.com/self-hosting/docker-compose): Docker Compose를 사용해 단일 가상 머신에서 Langfuse를 실행합니다.
-- Terraform 템플릿: [AWS](https://langfuse.com/self-hosting/aws), [Azure](https://langfuse.com/self-hosting/azure), [GCP](https://langfuse.com/self-hosting/gcp)
+- [Kubernetes (Helm)](https://langfuse.com/self-hosting/deployment/kubernetes-helm): Helm을 사용해 Kubernetes 클러스터에서 Langfuse를 실행합니다. 이는 권장되는 프로덕션 배포 방식입니다.
+- [VM](https://langfuse.com/self-hosting/deployment/docker-compose): Docker Compose를 사용해 단일 가상 머신에서 Langfuse를 실행합니다.
+- Terraform 템플릿: [AWS](https://langfuse.com/self-hosting/deployment/aws), [Azure](https://langfuse.com/self-hosting/deployment/azure), [GCP](https://langfuse.com/self-hosting/deployment/gcp)
 
 자세한 내용은 [자체 호스팅 문서](https://langfuse.com/self-hosting)를 참조하세요.
 
@@ -138,40 +138,40 @@ Langfuse 팀이 관리하는 배포 방식으로, 후한 무료 플랜(취미 �
 
 ### 주요 통합:
 
-| 통합                                                                         | 지원                       | 설명                                                                                                                                                               |
-| ---------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [SDK](https://langfuse.com/docs/sdk)                                         | Python, JS/TS              | SDK를 사용하여 완전한 유연성을 갖춘 수동 계측(manual instrumentation)을 수행합니다.                                                                                |
-| [OpenAI](https://langfuse.com/integrations/model-providers/openai-py)        | Python, JS/TS              | OpenAI SDK의 드롭인 대체(drop-in replacement)를 통해 자동 계측(automated instrumentation)을 수행합니다.                                                            |
-| [Langchain](https://langfuse.com/docs/integrations/langchain)                | Python, JS/TS              | Langchain 애플리케이션에 callback 핸들러를 전달하여 자동 계측합니다.                                                                                               |
-| [LlamaIndex](https://langfuse.com/docs/integrations/llama-index/get-started) | Python                     | LlamaIndex 콜백 시스템을 통한 자동 계측을 지원합니다.                                                                                                              |
-| [Haystack](https://langfuse.com/docs/integrations/haystack)                  | Python                     | Haystack 콘텐츠 추적 시스템을 통한 자동 계측을 지원합니다.                                                                                                         |
-| [LiteLLM](https://langfuse.com/docs/integrations/litellm)                    | Python, JS/TS (proxy only) | GPT의 드롭인 대체품으로 어떤 LLM도 사용할 수 있습니다. Azure, OpenAI, Cohere, Anthropic, Ollama, VLLM, Sagemaker, HuggingFace, Replicate 등 100개 이상의 LLM 지원. |
-| [Vercel AI SDK](https://langfuse.com/docs/integrations/vercel-ai-sdk)        | JS/TS                      | React, Next.js, Vue, Svelte, Node.js와 함께 AI 기반 애플리케이션 구축을 돕는 TypeScript 툴킷입니다.                                                                |
-| [API](https://langfuse.com/docs/api)                                         |                            | 공개 API를 직접 호출합니다. OpenAPI 명세가 제공됩니다.                                                                                                             |
+| 통합                                                                        | 지원                       | 설명                                                                                                                                                               |
+| --------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [SDK](https://langfuse.com/docs/observability/sdk/overview)                 | Python, JS/TS              | SDK를 사용하여 완전한 유연성을 갖춘 수동 계측(manual instrumentation)을 수행합니다.                                                                                |
+| [OpenAI](https://langfuse.com/integrations/model-providers/openai-py)       | Python, JS/TS              | OpenAI SDK의 드롭인 대체(drop-in replacement)를 통해 자동 계측(automated instrumentation)을 수행합니다.                                                            |
+| [Langchain](https://langfuse.com/integrations/frameworks/langchain)         | Python, JS/TS              | Langchain 애플리케이션에 callback 핸들러를 전달하여 자동 계측합니다.                                                                                               |
+| [LlamaIndex](https://langfuse.com/integrations/frameworks/llamaindex)       | Python                     | LlamaIndex 콜백 시스템을 통한 자동 계측을 지원합니다.                                                                                                              |
+| [Haystack](https://langfuse.com/integrations/frameworks/haystack)           | Python                     | Haystack 콘텐츠 추적 시스템을 통한 자동 계측을 지원합니다.                                                                                                         |
+| [LiteLLM](https://langfuse.com/integrations/gateways/litellm)               | Python, JS/TS (proxy only) | GPT의 드롭인 대체품으로 어떤 LLM도 사용할 수 있습니다. Azure, OpenAI, Cohere, Anthropic, Ollama, VLLM, Sagemaker, HuggingFace, Replicate 등 100개 이상의 LLM 지원. |
+| [Vercel AI SDK](https://langfuse.com/integrations/frameworks/vercel-ai-sdk) | JS/TS                      | React, Next.js, Vue, Svelte, Node.js와 함께 AI 기반 애플리케이션 구축을 돕는 TypeScript 툴킷입니다.                                                                |
+| [API](https://langfuse.com/docs/api-and-data-platform/features/public-api)  |                            | 공개 API를 직접 호출합니다. OpenAPI 명세가 제공됩니다.                                                                                                             |
 
 ### Langfuse와 통합된 패키지:
 
-| 이름                                                                                  | 유형                | 설명                                                                                                        |
-| ------------------------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------- |
-| [Instructor](https://langfuse.com/docs/integrations/instructor)                       | 라이브러리          | 구조화된 LLM 출력을(JSON, Pydantic) 얻기 위한 라이브러리입니다.                                             |
-| [DSPy](https://langfuse.com/docs/integrations/dspy)                                   | 라이브러리          | 언어 모델 프롬프트와 가중치를 체계적으로 최적화하는 프레임워크입니다.                                       |
-| [Mirascope](https://langfuse.com/docs/integrations/mirascope)                         | 라이브러리          | LLM 애플리케이션 구축을 위한 Python 툴킷입니다.                                                             |
-| [Ollama](https://langfuse.com/docs/integrations/ollama)                               | 모델 (로컬)         | 자신의 컴퓨터에서 오픈 소스 LLM을 손쉽게 실행할 수 있습니다.                                                |
-| [Amazon Bedrock](https://langfuse.com/docs/integrations/amazon-bedrock)               | 모델                | AWS에서 기본 및 파인튜닝된 모델을 실행합니다.                                                               |
-| [Google VertexAI and Gemini](https://langfuse.com/docs/integrations/google-vertex-ai) | 모델                | Google에서 기본 및 파인튜닝된 모델을 실행합니다.                                                            |
-| [AutoGen](https://langfuse.com/docs/integrations/autogen)                             | 에이전트 프레임워크 | 분산 에이전트 구축을 위한 오픈 소스 LLM 플랫폼입니다.                                                       |
-| [Flowise](https://langfuse.com/docs/integrations/flowise)                             | 채팅/에이전트 UI    | 맞춤형 LLM 플로우를 위한 JS/TS 코드 없는(no-code) 빌더입니다.                                               |
-| [Langflow](https://langfuse.com/docs/integrations/langflow)                           | 채팅/에이전트 UI    | react-flow를 활용하여 실험 및 프로토타이핑을 손쉽게 할 수 있도록 디자인된 LangChain용 Python 기반 UI입니다. |
-| [Dify](https://langfuse.com/docs/integrations/dify)                                   | 채팅/에이전트 UI    | 코드 없는 빌더와 함께 제공되는 오픈 소스 LLM 애플리케이션 개발 플랫폼입니다.                                |
-| [OpenWebUI](https://langfuse.com/docs/integrations/openwebui)                         | 채팅/에이전트 UI    | 셀프 호스팅 및 로컬 모델 등 다양한 LLM 실행기를 지원하는 셀프 호스팅 LLM 채팅 웹 UI입니다.                  |
-| [Promptfoo](https://langfuse.com/docs/integrations/promptfoo)                         | 도구                | 오픈 소스 LLM 테스트 플랫폼입니다.                                                                          |
-| [LobeChat](https://langfuse.com/docs/integrations/lobechat)                           | 채팅/에이전트 UI    | 오픈 소스 챗봇 플랫폼입니다.                                                                                |
-| [Vapi](https://langfuse.com/docs/integrations/vapi)                                   | 플랫폼              | 오픈 소스 음성 AI 플랫폼입니다.                                                                             |
-| [Inferable](https://langfuse.com/docs/integrations/other/inferable)                   | 에이전트            | 분산 에이전트 구축을 위한 오픈 소스 LLM 플랫폼입니다.                                                       |
-| [Gradio](https://langfuse.com/docs/integrations/other/gradio)                         | 채팅/에이전트 UI    | 채팅 UI와 같은 웹 인터페이스 구축을 위한 오픈 소스 Python 라이브러리입니다.                                 |
-| [Goose](https://langfuse.com/docs/integrations/goose)                                 | 에이전트            | 분산 에이전트 구축을 위한 오픈 소스 LLM 플랫폼입니다.                                                       |
-| [smolagents](https://langfuse.com/docs/integrations/smolagents)                       | 에이전트            | 오픈 소스 AI 에이전트 프레임워크입니다.                                                                     |
-| [CrewAI](https://langfuse.com/docs/integrations/crewai)                               | 에이전트            | 에이전트 간 협업 및 도구 사용을 위한 다중 에이전트 프레임워크입니다.                                        |
+| 이름                                                                                             | 유형                | 설명                                                                                                        |
+| ------------------------------------------------------------------------------------------------ | ------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [Instructor](https://langfuse.com/integrations/frameworks/instructor)                            | 라이브러리          | 구조화된 LLM 출력을(JSON, Pydantic) 얻기 위한 라이브러리입니다.                                             |
+| [DSPy](https://langfuse.com/integrations/frameworks/dspy)                                        | 라이브러리          | 언어 모델 프롬프트와 가중치를 체계적으로 최적화하는 프레임워크입니다.                                       |
+| [Mirascope](https://langfuse.com/integrations/frameworks/mirascope)                              | 라이브러리          | LLM 애플리케이션 구축을 위한 Python 툴킷입니다.                                                             |
+| [Ollama](https://langfuse.com/integrations/model-providers/ollama)                               | 모델 (로컬)         | 자신의 컴퓨터에서 오픈 소스 LLM을 손쉽게 실행할 수 있습니다.                                                |
+| [Amazon Bedrock](https://langfuse.com/integrations/model-providers/amazon-bedrock)               | 모델                | AWS에서 기본 및 파인튜닝된 모델을 실행합니다.                                                               |
+| [Google VertexAI and Gemini](https://langfuse.com/integrations/model-providers/google-vertex-ai) | 모델                | Google에서 기본 및 파인튜닝된 모델을 실행합니다.                                                            |
+| [AutoGen](https://langfuse.com/integrations/frameworks/autogen)                                  | 에이전트 프레임워크 | 분산 에이전트 구축을 위한 오픈 소스 LLM 플랫폼입니다.                                                       |
+| [Flowise](https://langfuse.com/integrations/no-code/flowise)                                     | 채팅/에이전트 UI    | 맞춤형 LLM 플로우를 위한 JS/TS 코드 없는(no-code) 빌더입니다.                                               |
+| [Langflow](https://langfuse.com/integrations/no-code/langflow)                                   | 채팅/에이전트 UI    | react-flow를 활용하여 실험 및 프로토타이핑을 손쉽게 할 수 있도록 디자인된 LangChain용 Python 기반 UI입니다. |
+| [Dify](https://langfuse.com/integrations/no-code/dify)                                           | 채팅/에이전트 UI    | 코드 없는 빌더와 함께 제공되는 오픈 소스 LLM 애플리케이션 개발 플랫폼입니다.                                |
+| [OpenWebUI](https://langfuse.com/integrations/no-code/openwebui)                                 | 채팅/에이전트 UI    | 셀프 호스팅 및 로컬 모델 등 다양한 LLM 실행기를 지원하는 셀프 호스팅 LLM 채팅 웹 UI입니다.                  |
+| [Promptfoo](https://langfuse.com/integrations/other/promptfoo)                                   | 도구                | 오픈 소스 LLM 테스트 플랫폼입니다.                                                                          |
+| [LobeChat](https://langfuse.com/integrations/no-code/lobechat)                                   | 채팅/에이전트 UI    | 오픈 소스 챗봇 플랫폼입니다.                                                                                |
+| [Vapi](https://langfuse.com/integrations/no-code/vapi)                                           | 플랫폼              | 오픈 소스 음성 AI 플랫폼입니다.                                                                             |
+| [Inferable](https://langfuse.com/integrations/other/inferable)                                   | 에이전트            | 분산 에이전트 구축을 위한 오픈 소스 LLM 플랫폼입니다.                                                       |
+| [Gradio](https://langfuse.com/integrations/other/gradio)                                         | 채팅/에이전트 UI    | 채팅 UI와 같은 웹 인터페이스 구축을 위한 오픈 소스 Python 라이브러리입니다.                                 |
+| [Goose](https://langfuse.com/integrations/no-code/goose)                                         | 에이전트            | 분산 에이전트 구축을 위한 오픈 소스 LLM 플랫폼입니다.                                                       |
+| [smolagents](https://langfuse.com/integrations/frameworks/smolagents)                            | 에이전트            | 오픈 소스 AI 에이전트 프레임워크입니다.                                                                     |
+| [CrewAI](https://langfuse.com/integrations/frameworks/crewai)                                    | 에이전트            | 에이전트 간 협업 및 도구 사용을 위한 다중 에이전트 프레임워크입니다.                                        |
 
 ## 🚀 빠른 시작
 
@@ -185,10 +185,10 @@ Langfuse 팀이 관리하는 배포 방식으로, 후한 무료 플랜(취미 �
 
 ### 2️⃣ 첫 번째 LLM 호출 기록하기
 
-[`@observe()` 데코레이터](https://langfuse.com/docs/sdk/python/decorators)를 사용하면 Python LLM 애플리케이션의 추적이 매우 간편해집니다. 이 빠른 시작 예제에서는 Langfuse [OpenAI 통합](https://langfuse.com/integrations/model-providers/openai-py)을 사용하여 모든 모델 파라미터를 자동으로 캡처합니다.
+[`@observe()` 데코레이터](https://langfuse.com/docs/observability/sdk/instrumentation#observe-wrapper)를 사용하면 Python LLM 애플리케이션의 추적이 매우 간편해집니다. 이 빠른 시작 예제에서는 Langfuse [OpenAI 통합](https://langfuse.com/integrations/model-providers/openai-py)을 사용하여 모든 모델 파라미터를 자동으로 캡처합니다.
 
 > [!TIP]
-> OpenAI를 사용하지 않으시다면, 다른 모델 및 프레임워크의 로그 기록 방법은 [문서](https://langfuse.com/docs/get-started#log-your-first-llm-call-to-langfuse)를 참조하세요.
+> OpenAI를 사용하지 않으시다면, 다른 모델 및 프레임워크의 로그 기록 방법은 [문서](https://langfuse.com/docs/observability/get-started)를 참조하세요.
 
 ```bash
 pip install langfuse openai
@@ -260,7 +260,7 @@ _[Langfuse의 공개 예제 trace](https://cloud.langfuse.com/project/cloramnkj0
 
 ## 🥇 라이선스
 
-이 저장소는 `ee` 폴더를 제외하고 MIT 라이선스가 적용됩니다. 자세한 내용은 [LICENSE](LICENSE)와 [문서](https://langfuse.com/docs/open-source)를 확인하세요.
+이 저장소는 `ee` 폴더를 제외하고 MIT 라이선스가 적용됩니다. 자세한 내용은 [LICENSE](LICENSE)와 [문서](https://langfuse.com/handbook/chapters/open-source)를 확인하세요.
 
 ## ⭐️ 별(Star) 히스토리
 
@@ -274,7 +274,7 @@ _[Langfuse의 공개 예제 trace](https://cloud.langfuse.com/project/cloramnkj0
 
 ## ❤️ Langfuse를 사용하는 오픈 소스 프로젝트
 
-별(star) 수를 기준으로 순위가 매겨진 Langfuse를 사용하는 상위 오픈 소스 Python 프로젝트들 ([출처](https://github.com/langfuse/langfuse-docs/blob/main/components-mdx/dependents)):
+별(star) 수를 기준으로 순위가 매겨진 Langfuse를 사용하는 상위 오픈 소스 Python 프로젝트들 ([출처](https://github.com/langfuse/langfuse-docs/tree/main/components-mdx/dependents)):
 
 | 저장소                                                                                                                                                                                                                                                              |    별 |
 | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----: |

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
          <a href="https://cloud.langfuse.com">
             <strong>Langfuse Cloud</strong>
          </a> · 
-         <a href="https://langfuse.com/docs/deployment/self-host">
+         <a href="https://langfuse.com/self-hosting">
             <strong>Self Host</strong>
          </a> · 
-         <a href="https://langfuse.com/demo">
+         <a href="https://langfuse.com/docs/demo">
             <strong>Demo</strong>
          </a>
       </h3>
@@ -20,7 +20,7 @@
       <a href="https://langfuse.com/issues"><strong>Report Bug</strong></a> ·
       <a href="https://langfuse.com/ideas"><strong>Feature Request</strong></a> ·
       <a href="https://langfuse.com/changelog"><strong>Changelog</strong></a> ·
-      <a href="https://langfuse.com/roadmap"><strong>Roadmap</strong></a> ·
+      <a href="https://langfuse.com/docs/roadmap"><strong>Roadmap</strong></a> ·
    </div>
    <br/>
    <div>
@@ -70,22 +70,21 @@ Langfuse is an **open source LLM engineering** platform. It helps teams collabor
 > We hire engineers who love open source and great developer experiences.
 > **[See open roles →](https://langfuse.com/careers?utm_source=github&utm_medium=readme&utm_campaign=hiring&utm_content=langfuse)**
 
-
 ## ✨ Core Features
 
 <img width="2400" alt="features" src="https://github.com/user-attachments/assets/0fad3dee-f3ad-423c-9f0d-7ccd0f26cc2d" />
 
-- [LLM Application Observability](https://langfuse.com/docs/tracing): Instrument your app and start ingesting traces to Langfuse, thereby tracking LLM calls and other relevant logic in your app such as retrieval, embedding, or agent actions. Inspect and debug complex logs and user sessions. Try the interactive [demo](https://langfuse.com/docs/demo) to see this in action.
+- [LLM Application Observability](https://langfuse.com/docs/observability/overview): Instrument your app and start ingesting traces to Langfuse, thereby tracking LLM calls and other relevant logic in your app such as retrieval, embedding, or agent actions. Inspect and debug complex logs and user sessions. Try the interactive [demo](https://langfuse.com/docs/demo) to see this in action.
 
 - [Prompt Management](https://langfuse.com/docs/prompt-management/get-started) helps you centrally manage, version control, and collaboratively iterate on your prompts. Thanks to strong caching on server and client side, you can iterate on prompts without adding latency to your application.
 
 - [Evaluations](https://langfuse.com/docs/evaluation/overview) are key to the LLM application development workflow, and Langfuse adapts to your needs. It supports LLM-as-a-judge, Code evaluators, user feedback collection, manual labeling, and custom evaluation pipelines via APIs/SDKs.
 
-- [Datasets](https://langfuse.com/docs/evaluation/dataset-runs/datasets) enable test sets and benchmarks for evaluating your LLM application. They support continuous improvement, pre-deployment testing, structured experiments, flexible evaluation, and seamless integration with frameworks like LangChain and LlamaIndex.
+- [Datasets](https://langfuse.com/docs/evaluation/experiments/datasets) enable test sets and benchmarks for evaluating your LLM application. They support continuous improvement, pre-deployment testing, structured experiments, flexible evaluation, and seamless integration with frameworks like LangChain and LlamaIndex.
 
-- [LLM Playground](https://langfuse.com/docs/playground) is a tool for testing and iterating on your prompts and model configurations, shortening the feedback loop and accelerating development. When you see a bad result in tracing, you can directly jump to the playground to iterate on it.
+- [LLM Playground](https://langfuse.com/docs/prompt-management/features/playground) is a tool for testing and iterating on your prompts and model configurations, shortening the feedback loop and accelerating development. When you see a bad result in tracing, you can directly jump to the playground to iterate on it.
 
-- [Comprehensive API](https://langfuse.com/docs/api): Langfuse is frequently used to power bespoke LLMOps workflows while using the building blocks provided by Langfuse via the API. OpenAPI spec, Postman collection, and typed SDKs for Python, JS/TS are available.
+- [Comprehensive API](https://langfuse.com/docs/api-and-data-platform/features/public-api): Langfuse is frequently used to power bespoke LLMOps workflows while using the building blocks provided by Langfuse via the API. OpenAPI spec, Postman collection, and typed SDKs for Python, JS/TS are available.
 
 ## 📦 Deploy Langfuse
 
@@ -105,7 +104,7 @@ Managed deployment by the Langfuse team, generous free-tier, no credit card requ
 
 Run Langfuse on your own infrastructure:
 
-- [Local (docker compose)](https://langfuse.com/self-hosting/local): Run Langfuse on your own machine in 5 minutes using Docker Compose.
+- [Local (docker compose)](https://langfuse.com/self-hosting/deployment/docker-compose): Run Langfuse on your own machine in 5 minutes using Docker Compose.
 
   ```bash
   # Get a copy of the latest Langfuse repository
@@ -116,9 +115,9 @@ Run Langfuse on your own infrastructure:
   docker compose up
   ```
 
-- [VM](https://langfuse.com/self-hosting/docker-compose): Run Langfuse on a single Virtual Machine using Docker Compose.
-- [Kubernetes (Helm)](https://langfuse.com/self-hosting/kubernetes-helm): Run Langfuse on a Kubernetes cluster using Helm. This is the preferred production deployment.
-- Terraform Templates: [AWS](https://langfuse.com/self-hosting/aws), [Azure](https://langfuse.com/self-hosting/azure), [GCP](https://langfuse.com/self-hosting/gcp)
+- [VM](https://langfuse.com/self-hosting/deployment/docker-compose): Run Langfuse on a single Virtual Machine using Docker Compose.
+- [Kubernetes (Helm)](https://langfuse.com/self-hosting/deployment/kubernetes-helm): Run Langfuse on a Kubernetes cluster using Helm. This is the preferred production deployment.
+- Terraform Templates: [AWS](https://langfuse.com/self-hosting/deployment/aws), [Azure](https://langfuse.com/self-hosting/deployment/azure), [GCP](https://langfuse.com/self-hosting/deployment/gcp)
 
 See [self-hosting documentation](https://langfuse.com/self-hosting) to learn more about architecture and configuration options.
 
@@ -131,40 +130,40 @@ See [self-hosting documentation](https://langfuse.com/self-hosting) to learn mor
 
 ### Main Integrations:
 
-| Integration                                                                  | Supports                   | Description                                                                                                                                      |
-| ---------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [SDK](https://langfuse.com/docs/sdk)                                         | Python, JS/TS              | Manual instrumentation using the SDKs for full flexibility.                                                                                      |
-| [OpenAI](https://langfuse.com/integrations/model-providers/openai-py)        | Python, JS/TS              | Automated instrumentation using drop-in replacement of OpenAI SDK.                                                                               |
-| [Langchain](https://langfuse.com/docs/integrations/langchain)                | Python, JS/TS              | Automated instrumentation by passing callback handler to Langchain application.                                                                  |
-| [LlamaIndex](https://langfuse.com/docs/integrations/llama-index/get-started) | Python                     | Automated instrumentation via LlamaIndex callback system.                                                                                        |
-| [Haystack](https://langfuse.com/docs/integrations/haystack)                  | Python                     | Automated instrumentation via Haystack content tracing system.                                                                                   |
-| [LiteLLM](https://langfuse.com/docs/integrations/litellm)                    | Python, JS/TS (proxy only) | Use any LLM as a drop in replacement for GPT. Use Azure, OpenAI, Cohere, Anthropic, Ollama, VLLM, Sagemaker, HuggingFace, Replicate (100+ LLMs). |
-| [Vercel AI SDK](https://langfuse.com/docs/integrations/vercel-ai-sdk)        | JS/TS                      | TypeScript toolkit designed to help developers build AI-powered applications with React, Next.js, Vue, Svelte, Node.js.                          |
-| [Mastra](https://langfuse.com/docs/integrations/mastra)                      | JS/TS                      | Open source framework for building AI agents and multi-agent systems.                                                                            |
-| [API](https://langfuse.com/docs/api)                                         |                            | Directly call the public API. OpenAPI spec available.                                                                                            |
+| Integration                                                                 | Supports                   | Description                                                                                                                                      |
+| --------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [SDK](https://langfuse.com/docs/observability/sdk/overview)                 | Python, JS/TS              | Manual instrumentation using the SDKs for full flexibility.                                                                                      |
+| [OpenAI](https://langfuse.com/integrations/model-providers/openai-py)       | Python, JS/TS              | Automated instrumentation using drop-in replacement of OpenAI SDK.                                                                               |
+| [Langchain](https://langfuse.com/integrations/frameworks/langchain)         | Python, JS/TS              | Automated instrumentation by passing callback handler to Langchain application.                                                                  |
+| [LlamaIndex](https://langfuse.com/integrations/frameworks/llamaindex)       | Python                     | Automated instrumentation via LlamaIndex callback system.                                                                                        |
+| [Haystack](https://langfuse.com/integrations/frameworks/haystack)           | Python                     | Automated instrumentation via Haystack content tracing system.                                                                                   |
+| [LiteLLM](https://langfuse.com/integrations/gateways/litellm)               | Python, JS/TS (proxy only) | Use any LLM as a drop in replacement for GPT. Use Azure, OpenAI, Cohere, Anthropic, Ollama, VLLM, Sagemaker, HuggingFace, Replicate (100+ LLMs). |
+| [Vercel AI SDK](https://langfuse.com/integrations/frameworks/vercel-ai-sdk) | JS/TS                      | TypeScript toolkit designed to help developers build AI-powered applications with React, Next.js, Vue, Svelte, Node.js.                          |
+| [Mastra](https://langfuse.com/integrations/frameworks/mastra)               | JS/TS                      | Open source framework for building AI agents and multi-agent systems.                                                                            |
+| [API](https://langfuse.com/docs/api-and-data-platform/features/public-api)  |                            | Directly call the public API. OpenAPI spec available.                                                                                            |
 
 ### Packages integrated with Langfuse:
 
-| Name                                                                    | Type               | Description                                                                                                             |
-| ----------------------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| [Instructor](https://langfuse.com/docs/integrations/instructor)         | Library            | Library to get structured LLM outputs (JSON, Pydantic)                                                                  |
-| [DSPy](https://langfuse.com/docs/integrations/dspy)                     | Library            | Framework that systematically optimizes language model prompts and weights                                              |
-| [Mirascope](https://langfuse.com/docs/integrations/mirascope)           | Library            | Python toolkit for building LLM applications.                                                                           |
-| [Ollama](https://langfuse.com/docs/integrations/ollama)                 | Model (local)      | Easily run open source LLMs on your own machine.                                                                        |
-| [Amazon Bedrock](https://langfuse.com/docs/integrations/amazon-bedrock) | Model              | Run foundation and fine-tuned models on AWS.                                                                            |
-| [AutoGen](https://langfuse.com/docs/integrations/autogen)               | Agent Framework    | Open source LLM platform for building distributed agents.                                                               |
-| [Flowise](https://langfuse.com/docs/integrations/flowise)               | Chat/Agent&nbsp;UI | JS/TS no-code builder for customized LLM flows.                                                                         |
-| [Langflow](https://langfuse.com/docs/integrations/langflow)             | Chat/Agent&nbsp;UI | Python-based UI for LangChain, designed with react-flow to provide an effortless way to experiment and prototype flows. |
-| [Dify](https://langfuse.com/docs/integrations/dify)                     | Chat/Agent&nbsp;UI | Open source LLM app development platform with no-code builder.                                                          |
-| [OpenWebUI](https://langfuse.com/docs/integrations/openwebui)           | Chat/Agent&nbsp;UI | Self-hosted LLM Chat web ui supporting various LLM runners including self-hosted and local models.                      |
-| [Promptfoo](https://langfuse.com/docs/integrations/promptfoo)           | Tool               | Open source LLM testing platform.                                                                                       |
-| [LobeChat](https://langfuse.com/docs/integrations/lobechat)             | Chat/Agent&nbsp;UI | Open source chatbot platform.                                                                                           |
-| [Vapi](https://langfuse.com/docs/integrations/vapi)                     | Platform           | Open source voice AI platform.                                                                                          |
-| [Inferable](https://langfuse.com/docs/integrations/other/inferable)     | Agents             | Open source LLM platform for building distributed agents.                                                               |
-| [Gradio](https://langfuse.com/docs/integrations/other/gradio)           | Chat/Agent&nbsp;UI | Open source Python library to build web interfaces like Chat UI.                                                        |
-| [Goose](https://langfuse.com/docs/integrations/goose)                   | Agents             | Open source LLM platform for building distributed agents.                                                               |
-| [smolagents](https://langfuse.com/docs/integrations/smolagents)         | Agents             | Open source AI agents framework.                                                                                        |
-| [CrewAI](https://langfuse.com/docs/integrations/crewai)                 | Agents             | Multi agent framework for agent collaboration and tool use.                                                             |
+| Name                                                                               | Type               | Description                                                                                                             |
+| ---------------------------------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| [Instructor](https://langfuse.com/integrations/frameworks/instructor)              | Library            | Library to get structured LLM outputs (JSON, Pydantic)                                                                  |
+| [DSPy](https://langfuse.com/integrations/frameworks/dspy)                          | Library            | Framework that systematically optimizes language model prompts and weights                                              |
+| [Mirascope](https://langfuse.com/integrations/frameworks/mirascope)                | Library            | Python toolkit for building LLM applications.                                                                           |
+| [Ollama](https://langfuse.com/integrations/model-providers/ollama)                 | Model (local)      | Easily run open source LLMs on your own machine.                                                                        |
+| [Amazon Bedrock](https://langfuse.com/integrations/model-providers/amazon-bedrock) | Model              | Run foundation and fine-tuned models on AWS.                                                                            |
+| [AutoGen](https://langfuse.com/integrations/frameworks/autogen)                    | Agent Framework    | Open source LLM platform for building distributed agents.                                                               |
+| [Flowise](https://langfuse.com/integrations/no-code/flowise)                       | Chat/Agent&nbsp;UI | JS/TS no-code builder for customized LLM flows.                                                                         |
+| [Langflow](https://langfuse.com/integrations/no-code/langflow)                     | Chat/Agent&nbsp;UI | Python-based UI for LangChain, designed with react-flow to provide an effortless way to experiment and prototype flows. |
+| [Dify](https://langfuse.com/integrations/no-code/dify)                             | Chat/Agent&nbsp;UI | Open source LLM app development platform with no-code builder.                                                          |
+| [OpenWebUI](https://langfuse.com/integrations/no-code/openwebui)                   | Chat/Agent&nbsp;UI | Self-hosted LLM Chat web ui supporting various LLM runners including self-hosted and local models.                      |
+| [Promptfoo](https://langfuse.com/integrations/other/promptfoo)                     | Tool               | Open source LLM testing platform.                                                                                       |
+| [LobeChat](https://langfuse.com/integrations/no-code/lobechat)                     | Chat/Agent&nbsp;UI | Open source chatbot platform.                                                                                           |
+| [Vapi](https://langfuse.com/integrations/no-code/vapi)                             | Platform           | Open source voice AI platform.                                                                                          |
+| [Inferable](https://langfuse.com/integrations/other/inferable)                     | Agents             | Open source LLM platform for building distributed agents.                                                               |
+| [Gradio](https://langfuse.com/integrations/other/gradio)                           | Chat/Agent&nbsp;UI | Open source Python library to build web interfaces like Chat UI.                                                        |
+| [Goose](https://langfuse.com/integrations/no-code/goose)                           | Agents             | Open source LLM platform for building distributed agents.                                                               |
+| [smolagents](https://langfuse.com/integrations/frameworks/smolagents)              | Agents             | Open source AI agents framework.                                                                                        |
+| [CrewAI](https://langfuse.com/integrations/frameworks/crewai)                      | Agents             | Multi agent framework for agent collaboration and tool use.                                                             |
 
 ## 🚀 Quickstart
 
@@ -178,10 +177,10 @@ Instrument your app and start ingesting traces to Langfuse, thereby tracking LLM
 
 ### 2️⃣ Log your first LLM call
 
-The [`@observe()` decorator](https://langfuse.com/docs/sdk/python/decorators) makes it easy to trace any Python LLM application. In this quickstart we also use the Langfuse [OpenAI integration](https://langfuse.com/integrations/model-providers/openai-py) to automatically capture all model parameters.
+The [`@observe()` decorator](https://langfuse.com/docs/observability/sdk/instrumentation#observe-wrapper) makes it easy to trace any Python LLM application. In this quickstart we also use the Langfuse [OpenAI integration](https://langfuse.com/integrations/model-providers/openai-py) to automatically capture all model parameters.
 
 > [!TIP]
-> Not using OpenAI? Visit [our documentation](https://langfuse.com/docs/get-started#log-your-first-llm-call-to-langfuse) to learn how to log other models and frameworks.
+> Not using OpenAI? Visit [our documentation](https://langfuse.com/docs/observability/get-started) to learn how to log other models and frameworks.
 
 ```bash
 pip install langfuse openai
@@ -245,7 +244,7 @@ Your contributions are welcome!
 
 ## 🥇 License
 
-This repository is MIT licensed, except for the `ee` folders. See [LICENSE](LICENSE) and [docs](https://langfuse.com/docs/open-source) for more details.
+This repository is MIT licensed, except for the `ee` folders. See [LICENSE](LICENSE) and [docs](https://langfuse.com/handbook/chapters/open-source) for more details.
 
 ## Dependencies
 
@@ -263,7 +262,7 @@ We deploy this code base in Docker containers based on the Linux Alpine Image ([
 
 ## ❤️ Open Source Projects Using Langfuse
 
-Top open-source Python projects that use Langfuse, ranked by stars ([Source](https://github.com/langfuse/langfuse-docs/blob/main/components-mdx/dependents)):
+Top open-source Python projects that use Langfuse, ranked by stars ([Source](https://github.com/langfuse/langfuse-docs/tree/main/components-mdx/dependents)):
 
 | Repository                                                                                                                                                                                                                                                                                                     |  Stars |
 | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -----: |
@@ -279,7 +278,7 @@ Top open-source Python projects that use Langfuse, ranked by stars ([Source](htt
 | <img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/6154722?s=40&v=4" width="20" height="20" alt=""> &nbsp; [microsoft](https://github.com/microsoft) / [ai-agents-for-beginners](https://github.com/microsoft/ai-agents-for-beginners)                                                      |  38012 |
 | <img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/139558948?s=40&v=4" width="20" height="20" alt=""> &nbsp; [chatchat-space](https://github.com/chatchat-space) / [Langchain-Chatchat](https://github.com/chatchat-space/Langchain-Chatchat)                                               |  36071 |
 | <img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/31035808?s=40&v=4" width="20" height="20" alt=""> &nbsp; [mindsdb](https://github.com/mindsdb) / [mindsdb](https://github.com/mindsdb/mindsdb)                                                                                           |  35669 |
-| <img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/169401942?s=40&v=4" width="20" height="20" alt=""> &nbsp; [danny-avila](https://github.com/danny-avila) / [LibreChat](https://github.com/danny-avila/LibreChat)                                                                            |  33142 |
+| <img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/169401942?s=40&v=4" width="20" height="20" alt=""> &nbsp; [danny-avila](https://github.com/danny-avila) / [LibreChat](https://github.com/danny-avila/LibreChat)                                                                          |  33142 |
 | <img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/121462774?s=40&v=4" width="20" height="20" alt=""> &nbsp; [BerriAI](https://github.com/BerriAI) / [litellm](https://github.com/BerriAI/litellm)                                                                                          |  28726 |
 | <img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/157326433?s=40&v=4" width="20" height="20" alt=""> &nbsp; [onlook-dev](https://github.com/onlook-dev) / [onlook](https://github.com/onlook-dev/onlook)                                                                                   |  22447 |
 | <img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/487568?s=40&v=4" width="20" height="20" alt=""> &nbsp; [NixOS](https://github.com/NixOS) / [nixpkgs](https://github.com/NixOS/nixpkgs)                                                                                                   |  21748 |

--- a/careers
+++ b/careers
@@ -1,0 +1,5 @@
+# We're hiring
+
+Langfuse is the open source LLM engineering platform. We build in person in Berlin, Germany.
+
+Open roles, compensation, and how to apply: **https://langfuse.com/careers**

--- a/careers
+++ b/careers
@@ -1,5 +1,5 @@
 # We're hiring
 
-Langfuse is the open source LLM engineering platform. We build in person in Berlin, Germany.
+Langfuse is the open source AI agent evaluation and tracing platform. We build in person in Berlin, Germany.
 
 Open roles, compensation, and how to apply: **https://langfuse.com/careers**


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17322 app preview](https://pr-17322.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Two small SEO/link-hygiene fixes surfaced by the Ahrefs site audit of `github.com/langfuse`:

**1. Update redirecting `langfuse.com` links in the READMEs**
~170 links across `README.md` and the `cn`/`ja`/`kr` translations currently 301 to new docs paths (old `/docs/integrations/*`, `/docs/sdk*`, `/docs/tracing`, `/docs/playground`, `/self-hosting/<cloud>`, `/demo`, `/roadmap`, etc.). This PR replaces each with its final destination, so the highest-traffic page in the org links directly instead of through a redirect. The `/ideas` and `/issues` short links are left as-is since they intentionally point to GitHub. The dependents "Source" link now uses `/tree/` instead of `/blob/` (directory).

**2. Restore a minimal `careers` file**
`github.com/langfuse/langfuse/blob/main/careers` was removed in the Feb 2025 README rework (#5446) and now 404s. Ahrefs still shows ~15 live external backlinks to that path from Hacker News hiring-post mirrors. GitHub has no redirects, so re-adding the file (pointing to https://langfuse.com/careers) is the only way to recover that link equity.

## How to verify
Every `https://langfuse.com/...` link in the four READMEs resolves with 0 redirects except the two intentional `/ideas` and `/issues` short links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62995889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no actionable correctness, security, or documentation-rendering regressions identified.

<details open><summary><h3>Summary</h3></summary>

- Updates documentation, integration, deployment, demo, roadmap, and licensing links across the English, Chinese, Japanese, and Korean READMEs.
- Corrects the dependents source URL to use GitHub’s directory-oriented `/tree/` route.
- Restores `careers` so existing external links no longer return a repository-level 404.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs: fix redirecting README links and r..."](https://github.com/langfuse/langfuse/commit/94f6acbc401197fbd7c5bc1f562f6fcd3988727d)</sub>

<!-- /greptile_comment -->