### PR TITLE
fix(worker): honor ERROR level on events path

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -303,6 +303,7 @@ export class IngestionService {
     // fields as strings, so stringify at this schema boundary.
     const input = this.stringify(eventData.input);
     const output = this.stringify(eventData.output);
+    const level = eventData.level ?? "DEFAULT";
     const modelParameters = parseEventModelParameters(
       eventData.modelParameters,
     );
@@ -350,6 +351,7 @@ export class IngestionService {
               provided_model_name: eventData.modelName,
               provided_usage_details: eventData.providedUsageDetails ?? {},
               provided_cost_details: eventData.providedCostDetails ?? {},
+              level,
               input,
               output,
             },
@@ -393,7 +395,7 @@ export class IngestionService {
       session_id: eventData.sessionId,
 
       // Status
-      level: eventData.level ?? "DEFAULT",
+      level,
       status_message: eventData.statusMessage,
 
       // Timestamps

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -159,6 +159,10 @@ describe("Token Cost Calculation", () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    tokenisationMocks.tokenCountAsyncOverride = null;
+  });
+
   it("should correctly calculate token costs with provided model prices", async () => {
     const prices = await prisma.price.findMany({
       where: {
@@ -1343,6 +1347,74 @@ describe("Token Cost Calculation", () => {
     expect(generation.usage_details.output).toBeUndefined();
     expect(generation.usage_details.total).toBeUndefined();
   });
+
+  // The two events-path generations below are identical except for `level`,
+  // so the ERROR guard is the only thing that can separate their outcomes.
+  const eventsPathGeneration = (level: string) => ({
+    projectId,
+    traceId: uuidv4(),
+    spanId: generationId,
+    startTimeISO: new Date().toISOString(),
+    type: "GENERATION",
+    modelName,
+    input: "hello world",
+    output: "hey whassup",
+    level,
+  });
+
+  it("should skip tokenization on the events path if generation status is ERROR", async () => {
+    const tokenCountAsyncSpy = vi.fn();
+    tokenisationMocks.tokenCountAsyncOverride = tokenCountAsyncSpy;
+
+    const eventRecord = await (mockIngestionService as any).createEventRecord(
+      eventsPathGeneration("ERROR"),
+      "testfile.txt",
+    );
+    await (mockIngestionService as any).writeEventRecord(eventRecord);
+
+    expect(mockAddToClickhouseWriter).toHaveBeenCalled();
+    const args = mockAddToClickhouseWriter.mock.calls[0];
+    const tableName = args[0];
+    const generation = args[1];
+
+    expect(tableName).toBe("events_full");
+    expect(generation.type).toBe("GENERATION");
+    expect(generation.level).toBe("ERROR");
+    // Model name is still matched, as on the legacy path
+    expect(generation.model_id).toBe(tokenModelData.id);
+
+    // The ERROR guard must short-circuit before the tokenizer is invoked
+    expect(tokenCountAsyncSpy).not.toHaveBeenCalled();
+    expect(generation.usage_details.input).toBeUndefined();
+    expect(generation.usage_details.output).toBeUndefined();
+    expect(generation.usage_details.total).toBeUndefined();
+  });
+
+  // Real tokenization: input and output are counted on worker threads that
+  // load the encoder on first use, which can exceed vitest's default 5s under
+  // a loaded suite. Match the tokenizer's own 30s operation timeout.
+  it("should tokenize on the events path when generation status is not ERROR", async () => {
+    const eventRecord = await (mockIngestionService as any).createEventRecord(
+      eventsPathGeneration("DEFAULT"),
+      "testfile.txt",
+    );
+    await (mockIngestionService as any).writeEventRecord(eventRecord);
+
+    expect(mockAddToClickhouseWriter).toHaveBeenCalled();
+    const args = mockAddToClickhouseWriter.mock.calls[0];
+    const tableName = args[0];
+    const generation = args[1];
+
+    expect(tableName).toBe("events_full");
+    expect(generation.type).toBe("GENERATION");
+    expect(generation.level).toBe("DEFAULT");
+    expect(generation.model_id).toBe(tokenModelData.id);
+    expect(generation.usage_details.input).toBeGreaterThan(0);
+    expect(generation.usage_details.output).toBeGreaterThan(0);
+    expect(generation.usage_details.total).toBe(
+      generation.usage_details.input + generation.usage_details.output,
+    );
+  }, 30_000);
 
   it("should skip tokenization and leave usage details blank when cost details are provided", async () => {
     const generationUsage1 = {


### PR DESCRIPTION
## What does this PR do?

`createEventRecord()` builds the `observationRecord` it hands to `getGenerationUsage()` without `level`, so the guard that skips manual tokenization for ERROR-level generations (`observationRecord.level !== ObservationLevel.ERROR`) never fires on the v4 events path — `undefined !== "ERROR"` is always true. The legacy `observations` path passes `level` and skips correctly, so one and the same failed generation is tokenized on the events path and not on the legacy path.

Failed generations carry a model name but no usage, so they always reach the tokenization branch. The tokenizer worker-thread pool that starts for them can push a memory-constrained worker past its container limit (kernel SIGKILL, no V8 error since the heap cap sits below the container cap), the BullMQ job stalls and is retried, and the span is never written to `events_core`. Details, production numbers and a Docker reproduction are in the linked issue.

This PR:

- hoists the `level` default (`eventData.level ?? "DEFAULT"`, already used when the record is written) into one `const` in `createEventRecord()` and passes it to `getGenerationUsage()`, so the usage lookup and the written record can no longer disagree;
- adds two events-path tests next to the existing legacy-path ERROR test, built from one shared input that differs only in `level`: an ERROR generation without usage must not invoke `tokenCountAsync` and must leave `usage_details` empty (this test fails on `main`: the tokenizer is called twice), and a DEFAULT generation without usage must still be tokenized. Both assert the `events_full` write target.

The omission compiled because `level` is `nullish()` in `observationRecordBaseSchema`, so the `Pick<…, "level">` in `getGenerationUsage`'s signature is optional. Tightening that type is left for a follow-up to keep this change minimal.

Fixes #17327

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checks run locally

Node 24.20.0, pnpm 12.3.1, `docker-compose.dev.yml` with the `worker-tests` profile, migrated with `db:deploy` + `ch:up` + `ch:dev-tables`.

- `pnpm exec turbo run lint --filter='!ai-gateway'` — 7/7 (the pre-commit hook runs the same)
- `pnpm exec turbo run typecheck --filter='!ai-gateway'` — 8/8
- `pnpm exec knip` — clean
- `pnpm exec prettier --check` on the changed files — clean
- `pnpm --filter=worker run test calculateTokenCost.unit.test.ts` — 33/33; with the one-line fix stashed, the new ERROR test fails (`tokenCountAsync` called 2×) and the DEFAULT test still passes
- `pnpm --filter=worker run test:exclude-llm-connections` — see comment below / CI


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63020023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The production fix appears safe to merge, with a non-blocking test-reliability concern around invoking the real tokenizer.

<details open><summary><h3>Summary</h3></summary>

- Prevents automatic tokenization for ERROR-level generations on the events path.
- Retains tokenization for DEFAULT-level generations.
- Adds direct-events regression coverage and resets the tokenizer override between tests.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(worker): honor ERROR level on events..."](https://github.com/langfuse/langfuse/commit/f86960aa71afd1b441d10f07179e15c680cdde8e)</sub>

<!-- /greptile_comment -->