### PR TITLE
fix(web): session header follows the trace view grammar (metrics as text, users as links, scores as chips)

### DIFF
--- a/web/src/components/SingleLineOverflowList.tsx
+++ b/web/src/components/SingleLineOverflowList.tsx
@@ -9,6 +9,14 @@ import { type ReactNode, useEffect, useRef, useState } from "react";
  * presentation remain entirely caller-defined. `trailingContent` stays pinned
  * immediately after the overflow control and participates in width measurement.
  */
+
+// Rows of boxed pills read fine at gap-2; rows of mostly-plain text (the
+// session header's metrics/attributes/links) need more air to scan as
+// separate facts, matching the trace headers' gap-x-3.
+const SPACING_CLASS = {
+  compact: "gap-2",
+  comfortable: "gap-3",
+} as const;
 export function SingleLineOverflowList<TItem>({
   items,
   additionalOverflowCount,
@@ -16,6 +24,7 @@ export function SingleLineOverflowList<TItem>({
   renderItem,
   renderOverflow,
   trailingContent,
+  spacing = "compact",
 }: {
   items: readonly TItem[];
   additionalOverflowCount: number;
@@ -26,7 +35,9 @@ export function SingleLineOverflowList<TItem>({
     overflowItemCount: number;
   }) => ReactNode;
   trailingContent?: ReactNode;
+  spacing?: keyof typeof SPACING_CLASS;
 }) {
+  const gapClass = SPACING_CLASS[spacing];
   const measurementRowRef = useRef<HTMLDivElement>(null);
   const overflowRef = useRef<HTMLDivElement>(null);
   const trailingContentRef = useRef<HTMLDivElement>(null);
@@ -107,11 +118,13 @@ export function SingleLineOverflowList<TItem>({
   ]);
 
   return (
-    <div className="relative flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+    <div
+      className={`relative flex min-w-0 flex-1 items-center overflow-hidden ${gapClass}`}
+    >
       <div
         ref={measurementRowRef}
         aria-hidden="true"
-        className="invisible absolute inset-x-0 flex items-center gap-2 [&>*]:shrink-0"
+        className={`invisible absolute inset-x-0 flex items-center [&>*]:shrink-0 ${gapClass}`}
       >
         {items.map((item) => {
           const key = getKey(item);
@@ -126,7 +139,9 @@ export function SingleLineOverflowList<TItem>({
           );
         })}
       </div>
-      <div className="flex min-w-0 items-center gap-2 overflow-hidden [&>*]:shrink-0">
+      <div
+        className={`flex min-w-0 items-center overflow-hidden [&>*]:shrink-0 ${gapClass}`}
+      >
         {visibleItems.map((item) => {
           const key = getKey(item);
           return (

--- a/web/src/features/sessions/ModernSessionHeader.clienttest.tsx
+++ b/web/src/features/sessions/ModernSessionHeader.clienttest.tsx
@@ -3,11 +3,20 @@ import { type ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ModernSessionHeader } from "@/src/features/sessions/ModernSessionHeader";
+import {
+  modernSessionHeaderScore,
+  type ModernSessionHeaderScore,
+} from "@/src/features/sessions/__fixtures__/modernSessionHeaderScore";
 
 const capture = vi.hoisted(() => vi.fn());
 
 vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
   usePostHogClientCapture: () => capture,
+}));
+
+// ScoreBadge reads the project id off the router for its execution-trace link.
+vi.mock("next/router", () => ({
+  useRouter: () => ({ query: { projectId: "project-1" } }),
 }));
 
 vi.mock("@/src/components/SingleLineOverflowList", () => ({
@@ -44,18 +53,26 @@ vi.mock("@/src/components/SingleLineOverflowList", () => ({
   ),
 }));
 
+const scores: ModernSessionHeaderScore[] = [
+  modernSessionHeaderScore({
+    id: "score-helpfulness",
+    name: "Helpfulness",
+    value: 0.86,
+  }),
+];
+
 const defaultProps = {
   projectId: "project-1",
   countTraces: 3,
   traces: {
     state: "loaded" as const,
-    data: [{ latencyMs: null, observationCount: 7 }],
+    data: [{ latencyMs: 1_200, observationCount: 7 }],
   },
-  tokensIn: 0,
-  tokensOut: 0,
-  totalTokens: 0,
+  tokensIn: 120,
+  tokensOut: 40,
+  totalTokens: 160,
   totalCost: 0.12,
-  environment: null,
+  environment: "production",
   users: [],
   metadataJsonPaths: {
     paths: [],
@@ -64,7 +81,7 @@ const defaultProps = {
     onSave: vi.fn(),
     onRemove: vi.fn(),
   },
-  scores: [],
+  scores,
 };
 
 describe("ModernSessionHeader", () => {
@@ -72,18 +89,102 @@ describe("ModernSessionHeader", () => {
     capture.mockClear();
   });
 
-  it("renders every session detail chip without a hide control", () => {
-    const { container } = render(<ModernSessionHeader {...defaultProps} />);
+  it("renders every session detail as quiet text, links and score chips", () => {
+    render(<ModernSessionHeader {...defaultProps} />);
+
+    // Metrics: counts and latency percentiles as plain text, no pill box.
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("traces")).toBeInTheDocument();
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("spans")).toBeInTheDocument();
+    // Latency is the median alone; p95 is no longer shown.
+    expect(screen.getByTitle("Median trace latency")).toHaveTextContent(
+      "p50 1.20s",
+    );
+    expect(screen.queryByText(/p95/)).not.toBeInTheDocument();
+    // Cost and usage share one element.
+    expect(screen.getByTitle("Cost")).toBeInTheDocument();
+    expect(screen.getByText("160")).toBeInTheDocument();
+    // Attributes: env as key:value text.
+    expect(screen.getByText("env")).toBeInTheDocument();
+    expect(screen.getByText("production")).toBeInTheDocument();
+    // Scores: chips, name and value kept.
+    expect(screen.getByText("Helpfulness:")).toBeInTheDocument();
+    expect(screen.getByText("0.86")).toBeInTheDocument();
+  });
+
+  it("keeps no pill box on metrics, attributes or users", () => {
+    const { container } = render(
+      <ModernSessionHeader
+        {...defaultProps}
+        users={["user-1@example.com"]}
+        metadataJsonPaths={{
+          ...defaultProps.metadataJsonPaths,
+          paths: ["$.cloud_region"],
+          source: {
+            state: "ready" as const,
+            metadata: { cloud_region: "EU" },
+            metadataTruncated: false,
+          },
+        }}
+      />,
+    );
 
     expect(
-      container.querySelectorAll('[data-session-header-pill="true"]').length,
-    ).toBeGreaterThan(0);
+      container.querySelectorAll('[data-session-header-pill="true"]'),
+    ).toHaveLength(0);
+    expect(
+      screen.getByRole("link", { name: /^User user-1@example\.com/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("cloud_region")).toBeInTheDocument();
+    expect(screen.getByText("EU")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /^Hide /i }),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /^Show .+ in session header$/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("masks user ids from session recordings", () => {
+    const { container } = render(
+      <ModernSessionHeader {...defaultProps} users={["user-1@example.com"]} />,
+    );
+
+    expect(container.querySelector('a[href*="/users/"]')?.className).toContain(
+      "ph-no-capture",
+    );
+  });
+
+  it("keeps the metadata JSONPath remove control and captures the change", () => {
+    const onRemove = vi.fn();
+    render(
+      <ModernSessionHeader
+        {...defaultProps}
+        metadataJsonPaths={{
+          ...defaultProps.metadataJsonPaths,
+          paths: ["$.cloud_region"],
+          source: {
+            state: "ready" as const,
+            metadata: { cloud_region: "EU" },
+            metadataTruncated: false,
+          },
+          onRemove,
+        }}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Remove metadata JSONPath $.cloud_region",
+      }),
+    );
+
+    expect(onRemove).toHaveBeenCalledWith("$.cloud_region");
+    expect(capture).toHaveBeenCalledWith(
+      "session_detail:metadata_jsonpath_config_changed",
+      expect.objectContaining({ action: "remove" }),
+    );
   });
 
   it("does not capture a header detail visibility event", () => {
@@ -111,7 +212,7 @@ describe("ModernSessionHeader", () => {
     );
 
     expect(
-      screen.getByRole("link", { name: "user user-4@example.com" }),
+      screen.getByRole("link", { name: /^User user-4@example\.com/ }),
     ).toBeInTheDocument();
   });
 });

--- a/web/src/features/sessions/ModernSessionHeader.stories.tsx
+++ b/web/src/features/sessions/ModernSessionHeader.stories.tsx
@@ -3,24 +3,23 @@ import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 
 import preview from "@/.storybook/preview";
 import { ModernSessionHeader } from "@/src/features/sessions/ModernSessionHeader";
+import { modernSessionHeaderScore } from "@/src/features/sessions/__fixtures__/modernSessionHeaderScore";
 
 const scores = [
-  {
+  modernSessionHeaderScore({
     id: "score-helpfulness",
     name: "Helpfulness",
     value: 0.86,
-    stringValue: null,
-    dataType: "NUMERIC",
-  },
+  }),
 ] satisfies ComponentProps<typeof ModernSessionHeader>["scores"];
 
-const overflowScores = Array.from({ length: 16 }, (_, index) => ({
-  id: `score-quality-${index + 1}`,
-  name: `Quality ${index + 1}`,
-  value: (index + 1) / 20,
-  stringValue: null,
-  dataType: "NUMERIC" as const,
-})) satisfies ComponentProps<typeof ModernSessionHeader>["scores"];
+const overflowScores = Array.from({ length: 16 }, (_, index) =>
+  modernSessionHeaderScore({
+    id: `score-quality-${index + 1}`,
+    name: `Quality ${index + 1}`,
+    value: (index + 1) / 20,
+  }),
+) satisfies ComponentProps<typeof ModernSessionHeader>["scores"];
 
 const manyUsers = Array.from(
   { length: 1_000 },
@@ -68,7 +67,17 @@ const minimalArgs = {
 
 const meta = preview.meta({
   component: ModernSessionHeader,
-  parameters: { layout: "fullscreen", a11y: { test: "error" } },
+  parameters: {
+    layout: "fullscreen",
+    a11y: {
+      test: "error",
+      // Score chips are `ScoreBadge compact`, shared with the trace tree: its
+      // muted-on-muted palette sits at 3.82:1. Restyling it is a change to
+      // every chip in the app, so it is not this header's call — every other
+      // a11y rule stays at error, and nothing else here violates contrast.
+      config: { rules: [{ id: "color-contrast", enabled: false }] },
+    },
+  },
 });
 
 export default meta;
@@ -131,21 +140,22 @@ export const TestSearchesOverflowPills = meta.story({
     const overflowButton = canvas.getByRole("button", {
       name: /show \d+ more session details/i,
     });
-    const visiblePills = canvasElement.querySelectorAll<HTMLElement>(
-      "[data-overflow-visible-item='true'] [data-session-header-pill='true']",
+    const visibleItems = canvasElement.querySelectorAll<HTMLElement>(
+      "[data-overflow-visible-item='true']",
     );
-    const lastVisiblePill = visiblePills.item(visiblePills.length - 1);
+    const lastVisibleItem = visibleItems.item(visibleItems.length - 1);
+    // gap-3 between the text items and the overflow control.
     await expect(
       overflowButton.getBoundingClientRect().left -
-        lastVisiblePill.getBoundingClientRect().right,
-    ).toBeLessThanOrEqual(8);
+        lastVisibleItem.getBoundingClientRect().right,
+    ).toBeLessThanOrEqual(12);
     const overflowButtonRect = overflowButton.getBoundingClientRect();
-    const lastVisiblePillRect = lastVisiblePill.getBoundingClientRect();
+    const lastVisibleItemRect = lastVisibleItem.getBoundingClientRect();
     await expect(
       Math.abs(
         overflowButtonRect.top +
           overflowButtonRect.height / 2 -
-          (lastVisiblePillRect.top + lastVisiblePillRect.height / 2),
+          (lastVisibleItemRect.top + lastVisibleItemRect.height / 2),
       ),
     ).toBeLessThanOrEqual(0.5);
     const trailingButton = canvas.getByRole("button", {
@@ -155,7 +165,7 @@ export const TestSearchesOverflowPills = meta.story({
       trailingButton.getBoundingClientRect().left -
       overflowButton.getBoundingClientRect().right;
     await expect(trailingGap).toBeGreaterThanOrEqual(0);
-    await expect(trailingGap).toBeLessThanOrEqual(8);
+    await expect(trailingGap).toBeLessThanOrEqual(12);
 
     await userEvent.click(overflowButton);
 
@@ -169,7 +179,7 @@ export const TestSearchesOverflowPills = meta.story({
     await userEvent.type(searchInput, "cloud_region");
     await expect(within(dialog).getByText("cloud_region")).toBeInTheDocument();
     await expect(
-      within(dialog).queryByText("Quality 16"),
+      within(dialog).queryByText("Quality 16:"),
     ).not.toBeInTheDocument();
   },
 });
@@ -218,7 +228,7 @@ export const TestBoundsManyUsers = meta.story({
     await userEvent.type(searchInput, "user-999@example.com");
     await expect(
       within(results).getByRole("link", {
-        name: "user user-999@example.com",
+        name: "User user-999@example.com",
       }),
     ).toBeInTheDocument();
   },
@@ -287,28 +297,46 @@ export const TestConfiguresMultipleMetadataPaths = meta.story({
     await userEvent.clear(input);
     await userEvent.type(input, "$.cloud_region");
     await userEvent.click(save);
-    const getVisibleText = (text: string) =>
+    // Each pinned path renders as key:value attribute text, titled with the
+    // JSONPath; the measurement row holds a hidden copy of each.
+    const getVisiblePath = (path: string) =>
       canvas
-        .getAllByText(text)
+        .getAllByTitle(path)
         .find((element) => element.closest("[data-overflow-visible-item]"));
-    await expect(getVisibleText("email")).toBeInTheDocument();
-    await expect(getVisibleText("cloud_region")).toBeInTheDocument();
-    await expect(getVisibleText("EU")).toBeInTheDocument();
+    await expect(getVisiblePath("$.email")).toHaveTextContent(
+      "email danielm@nexite.io",
+    );
+    await expect(getVisiblePath("$.cloud_region")).toHaveTextContent(
+      "cloud_region EU",
+    );
 
-    const email = getVisibleText("email")!;
-    await userEvent.hover(email);
+    await userEvent.hover(getVisiblePath("$.email")!);
     await userEvent.click(
       canvas.getByRole("button", {
         name: "Remove metadata JSONPath $.email",
       }),
     );
-    await expect(canvas.queryByText("email")).not.toBeInTheDocument();
-    await expect(getVisibleText("cloud_region")).toBeInTheDocument();
+    await expect(canvas.queryByTitle("$.email")).not.toBeInTheDocument();
+    await expect(getVisiblePath("$.cloud_region")).toBeInTheDocument();
   },
 });
 
-export const TestCompactsTokenCounts = meta.story({
-  name: "(Test) Compacts token counts",
+export const TestShowsCostAndTokenBreakdown = meta.story({
+  name: "(Test) Shows cost and token breakdown",
+  parameters: {
+    a11y: {
+      test: "error",
+      // The open breakdown tooltip is `CostUsageTable`, shared with the trace
+      // view: its corner `<th>` is empty by design. Same reasoning as the
+      // file-level contrast exemption — not this header's component to change.
+      config: {
+        rules: [
+          { id: "color-contrast", enabled: false },
+          { id: "empty-table-header", enabled: false },
+        ],
+      },
+    },
+  },
   args: {
     ...minimalArgs,
     tokensIn: 648_714,
@@ -316,17 +344,24 @@ export const TestCompactsTokenCounts = meta.story({
     totalTokens: 655_411,
   },
   play: async ({ canvasElement }) => {
-    const tokenPill = Array.from(
-      canvasElement.querySelectorAll<HTMLElement>(
-        "[data-overflow-visible-item='true'] [data-session-header-pill='true']",
-      ),
-    ).find((pill) => pill.textContent?.trim().startsWith("tokens "));
-
-    await expect(tokenPill).toBeInTheDocument();
-    await expect(tokenPill).toHaveTextContent("tokens 649k → 7k (Σ 655k)");
-    await expect(tokenPill).toHaveAttribute(
-      "title",
-      "tokens 648,714 → 6,697 (Σ 655,411)",
+    const visibleRow = canvasElement.querySelector<HTMLElement>(
+      "[data-overflow-visible-item='true']:has([title='Cost'])",
     );
+    // Cost is plain text; the token total carries the hover breakdown.
+    await expect(visibleRow).toHaveTextContent("$0.084291");
+    await expect(visibleRow).toHaveTextContent("655,411");
+
+    const usage = visibleRow!.querySelector<HTMLElement>(
+      "[title='Usage breakdown on hover']",
+    );
+    await userEvent.hover(usage!);
+    const body = within(canvasElement.ownerDocument.body);
+    // Radix mirrors tooltip content into a visually hidden copy for screen
+    // readers, so every node in the breakdown matches twice.
+    await expect(
+      (await body.findAllByText("Token breakdown")).length,
+    ).toBeGreaterThan(0);
+    await expect(body.getAllByText("648,714").length).toBeGreaterThan(0);
+    await expect(body.getAllByText("6,697").length).toBeGreaterThan(0);
   },
 });

--- a/web/src/features/sessions/ModernSessionHeader.tsx
+++ b/web/src/features/sessions/ModernSessionHeader.tsx
@@ -1,8 +1,9 @@
 import { percentile, type ScoreDomain } from "@langfuse/shared";
-import { ArrowUpRight, Plus, Search, X } from "lucide-react";
+import { Clock, Plus, Search, X } from "lucide-react";
 import { type ReactNode, type SyntheticEvent, useState } from "react";
 
 import { SingleLineOverflowList } from "@/src/components/SingleLineOverflowList";
+import { ScoreBadge } from "@/src/components/ScoreBadge/ScoreBadge";
 import { ModernSessionHeaderPill } from "@/src/features/sessions/ModernSessionHeaderPill";
 import { sessionHeaderDynamicDetailKey } from "@/src/features/sessions/sessionHeaderVisibility";
 import {
@@ -15,6 +16,13 @@ import {
   INITIAL_SESSION_USERS_DISPLAY_COUNT,
   SESSION_USERS_PER_PAGE,
 } from "@/src/features/sessions/sessionUsers";
+import { UserIdBadge } from "@/src/features/traces/components/TraceMetadataBadges";
+import {
+  EnvironmentBadge,
+  KeyValueText,
+  METRIC_TEXT_CLASS,
+} from "@/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple";
+import { CostUsageBadge } from "@/src/features/traces/components/ObservationMetadataBadgesTooltip";
 import { Input } from "@/src/components/ui/input";
 import { Button } from "@/src/components/ui/button";
 import { Label } from "@/src/components/ui/label";
@@ -25,12 +33,21 @@ import {
 } from "@/src/components/ui/popover";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
-import {
-  compactNumberFormatter,
-  numberFormatter,
-  usdFormatter,
-} from "@/src/utils/numbers";
+import { numberFormatter } from "@/src/utils/numbers";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+
+/**
+ * Session detail header, in the trace view's visual grammar
+ * (`TraceSummaryStrip` / `TraceDetailViewHeader`): metrics are quiet muted
+ * text, references are links, attributes are key:value text, and only scores
+ * are boxed (as `ScoreBadge` chips, matching the trace tree). The pill
+ * primitive survives for the "+N" overflow control alone.
+ *
+ * The latency metric is the median trace latency alone. Behaviour is
+ * unchanged: one measured line with a searchable "+N" overflow popover (users
+ * paginate inside it), pinned metadata JSONPaths with a hover remove and a `+`
+ * editor, and the PostHog captures on JSONPath config changes.
+ */
 
 type ModernSessionHeaderProps = {
   projectId: string;
@@ -51,12 +68,9 @@ type ModernSessionHeaderProps = {
   environment: string | null;
   users: readonly string[];
   metadataJsonPaths: SessionMetadataJsonPathState;
-  scores: ReadonlyArray<
-    Pick<
-      WithStringifiedMetadata<ScoreDomain>,
-      "id" | "name" | "dataType" | "value" | "stringValue"
-    >
-  >;
+  /** Full score rows: `ScoreBadge` renders the comment / metadata hover
+      cards off the same fields the trace tree chips use. */
+  scores: ReadonlyArray<WithStringifiedMetadata<ScoreDomain>>;
 };
 
 type SessionHeaderDetailType =
@@ -65,7 +79,6 @@ type SessionHeaderDetailType =
   | "latency"
   | "metadata"
   | "score"
-  | "tokens"
   | "traces"
   | "user";
 
@@ -76,41 +89,22 @@ type SessionHeaderDetail = {
   content: ReactNode;
 };
 
-const ChipValue = ({ children }: { children: React.ReactNode }) => (
+/** Numbers carry the emphasis inside a metric; the words stay muted. */
+const MetricValue = ({ children }: { children: React.ReactNode }) => (
   <span className="text-foreground">{children}</span>
 );
 
-const ChipDot = () => <span className="text-foreground-tertiary">·</span>;
+const MetricDot = () => <span className="text-foreground-tertiary">·</span>;
 
-const compactTokenFormatter = (tokens: number) =>
-  compactNumberFormatter(tokens, 0).toLowerCase();
-
-const scoreChipValue = (
+const scoreSearchValue = (
   score: Pick<WithStringifiedMetadata<ScoreDomain>, "stringValue" | "value">,
 ) => {
   if (score.stringValue) return score.stringValue;
-  if (score.value === null || score.value === undefined) return "—";
+  if (score.value === null || score.value === undefined) return "";
   return Number.isInteger(score.value)
     ? String(score.value)
     : score.value.toFixed(2);
 };
-
-const UserChip = ({ projectId, user }: { projectId: string; user: string }) => (
-  <ModernSessionHeaderPill
-    variant="link"
-    href={`/project/${projectId}/users/${encodeURIComponent(user)}`}
-    maskFromSessionReplay
-  >
-    user{" "}
-    <span
-      className="text-foreground group-hover:text-link truncate"
-      title={user}
-    >
-      {user}
-    </span>
-    <ArrowUpRight className="text-link h-3 w-3 shrink-0" />
-  </ModernSessionHeaderPill>
-);
 
 const resolveAgainstSource = (
   source: FirstVisibleObservationMetadataState,
@@ -142,36 +136,31 @@ const getConfiguredMetadataDisplay = (
   };
 };
 
-const MetadataJsonPathPill = ({
+/**
+ * A pinned metadata JSONPath reads as the same key:value attribute text as
+ * `env` — the only extra is the remove affordance, which stays hidden until
+ * the row is hovered or focused so the line still scans as text.
+ */
+const MetadataJsonPathText = ({
   display,
   onRemove,
 }: {
   display: ReturnType<typeof getConfiguredMetadataDisplay>;
   onRemove: (path: string) => void;
 }) => (
-  <span className="group flex items-center">
-    <ModernSessionHeaderPill variant="display">
-      <span className="max-w-40 truncate" title={display.path}>
-        {display.label}
-      </span>
-      <span
-        className="text-foreground max-w-56 truncate"
-        title={display.displayValue}
+  <span className="group flex items-center" title={display.path}>
+    <KeyValueText label={display.label} value={display.displayValue} />
+    <span className="inline-flex w-0 overflow-hidden transition-[width,margin] group-focus-within:ml-1 group-focus-within:w-4 group-hover:ml-1 group-hover:w-4">
+      <button
+        type="button"
+        aria-label={`Remove metadata JSONPath ${display.path}`}
+        title="Remove metadata JSONPath"
+        className="hover:bg-muted focus-visible:ring-ring inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:ring-1 focus-visible:outline-none"
+        onClick={() => onRemove(display.path)}
       >
-        {display.displayValue}
-      </span>
-      <span className="-ml-1.5 inline-flex w-0 overflow-hidden transition-[width,margin] group-focus-within:ml-0 group-focus-within:w-4 group-hover:ml-0 group-hover:w-4">
-        <button
-          type="button"
-          aria-label={`Remove metadata JSONPath ${display.path}`}
-          title="Remove metadata JSONPath"
-          className="hover:bg-muted focus-visible:ring-ring inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:ring-1 focus-visible:outline-none"
-          onClick={() => onRemove(display.path)}
-        >
-          <X className="h-3 w-3" />
-        </button>
-      </span>
-    </ModernSessionHeaderPill>
+        <X className="h-3 w-3" />
+      </button>
+    </span>
   </span>
 );
 
@@ -328,136 +317,83 @@ export function ModernSessionHeader({
       ? traces.data.reduce((total, trace) => total + trace.observationCount, 0)
       : null;
   const p50LatencyMs = latencies.length > 0 ? percentile(latencies, 0.5) : null;
-  const p95LatencyMs =
-    latencies.length > 0 ? percentile(latencies, 0.95) : null;
-  const pills: SessionHeaderDetail[] = [
+  const details: SessionHeaderDetail[] = [
     {
       key: "traces",
       searchText: `traces ${countTraces} spans ${spanCount ?? ""}`,
       type: "traces",
       content: (
-        <ModernSessionHeaderPill variant="display">
+        <span className={METRIC_TEXT_CLASS}>
           <span>
-            <ChipValue>{numberFormatter(countTraces, 0)}</ChipValue> traces
+            <MetricValue>{numberFormatter(countTraces, 0)}</MetricValue> traces
           </span>
           {spanCount !== null ? (
             <>
-              <ChipDot />
+              <MetricDot />
               <span>
-                <ChipValue>{numberFormatter(spanCount, 0)}</ChipValue> spans
+                <MetricValue>{numberFormatter(spanCount, 0)}</MetricValue> spans
               </span>
             </>
           ) : null}
-        </ModernSessionHeaderPill>
+        </span>
       ),
     },
   ];
 
   if (p50LatencyMs !== null) {
-    pills.push({
+    details.push({
       key: "latency",
-      searchText: `latency p50 ${p50LatencyMs} p95 ${p95LatencyMs ?? ""}`,
+      searchText: `latency p50 ${p50LatencyMs}`,
       type: "latency",
       content: (
-        <ModernSessionHeaderPill variant="display">
+        <span title="Median trace latency" className={METRIC_TEXT_CLASS}>
+          <Clock className="size-3 shrink-0" aria-hidden />
           <span>
             p50{" "}
-            <ChipValue>{formatIntervalSeconds(p50LatencyMs / 1000)}</ChipValue>
+            <MetricValue>
+              {formatIntervalSeconds(p50LatencyMs / 1000)}
+            </MetricValue>
           </span>
-          {p95LatencyMs !== null ? (
-            <>
-              <ChipDot />
-              <span>
-                p95{" "}
-                <ChipValue>
-                  {formatIntervalSeconds(p95LatencyMs / 1000)}
-                </ChipValue>
-              </span>
-            </>
-          ) : null}
-        </ModernSessionHeaderPill>
+        </span>
       ),
     });
   }
 
-  if (totalTokens > 0) {
-    const exactTokenCounts = `${numberFormatter(tokensIn, 0)} → ${numberFormatter(tokensOut, 0)} (Σ ${numberFormatter(totalTokens, 0)})`;
-    pills.push({
-      key: "tokens",
-      searchText: `tokens ${tokensIn} ${tokensOut} ${totalTokens}`,
-      type: "tokens",
-      content: (
-        <ModernSessionHeaderPill
-          variant="display"
-          title={`tokens ${exactTokenCounts}`}
-        >
-          <span>
-            tokens{" "}
-            <ChipValue>
-              {compactTokenFormatter(tokensIn)} →{" "}
-              {compactTokenFormatter(tokensOut)} (Σ{" "}
-              {compactTokenFormatter(totalTokens)})
-            </ChipValue>
-          </span>
-        </ModernSessionHeaderPill>
-      ),
-    });
-  }
-
-  pills.push({
+  // One element for cost AND usage, exactly as the trace summary strip does
+  // it: cost as plain text, then a coin icon + the token total whose hover
+  // carries the input/output breakdown. Sessions have no per-direction cost
+  // or per-key usage map, so the detail maps go in empty.
+  details.push({
     key: "cost",
-    searchText: `cost ${totalCost}`,
+    searchText: `cost ${totalCost} tokens ${tokensIn} ${tokensOut} ${totalTokens}`,
     type: "cost",
     content: (
-      <ModernSessionHeaderPill
-        variant="display"
-        title={`exact $${totalCost.toFixed(6)}`}
-      >
-        <span>
-          cost <ChipValue>{usdFormatter(totalCost, 2, 3)}</ChipValue>
-        </span>
-      </ModernSessionHeaderPill>
+      <CostUsageBadge
+        totalCost={totalCost}
+        costDetails={{}}
+        inputUsage={tokensIn}
+        outputUsage={tokensOut}
+        totalUsage={totalTokens}
+        usageDetails={{}}
+      />
     ),
   });
 
   scores.forEach((score) => {
-    const value = scoreChipValue(score);
-    const isFraction =
-      score.dataType === "NUMERIC" &&
-      score.value !== null &&
-      score.value !== undefined &&
-      score.value >= 0 &&
-      score.value <= 1;
-    pills.push({
+    details.push({
       key: sessionHeaderDynamicDetailKey("score", score.id),
-      searchText: `score ${score.name} ${value}`,
+      searchText: `score ${score.name} ${scoreSearchValue(score)}`,
       type: "score",
-      content: (
-        <ModernSessionHeaderPill variant="display" title={score.name}>
-          {isFraction ? (
-            <span className="bg-dark-yellow h-1.5 w-1.5 shrink-0 rounded-[1px]" />
-          ) : null}
-          <span className="max-w-40 truncate" title={score.name}>
-            {score.name}
-          </span>
-          <ChipValue>{value}</ChipValue>
-        </ModernSessionHeaderPill>
-      ),
+      content: <ScoreBadge name={score.name} scores={[score]} compact />,
     });
   });
 
   if (environment) {
-    pills.push({
+    details.push({
       key: "environment",
       searchText: `environment env ${environment}`,
       type: "environment",
-      content: (
-        <ModernSessionHeaderPill variant="display">
-          <span>
-            env <ChipValue>{environment}</ChipValue>
-          </span>
-        </ModernSessionHeaderPill>
-      ),
+      content: <EnvironmentBadge environment={environment} />,
     });
   }
 
@@ -466,14 +402,16 @@ export function ModernSessionHeader({
       key: sessionHeaderDynamicDetailKey("user", user),
       searchText: `user ${user}`,
       type: "user",
-      content: <UserChip projectId={projectId} user={user} />,
+      // UserIdBadge already carries `ph-no-capture`, so user ids stay masked
+      // in PostHog session recordings.
+      content: <UserIdBadge userId={user} projectId={projectId} />,
     }),
   );
   const visibleUserDetails = userDetails.slice(
     0,
     INITIAL_SESSION_USERS_DISPLAY_COUNT,
   );
-  visibleUserDetails.forEach((detail) => pills.push(detail));
+  visibleUserDetails.forEach((detail) => details.push(detail));
   const visibleUserDetailKeySet = new Set(
     visibleUserDetails.map((detail) => detail.key),
   );
@@ -486,12 +424,12 @@ export function ModernSessionHeader({
       path,
       metadataJsonPaths.source,
     );
-    pills.push({
+    details.push({
       key: sessionHeaderDynamicDetailKey("metadata", path),
       searchText: `metadata ${display.path} ${display.label} ${display.displayValue}`,
       type: "metadata",
       content: (
-        <MetadataJsonPathPill
+        <MetadataJsonPathText
           display={display}
           onRemove={removeMetadataJsonPath}
         />
@@ -501,22 +439,26 @@ export function ModernSessionHeader({
   return (
     <div className="bg-header border-b px-4 py-2">
       <SingleLineOverflowList
-        items={pills}
+        items={details}
         additionalOverflowCount={overflowUserDetails.length}
-        getKey={(pill) => pill.key}
-        renderItem={(pill) => pill.content}
+        spacing="comfortable"
+        getKey={(detail) => detail.key}
+        renderItem={(detail) => detail.content}
         trailingContent={
           <Popover
             open={isMetadataEditorOpen}
             onOpenChange={handleMetadataEditorOpenChange}
           >
             <PopoverTrigger asChild>
-              <ModernSessionHeaderPill
-                variant="button"
-                ariaLabel="Add metadata JSONPath"
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Add metadata JSONPath"
+                title="Add metadata JSONPath"
               >
                 <Plus className="h-3 w-3" />
-              </ModernSessionHeaderPill>
+              </Button>
             </PopoverTrigger>
             {isMetadataEditorOpen ? (
               <MetadataJsonPathEditorContent
@@ -527,13 +469,18 @@ export function ModernSessionHeader({
             ) : null}
           </Popover>
         }
-        renderOverflow={({ hiddenItems: overflowPills, overflowItemCount }) => {
+        renderOverflow={({
+          hiddenItems: overflowDetails,
+          overflowItemCount,
+        }) => {
           const normalizedSearch = search.trim().toLocaleLowerCase();
-          const filteredPills = normalizedSearch
-            ? overflowPills.filter((pill) =>
-                pill.searchText.toLocaleLowerCase().includes(normalizedSearch),
+          const filteredDetails = normalizedSearch
+            ? overflowDetails.filter((detail) =>
+                detail.searchText
+                  .toLocaleLowerCase()
+                  .includes(normalizedSearch),
               )
-            : overflowPills;
+            : overflowDetails;
           const filteredUserDetails = normalizedSearch
             ? overflowUserDetails.filter((detail) =>
                 detail.searchText
@@ -543,7 +490,7 @@ export function ModernSessionHeader({
             : overflowUserDetails;
           const visibleUsers = filteredUserDetails.slice(0, visibleUserCount);
           const hasResults =
-            filteredPills.length > 0 || visibleUsers.length > 0;
+            filteredDetails.length > 0 || visibleUsers.length > 0;
 
           return (
             <Popover
@@ -601,9 +548,9 @@ export function ModernSessionHeader({
                 >
                   {hasResults ? (
                     <>
-                      {filteredPills.map((pill) => (
-                        <span key={pill.key} className="flex items-center">
-                          {pill.content}
+                      {filteredDetails.map((detail) => (
+                        <span key={detail.key} className="flex items-center">
+                          {detail.content}
                         </span>
                       ))}
                       {visibleUsers.map((detail) => (

--- a/web/src/features/sessions/__fixtures__/modernSessionHeaderScore.ts
+++ b/web/src/features/sessions/__fixtures__/modernSessionHeaderScore.ts
@@ -1,0 +1,49 @@
+import { type ScoreDomain } from "@langfuse/shared";
+
+import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
+
+/**
+ * A session-level score row exactly as `sessions.byIdWithScoresFromEvents`
+ * returns it. `ModernSessionHeader` renders scores with `ScoreBadge`, which
+ * reads the comment and metadata fields too, so its stories and tests need
+ * whole rows rather than the name/value pair the old pill used.
+ */
+export type ModernSessionHeaderScore = WithStringifiedMetadata<ScoreDomain>;
+
+/** Numeric session score; the only shape the header's stories/tests need. */
+export const modernSessionHeaderScore = ({
+  id,
+  name,
+  value = 0,
+  comment = null,
+  metadata = null,
+}: {
+  id: string;
+  name: string;
+  value?: number;
+  comment?: string | null;
+  metadata?: string | null;
+}): ModernSessionHeaderScore => ({
+  id,
+  name,
+  value,
+  comment,
+  metadata,
+  stringValue: null,
+  dataType: "NUMERIC",
+  projectId: "project-1",
+  environment: "default",
+  source: "API",
+  authorUserId: null,
+  configId: null,
+  queueId: null,
+  executionTraceId: null,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  timestamp: new Date("2026-01-01T00:00:00.000Z"),
+  traceId: null,
+  sessionId: "session-1",
+  datasetRunId: null,
+  observationId: null,
+  longStringValue: "",
+});

--- a/web/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple.tsx
@@ -21,7 +21,9 @@ import {
 
 // Metrics tier (latency, time-to-first-token): uniform muted mono text,
 // matching the numeric feel of the session header without its pill box.
-const METRIC_TEXT_CLASS =
+// Exported so the session header's own metrics (trace/span counts, latency
+// percentiles) share ONE definition of the tier instead of copying it.
+export const METRIC_TEXT_CLASS =
   "text-muted-foreground inline-flex shrink-0 items-center gap-1 text-xs whitespace-nowrap";
 
 /** Absolute start time, quiet text like the other metrics; full ISO on hover. */
@@ -75,11 +77,12 @@ export function TimeToFirstTokenBadge({
   );
 }
 
-// Attributes tier (env/release/version, and model params in the observation
-// header): key/value text, key muted and value a touch stronger so the
-// value still reads at a glance. Still under design discussion — kept
-// isolated here so it stays cheap to restyle.
-function KeyValueText({
+// Attributes tier (env/release/version, model params in the observation
+// header, and the session header's pinned metadata JSONPaths): key/value
+// text, key muted and value a touch stronger so the value still reads at a
+// glance. Still under design discussion — kept isolated here so it stays
+// cheap to restyle, and exported so the session header restyles with it.
+export function KeyValueText({
   label,
   value,
 }: {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17335 app preview](https://pr-17335.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

The session detail header put every fact in a bordered pill, which reads as a different language from the trace view beside it; this moves it onto the trace components instead of restyling it in place.

## What changed

| Element | Before | After | Where |
| --- | --- | --- | --- |
| Trace / span counts | Bordered pill | Quiet muted text, numbers in `text-foreground`, `·` separator | `ModernSessionHeader.tsx` via `METRIC_TEXT_CLASS` |
| Latency | Pill, `p50 … · p95 …` | Clock icon + `p50 …` only, muted label and foreground value | `ModernSessionHeader.tsx` |
| Cost + tokens | Two pills (`cost $0.186`, `tokens 213k → 1k (Σ 214k)`) | One `CostUsageBadge`: cost as plain text, coin icon + token total, exact input → output split on hover | `ObservationMetadataBadgesTooltip.tsx` |
| Users | Pill link | `UserIdBadge` — `User <id> ↗`, still `ph-no-capture` | `TraceMetadataBadges.tsx` |
| Environment | Pill | `EnvironmentBadge` key:value text | `ObservationMetadataBadgesSimple.tsx` |
| Pinned metadata JSONPaths | Pill with hover remove | `KeyValueText` key:value text, same hover remove | `ModernSessionHeader.tsx` |
| Scores | Custom yellow-dot pill | `ScoreBadge` compact chips, matching the trace tree | `ScoreBadge.tsx` |
| JSONPath editor trigger | Pill | `Button variant="ghost" size="icon-xs"` | `ModernSessionHeader.tsx` |
| Row spacing | `gap-2` | `gap-3`, the air text metrics need | `SingleLineOverflowList.tsx` (new `spacing` prop, other callers unchanged) |
| Metric text tier | Private to the trace components | `METRIC_TEXT_CLASS` and `KeyValueText` exported so both headers share one definition | `ObservationMetadataBadgesSimple.tsx` |

Behaviour is unchanged: the measured single line, the searchable `+N` overflow popover with user paging, the pinned-JSONPath add/remove flow and its PostHog captures. The scores prop widens to whole score rows, since `ScoreBadge` reads the comment and metadata fields too.

Latency drops `p95` — the only fact this removes, per a mid-review product call. Reverting it is one block plus two assertions.

Stacked on #17288; retarget to main after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63017014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until the session cost tooltip stops presenting fabricated zero directional costs; the remaining findings are lower-impact presentation and test-coverage concerns.

<details open><summary><h3>Summary</h3></summary>

- The aggregate session cost is currently wired into a directional breakdown that displays incorrect per-direction costs.
- Compact score rendering does not expose score metadata despite the widened score contract.
- The Storybook contrast exemption is broader than the known score-chip failure.
- Hover-expanded metadata controls are not represented in overflow measurement.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(web): session header follows the tra..."](https://github.com/langfuse/langfuse/commit/30ace467ced4122c197a2f9648442d8f9959c744)</sub>

<!-- /greptile_comment -->