### PR TITLE
fix(sessions): stop preset recovery from looping on unchanged state

### DIFF
--- a/web/src/features/filters/hooks/useKeyedSessionStorageState.ts
+++ b/web/src/features/filters/hooks/useKeyedSessionStorageState.ts
@@ -62,6 +62,13 @@ export function useKeyedSessionStorageState<T>(
             ? (next as (value: T) => T)(baseValue)
             : next;
 
+        if (
+          previous.key === storageKey &&
+          Object.is(previous.value, resolved)
+        ) {
+          return previous;
+        }
+
         return {
           key: storageKey,
           value: resolved,

--- a/web/src/features/filters/viewStateHistoryWrites.clienttest.tsx
+++ b/web/src/features/filters/viewStateHistoryWrites.clienttest.tsx
@@ -1,6 +1,17 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { TableViewPresetTableName, type FilterState } from "@langfuse/shared";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import {
+  QueryParamProvider,
+  type QueryParamAdapterComponent,
+  useQueryParam,
+} from "use-query-params";
 import { useSidebarFilterState } from "./hooks/useSidebarFilterState";
 import type { FilterConfig } from "./lib/filter-config";
 import { useTableViewManager } from "../../components/table/table-view-presets/hooks/useTableViewManager";
@@ -60,12 +71,9 @@ vi.mock("use-query-params", async () => {
   const React = require("react");
   const actual = await vi.importActual("use-query-params");
 
-  const StringParam = { __type: "string" } as const;
-
   return {
     ...actual,
-    StringParam,
-    useQueryParam: (key: string) => {
+    useQueryParam: vi.fn(function useMockQueryParam(key: string) {
       const initialValue = queryParamStore.has(key)
         ? queryParamStore.get(key)
         : null;
@@ -96,7 +104,7 @@ vi.mock("use-query-params", async () => {
       );
 
       return [value, setQueryValue];
-    },
+    }),
   };
 });
 
@@ -196,6 +204,7 @@ function FilterStateHarness() {
 describe("view-state URL writes and browser history (LFE-10715)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useQueryParam).mockReset();
     sessionStorage.clear();
     queryParamStore.clear();
     urlParamWrites.length = 0;
@@ -235,6 +244,76 @@ describe("view-state URL writes and browser history (LFE-10715)", () => {
     expect(viewIdWrites.length).toBeGreaterThan(0);
     for (const write of viewIdWrites) {
       expect(write).toMatchObject({ value: null, updateType: "replaceIn" });
+    }
+  });
+
+  it("settles session preset recovery while URL updates are batched", async () => {
+    const actual = await vi.importActual<{
+      useQueryParam: typeof useQueryParam;
+    }>("use-query-params");
+    const presetId = "__langfuse_with_io__";
+    const recoverPreset = vi.fn(() => {
+      if (recoverPreset.mock.calls.length > 20) {
+        throw new Error("Session preset recovery did not settle");
+      }
+    });
+
+    const Adapter: QueryParamAdapterComponent = ({ children }) => {
+      const [location, setLocation] = useState({
+        search: `?viewId=${presetId}`,
+      });
+      return children({ location, replace: setLocation, push: setLocation });
+    };
+
+    function SessionPresetRecoveryHarness() {
+      const viewControllers = useTableViewManager({
+        tableName: TableViewPresetTableName.SessionDetail,
+        projectId: "project-1",
+        stateUpdaters: {
+          setColumnOrder: () => {},
+          setColumnVisibility: () => {},
+        },
+      });
+
+      // Session detail restores a matching frontend preset after URL stripping.
+      useEffect(() => {
+        if (viewControllers.isLoading || viewControllers.selectedViewId) return;
+        recoverPreset();
+        viewControllers.handleSetViewId(presetId, { updateType: "replaceIn" });
+      }, [viewControllers]);
+
+      return (
+        <div data-testid="recovered-view-id">
+          {viewControllers.selectedViewId ?? "null"}
+        </div>
+      );
+    }
+
+    vi.useFakeTimers();
+    try {
+      await vi
+        .mocked(useQueryParam)
+        .withImplementation(actual.useQueryParam, () => {
+          render(
+            <QueryParamProvider
+              adapter={Adapter}
+              options={{ enableBatching: true }}
+            >
+              <SessionPresetRecoveryHarness />
+            </QueryParamProvider>,
+          );
+
+          act(() => vi.runOnlyPendingTimers());
+          act(() => vi.runOnlyPendingTimers());
+
+          expect(screen.getByTestId("recovered-view-id").textContent).toBe(
+            presetId,
+          );
+          expect(recoverPreset).toHaveBeenCalled();
+        });
+    } finally {
+      act(() => vi.runOnlyPendingTimers());
+      vi.useRealTimers();
     }
   });
 


### PR DESCRIPTION
**TL;DR:** Fix the session-detail render loop introduced by #17308. Restoring a system preset can crash the legacy session view with React error #185.

**Why:** Preset recovery retries while the batched URL update is pending. Selecting a view now clears its stored update target; clearing an already-null target still created a new state object, triggering another recovery render before navigation could settle.

**What:** Preserve the previous keyed session-storage state when both its key and value are unchanged. Key changes and actual value updates still apply. Add one regression using the real batched query-param provider.

**Result:** The same production-build session permalink that crashed before renders and survives reload in Chrome and Firefox. Fixes #17325. Related: #17308.

<details>
<summary>Before/after proof and verification</summary>

Affected package: `web`. Production change: seven lines in `useKeyedSessionStorageState`.

| Check | v4.34.0 before | This fix |
| --- | --- | --- |
| Legacy session, I/O preset permalink | Application error screen; console reports `Minified React error #185` with composed-ref frames | Eight seeded traces render; permalink and reload pass in Chrome and Firefox |
| Batched preset recovery regression | `Tests 1 failed \| 8 passed (9)` — recovery does not settle | `Tests 9 passed (9)` |

Browser setup: production `pnpm --filter web run build` + `next start -p 3131`; synthetic `session-shapes --shape chat --id-prefix pc131-loop` data. The legacy layout was selected with a browser-only session-response override (`modernSession=false`); `sessionTimeline=false`. The unmodified compact layout did not reproduce the crash. No production/customer data used.

Validation:

- Four targeted client suites (history writes, preset demotion, session persistence, table controls): `Test Files 4 passed (4)`, `Tests 73 passed (73)`.
- `pnpm exec turbo run lint --force`: `Tasks: 8 successful, 8 total`; `Cached: 0 cached, 8 total`.
- `pnpm exec knip`: exit 0.
- `pnpm --filter web run build`: compiled, TypeScript checked, `Generating static pages ... (82/82)`; exit 0.
- `pnpm run scan:client-bundle`: `clean: every referenced identifier is declared or a known global`.
- Pre-commit: `All matched files use Prettier code style!`; lint `Tasks: 7 successful, 7 total`, `Cached: 0 cached, 7 total`.

Reproduce locally:

1. Run `pnpm run seed -- session-shapes --shape chat --id-prefix pc131-loop` and sign in as the demo user.
2. Disable Compact Session View in Feature Previews. Open [the synthetic session](http://localhost:3131/project/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a/sessions/pc131-loop-chat?viewId=__langfuse_with_io__&filter=hasInput%3Bboolean%3B%3B%3D%3Btrue%2ChasOutput%3Bboolean%3B%3B%3D%3Btrue).
3. Reload, select another observation preset, and use Back. Session content should remain visible and the URL should settle.

No schema, API, analytics, or rendering-layout changes. Full server test suites were skipped because the change is confined to client state.
</details>

🤖 Generated with [Codex](https://openai.com/codex)


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63009175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The behavioral fix appears sound, but the explicit import-placement requirement must be satisfied before merging.

<details open><summary><h3>Summary</h3></summary>

- Adds an `Object.is`-based no-op update bailout.
- Adds a regression test using batched query-parameter updates.
- Introduces one repository import-placement rule violation in the test.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(sessions): stop preset recovery from..."](https://github.com/langfuse/langfuse/commit/bf98a70b23ce039e5ebe183e3e9fa0bc8cda039e)</sub>

<!-- /greptile_comment -->