### PR TITLE
chore(clickhouse): label dataset_run_items and blob_storage_file_log query outcomes

### DIFF
--- a/packages/shared/src/server/clickhouse/queryOutcome.test.ts
+++ b/packages/shared/src/server/clickhouse/queryOutcome.test.ts
@@ -80,6 +80,16 @@ describe("ClickHouse query outcome metric", () => {
       ],
       ["SELECT * FROM traces WHERE id = {id:String}", "traces"],
       ["SELECT * FROM scores WHERE project_id = {p:String}", "scores"],
+      // Worker ingestion checks dataset-run membership per trace; the physical
+      // table is dataset_run_items_rmt but the label drops the engine suffix.
+      [
+        "SELECT dri.dataset_item_id FROM dataset_run_items_rmt dri WHERE project_id = {p:String}",
+        "dataset_run_items",
+      ],
+      [
+        "SELECT * FROM blob_storage_file_log FINAL WHERE project_id = {p:String}",
+        "blob_storage_file_log",
+      ],
     ])("labels %s as %s", (query, expected) => {
       expect(clickHouseQueryTableLabel(query)).toBe(expected);
     });

--- a/packages/shared/src/server/clickhouse/queryOutcome.ts
+++ b/packages/shared/src/server/clickhouse/queryOutcome.ts
@@ -95,6 +95,8 @@ export type ClickHouseQueryTable =
   | "traces"
   | "observations"
   | "scores"
+  | "dataset_run_items"
+  | "blob_storage_file_log"
   | "other";
 
 /**
@@ -113,6 +115,8 @@ const TABLE_LABEL_PATTERNS: ReadonlyArray<[ClickHouseQueryTable, RegExp]> = [
   ["observations", /\bfrom\s+(?:\w+\.)?observations\b/i],
   ["traces", /\bfrom\s+(?:\w+\.)?traces\b/i],
   ["scores", /\bfrom\s+(?:\w+\.)?scores\b/i],
+  ["dataset_run_items", /\bfrom\s+(?:\w+\.)?dataset_run_items_rmt\b/i],
+  ["blob_storage_file_log", /\bfrom\s+(?:\w+\.)?blob_storage_file_log\b/i],
 ];
 
 const OTHER_TABLE_LABEL = "other" as const;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17326 app preview](https://pr-17326.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

The `langfuse.clickhouse.query.outcome` metric derives its `table` tag by regex-matching the query's `FROM` clause against a fixed list of five tables. Everything else falls through to `other`.

Investigation of the metric (prod-eu + prod-us, last 2d) showed `table:other` is almost entirely `surface:worker` and, on worker, is the single largest bucket — larger than `traces` or `observations`. Sampling the query text, ~100% of it is two real ClickHouse tables the classifier didn't know:

- `dataset_run_items_rmt` (~92%) — per-trace dataset-run membership check on the ingestion path
- `blob_storage_file_log` (~8%) — blob-storage file lookups

This adds both to the classifier so `other` shrinks to a genuine catch-all and per-table outcome/timeout attribution covers these high-volume worker paths. The `dataset_run_items_rmt` physical table is labelled `dataset_run_items` (engine suffix dropped, consistent with the logical names used for the other tables).

## Type of change

- [x] Chore / internal instrumentation (no user- or operator-visible behavior change)

## Checklist

- [x] Added test cases pinning the two new labels (`queryOutcome.test.ts`)
- [x] `pnpm --filter @langfuse/shared run test queryOutcome` — 31 passed
- [x] `pnpm exec turbo run lint --filter=@langfuse/shared --force` — 2 successful, 0 cached

🤖 Written by Claude (an AI agent) on behalf of Niklas

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63005559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge and introduces no actionable correctness, security, or repository-rule issues.

<details open><summary><h3>Summary</h3></summary>

- Maps `dataset_run_items_rmt` queries to the logical `dataset_run_items` label.
- Classifies `blob_storage_file_log` queries under their own label.
- Adds focused tests for both mappings.
</details>

<sub>Reviews (1) · Last reviewed commit: ["chore(clickhouse): label dataset\_run\_ite..."](https://github.com/langfuse/langfuse/commit/5629a9f1a5874759913176faa04c78a628544666)</sub>

<!-- /greptile_comment -->