### PR TITLE
fix(evals): distinguish retry queue delays

### DIFF
--- a/worker/src/features/evaluation/evalExecutionMetrics.test.ts
+++ b/worker/src/features/evaluation/evalExecutionMetrics.test.ts
@@ -26,7 +26,7 @@ describe("evaluation execution metrics", () => {
   });
 
   it("records the bounded metric contract", () => {
-    recordEvalTimeToFirstAttempt(EvalTemplateType.LLM_AS_JUDGE, 1_234);
+    recordEvalTimeToFirstAttempt(EvalTemplateType.LLM_AS_JUDGE, 1_234, true);
     recordEvalTerminalOutcome(EvalTemplateType.CODE, "success");
 
     expect(recordDistribution).toHaveBeenCalledWith(
@@ -34,6 +34,7 @@ describe("evaluation execution metrics", () => {
       1_234,
       {
         evaluator_type: "llm_as_judge",
+        isRetry: "true",
         unit: "milliseconds",
       },
     );

--- a/worker/src/features/evaluation/evalExecutionMetrics.ts
+++ b/worker/src/features/evaluation/evalExecutionMetrics.ts
@@ -37,12 +37,14 @@ const CODE_EVAL_CUSTOMER_ERROR_CODES: ReadonlySet<string> = new Set([
 export function recordEvalTimeToFirstAttempt(
   executionType: ObservationEvalExecutionType,
   durationMs: number,
+  isRetry: boolean,
 ): void {
   recordDistribution(
     "langfuse.evaluation.execution.time_to_first_attempt_ms",
     durationMs,
     {
       evaluator_type: getEvaluatorTypeTag(executionType),
+      isRetry: isRetry ? "true" : "false",
       unit: "milliseconds",
     },
   );

--- a/worker/src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts
+++ b/worker/src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts
@@ -155,6 +155,7 @@ describe("codeEvalExecutionQueueProcessor", () => {
       1_500,
       {
         evaluator_type: "code_as_judge",
+        isRetry: "false",
         unit: "milliseconds",
       },
     );

--- a/worker/src/queues/__tests__/llmAsJudgeExecutionQueueProcessor.test.ts
+++ b/worker/src/queues/__tests__/llmAsJudgeExecutionQueueProcessor.test.ts
@@ -225,7 +225,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
       );
     });
 
-    it("records schedule-to-first-attempt latency only for the logical first attempt", async () => {
+    it("records queue latency for initial and logical retry attempts", async () => {
       const now = vi.spyOn(Date, "now").mockReturnValue(10_000);
 
       await llmAsJudgeExecutionQueueProcessor(
@@ -236,6 +236,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
         1_500,
         {
           evaluator_type: "llm_as_judge",
+          isRetry: "false",
           unit: "milliseconds",
         },
       );
@@ -248,13 +249,23 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
           timestamp: 8_000,
         }),
       );
+      expect(recordDistribution).not.toHaveBeenCalled();
+
       await llmAsJudgeExecutionQueueProcessor(
         createMockJob({
           data: { retryBaggage: { attempt: 1 } },
           timestamp: 8_000,
         }),
       );
-      expect(recordDistribution).not.toHaveBeenCalled();
+      expect(recordDistribution).toHaveBeenCalledWith(
+        "langfuse.evaluation.execution.time_to_first_attempt_ms",
+        2_000,
+        {
+          evaluator_type: "llm_as_judge",
+          isRetry: "true",
+          unit: "milliseconds",
+        },
+      );
 
       now.mockRestore();
     });

--- a/worker/src/queues/codeEvalQueue.ts
+++ b/worker/src/queues/codeEvalQueue.ts
@@ -27,6 +27,7 @@ export const codeEvalExecutionQueueProcessorBuilder = (
       recordEvalTimeToFirstAttempt(
         EvalTemplateType.CODE,
         Math.max(0, Date.now() - job.timestamp),
+        false,
       );
     }
 

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -279,10 +279,11 @@ export const llmAsJudgeExecutionQueueProcessorBuilder =
   (queueName: string): Processor =>
   async (job: Job<TQueueJobTypes[QueueName.LLMAsJudgeExecution]>) => {
     const retryAttempt = job.data.retryBaggage?.attempt ?? 0;
-    if (job.attemptsStarted === 1 && retryAttempt === 0) {
+    if (job.attemptsStarted === 1) {
       recordEvalTimeToFirstAttempt(
         EvalTemplateType.LLM_AS_JUDGE,
         Math.max(0, Date.now() - job.timestamp),
+        retryAttempt > 0,
       );
     }
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17324 app preview](https://pr-17324.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- record queue-delay samples for newly scheduled LLM judge retries
- add an `isRetry` metric tag so dashboards and SLOs can separate retry waits from initial attempts
- keep BullMQ processing retries excluded to avoid duplicate samples

## Impacted package

- `worker`

## Verification

- `pnpm --filter worker run test evalExecutionMetrics.test.ts codeEvalExecutionQueueProcessor.test.ts llmAsJudgeExecutionQueueProcessor.test.ts`
- `pnpm exec turbo run lint --filter=worker --force`
- `pnpm --filter worker run typecheck`
- commit hooks: Prettier and workspace lint


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62999655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with the retry classification and duplicate-sample guards behaving consistently.

<details open><summary><h3>Summary</h3></summary>

- Adds the bounded `isRetry` dimension to evaluation queue-delay distributions.
- Records newly scheduled LLM retry jobs as retry samples.
- Marks code-evaluation and initial LLM attempts as non-retries.
- Updates metric and queue-processor tests for the revised contract.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  J[Evaluation job begins processing] --> A{attemptsStarted equals 1?}
  A -->|No| X[Exclude BullMQ processing retry]
  A -->|Yes| T{retryBaggage attempt greater than 0?}
  T -->|No| I[Record queue delay with isRetry false]
  T -->|Yes| R[Record queue delay with isRetry true]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(evals): distinguish retry queue dela..."](https://github.com/langfuse/langfuse/commit/202e5b6d056722f5ed36280fcb555156773381e1)</sub>

<!-- /greptile_comment -->