### PR TITLE
fix(web): tree rows keep icon, connector and chevron on the first text line

### DIFF
--- a/web/src/features/traces/components/VirtualizedTreeNodeWrapper.tsx
+++ b/web/src/features/traces/components/VirtualizedTreeNodeWrapper.tsx
@@ -108,7 +108,9 @@ export function VirtualizedTreeNodeWrapper({
           </div>
         )}
 
-        {/* 2. Current element bars: up/down/horizontal connectors */}
+        {/* 2. Current element bars: up/down/horizontal connectors. The 10px
+            offsets are the icon's centre on the row's first text line, so the
+            elbow meets the icon and the spine stays continuous. */}
         {visualDepth > 0 && (
           <div className="relative w-5 shrink-0">
             <>
@@ -116,21 +118,24 @@ export function VirtualizedTreeNodeWrapper({
               <div
                 className={cn(
                   "bg-border-contrast absolute top-0 left-3 w-px",
-                  isLastSibling ? "h-3" : "bottom-3",
+                  isLastSibling ? "h-2.5" : "bottom-2.5",
                 )}
               />
               {/* Vertical bar connecting downwards if not last sibling */}
               {!isLastSibling && (
-                <div className="bg-border-contrast absolute top-3 bottom-0 left-3 w-px" />
+                <div className="bg-border-contrast absolute top-2.5 bottom-0 left-3 w-px" />
               )}
               {/* Horizontal bar connecting to icon */}
-              <div className="bg-border-contrast absolute top-3 left-3 h-px w-2" />
+              <div className="bg-border-contrast absolute top-2.5 left-3 h-px w-2" />
             </>
           </div>
         )}
 
-        {/* 3. Icon + child connector: fixed width container */}
-        <div className="relative flex w-6 shrink-0 flex-col py-1.5">
+        {/* 3. Icon + child connector: fixed width container.
+            py-0.5 matches the content's own row padding, so the icon box sits
+            on the first text line instead of centring against a multi-line
+            block (metrics row, score badges, a name wrapped over two lines). */}
+        <div className="relative flex w-6 shrink-0 flex-col py-0.5">
           <div className="relative z-10 flex h-4 items-center justify-center">
             <ItemBadge type={nodeType} isSmall className="size-3!" />
           </div>
@@ -138,20 +143,22 @@ export function VirtualizedTreeNodeWrapper({
               when children render capped at this same indent — the spine
               would point at nothing) */}
           {hasChildren && !isCollapsed && !childrenAreCapped && (
-            <div className="bg-border-contrast absolute top-3 bottom-0 left-1/2 w-px" />
+            <div className="bg-border-contrast absolute top-2.5 bottom-0 left-1/2 w-px" />
           )}
           {/* Root node downward connector */}
           {depth === 0 && hasChildren && !isCollapsed && !childrenAreCapped && (
-            <div className="bg-border-contrast absolute top-3 bottom-0 left-1/2 w-px" />
+            <div className="bg-border-contrast absolute top-2.5 bottom-0 left-1/2 w-px" />
           )}
         </div>
 
-        {/* 4. Content area (passed as children - completely decoupled) */}
-        <div className="flex min-w-0 flex-1">{children}</div>
+        {/* 4. Content area (passed as children - completely decoupled).
+            items-start keeps the first text line at the top of the row so it
+            stays level with the icon and the chevron. */}
+        <div className="flex min-w-0 flex-1 items-start">{children}</div>
 
         {/* 5. Expand/Collapse button */}
         {hasChildren && (
-          <div className="flex items-center justify-end py-1 pr-1">
+          <div className="flex items-start justify-end py-0.5 pr-1">
             <Button
               aria-expanded={!isCollapsed}
               data-expand-button
@@ -161,7 +168,9 @@ export function VirtualizedTreeNodeWrapper({
                 ev.stopPropagation();
                 onToggleCollapse();
               }}
-              className="hover:bg-primary/10 h-6 w-6 shrink-0"
+              // -my-1 keeps the 24px hit target while its layout box shrinks to
+              // the 16px first line, so the chevron centres on the name.
+              className="hover:bg-primary/10 -my-1 h-6 w-6 shrink-0"
             >
               <span
                 className={cn(

--- a/web/src/features/traces/components/VirtualizedTreeNodeWrapper.tsx
+++ b/web/src/features/traces/components/VirtualizedTreeNodeWrapper.tsx
@@ -158,7 +158,7 @@ export function VirtualizedTreeNodeWrapper({
 
         {/* 5. Expand/Collapse button */}
         {hasChildren && (
-          <div className="flex items-start justify-end py-0.5 pr-1">
+          <div className="flex items-start justify-end pr-1">
             <Button
               aria-expanded={!isCollapsed}
               data-expand-button
@@ -168,8 +168,9 @@ export function VirtualizedTreeNodeWrapper({
                 ev.stopPropagation();
                 onToggleCollapse();
               }}
-              // 20px button on a 20px first line: hit target equals the row, so
-              // consecutive rows never overlap.
+              // 20px button, no column padding: same 20px as the icon column, so
+              // the chevron centres on the first line and rows with children
+              // are no taller than leaves.
               className="hover:bg-primary/10 h-5 w-5 shrink-0"
             >
               <span

--- a/web/src/features/traces/components/VirtualizedTreeNodeWrapper.tsx
+++ b/web/src/features/traces/components/VirtualizedTreeNodeWrapper.tsx
@@ -168,9 +168,9 @@ export function VirtualizedTreeNodeWrapper({
                 ev.stopPropagation();
                 onToggleCollapse();
               }}
-              // -my-1 keeps the 24px hit target while its layout box shrinks to
-              // the 16px first line, so the chevron centres on the name.
-              className="hover:bg-primary/10 -my-1 h-6 w-6 shrink-0"
+              // 20px button on a 20px first line: hit target equals the row, so
+              // consecutive rows never overlap.
+              className="hover:bg-primary/10 h-5 w-5 shrink-0"
             >
               <span
                 className={cn(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17332 app preview](https://pr-17332.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Tree rows: the type icon, connector elbow and expand chevron now sit on the row's first text line instead of centring against the whole block (metrics row plus score chips), and all rows share one 2px vertical padding. Replaces #17301, which was opened against the wrong ticket.

| What changed | Where |
|---|---|
| Icon column and chevron column top-align with the first text line (`items-start`, `py-0.5`) | `VirtualizedTreeNodeWrapper` |
| Connector spine and elbow re-anchored to the icon centre on that line; no gaps across 29 rows checked | `VirtualizedTreeNodeWrapper` |
| Single-line rows (metrics toggled off) go from 28 / 32px to a uniform 20px; multi-line rows keep their height | `VirtualizedTreeNodeWrapper` |
| Expand button is 20px, so chevron hit targets on consecutive 20px rows do not overlap | `VirtualizedTreeNodeWrapper` |

Checks: web lint and typecheck clean. Browser-measured on the seeded `trace-tree-s42-trace`: icon centre, elbow and chevron all within 1px of the name line centre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63012127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge after addressing the non-blocking expand-control geometry inconsistency.

<details open><summary><h3>Summary</h3></summary>

- Re-anchors connector elbows and spines at a 10px offset.
- Top-aligns icon, content, and chevron columns.
- Shrinks the expand control from 24px to 20px.
- The expand-control wrapper currently prevents the claimed 20px row height and offsets the chevron from the icon.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(web): 20px expand button so chevron ..."](https://github.com/langfuse/langfuse/commit/2f59e926786a8d6f8f478775586f0f52a1208a41)</sub>

<!-- /greptile_comment -->