### PR TITLE
fix(tokenisation): count a tool call by its contents

### DIFF
--- a/worker/src/__tests__/tokenisationToolCalls.unit.test.ts
+++ b/worker/src/__tests__/tokenisationToolCalls.unit.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { type Model } from "@langfuse/shared";
+
+import { tokenCount } from "../features/tokenisation/usage";
+
+const gpt4o = {
+  id: "model-gpt-4o",
+  tokenizerId: "openai",
+  tokenizerConfig: {
+    tokenizerModel: "gpt-4o",
+    tokensPerMessage: 3,
+    tokensPerName: 1,
+  },
+} as unknown as Model;
+
+const toolCalls = [
+  {
+    id: "call_abc123",
+    type: "function",
+    function: {
+      name: "get_current_weather",
+      arguments: '{"location":"Paris, France","unit":"celsius"}',
+    },
+  },
+];
+
+describe("openAI chat token count", () => {
+  it("prices a tool call by its contents rather than as [object Object]", () => {
+    // An assistant turn that calls a tool carries the call as an object. Passing
+    // that object to the tokeniser unchanged stringifies it to "[object Object]",
+    // which is a handful of tokens no matter how large the call actually is.
+    const withToolCalls = tokenCount({
+      model: gpt4o,
+      text: [
+        { role: "assistant", content: "Let me check.", tool_calls: toolCalls },
+      ],
+    });
+
+    const withoutToolCalls = tokenCount({
+      model: gpt4o,
+      text: [{ role: "assistant", content: "Let me check." }],
+    });
+
+    expect(withToolCalls).toBeDefined();
+    expect(withoutToolCalls).toBeDefined();
+
+    // The function name and its JSON arguments alone run past twenty tokens, so
+    // anything near the "[object Object]" cost of four would be the old undercount.
+    expect(
+      (withToolCalls as number) - (withoutToolCalls as number),
+    ).toBeGreaterThan(20);
+  });
+
+  it("counts a tool call the same whether the SDK sent it as an object or as JSON", () => {
+    const asObject = tokenCount({
+      model: gpt4o,
+      text: [
+        { role: "assistant", content: "Let me check.", tool_calls: toolCalls },
+      ],
+    });
+
+    const asJson = tokenCount({
+      model: gpt4o,
+      text: [
+        {
+          role: "assistant",
+          content: "Let me check.",
+          tool_calls: JSON.stringify(toolCalls),
+        },
+      ],
+    });
+
+    expect(asObject).toBe(asJson);
+  });
+
+  it("still counts a plain assistant message the same as before", () => {
+    expect(
+      tokenCount({
+        model: gpt4o,
+        text: [{ role: "user", content: "Hello world" }],
+      }),
+    ).toBe(9);
+  });
+});

--- a/worker/src/features/tokenisation/usage.ts
+++ b/worker/src/features/tokenisation/usage.ts
@@ -58,6 +58,9 @@ type ChatMessage = {
   role: string;
   name?: string;
   content: string;
+  // Chat completions carry more than the three keys we match on, and the ones
+  // that matter for the token count (tool_calls, function_call) are objects.
+  [key: string]: unknown;
 };
 
 function openAiTokenCount(p: { model: Model; text: unknown }) {
@@ -141,7 +144,13 @@ function openAiChatTokenCount(params: {
           "functionCall",
         ].some((k) => k === key)
       ) {
-        const tokens = getTokensByModel(model, value);
+        // tool_calls and function_call arrive as objects. Handing one straight
+        // to the tokeniser stringifies it as "[object Object]", which prices a
+        // whole tool call at a handful of tokens, so serialise it first.
+        const tokens = getTokensByModel(
+          model,
+          isString(value) ? value : JSON.stringify(value),
+        );
         if (tokens) numTokens += tokens;
       }
       if (key === "name") {


### PR DESCRIPTION
Closes #17337.

### Problem

`openAiChatTokenCount` matches on `tool_calls`, `function_call`, `toolCalls` and `functionCall` and passes the value to the tokeniser. Those values are objects, so they were stringified by concatenation and every tool call was counted as the literal string `[object Object]`.

Measured on the `gpt-4o` tokenizer config, for one small weather call:

| input | counted |
|--|--|
| tool call as the object the SDK sends | 15 |
| same call pre-serialised to JSON | 49 |
| message with no tool call | 11 |

Four tokens for a call worth thirty-eight, and the gap grows with the size of the arguments.

### Scope

Only observations whose usage Langfuse infers rather than receives from the provider. Anything that reports its own usage is untouched. Within that set it is tool-calling agent traces that were undercounted, and the cost derived from those tokens with them. Nothing raised an error, so the undercount was silent.

### Change

Serialise a non-string value before counting it. `ChatMessage` gains an index signature so the extra keys the matcher already looks for are typed as what they are rather than inferred as `string`.

### Tests

New unit test in `worker/src/__tests__/tokenisationToolCalls.unit.test.ts`. Against main the first two fail with `expected 4 to be greater than 20` and `expected 15 to be 49`; with the change all three pass.

- a tool call costs more than twenty tokens beyond the same message without it
- the object form and the pre-serialised JSON form agree
- a plain assistant message is unchanged at nine tokens

`tsc --noEmit` on the worker package is clean.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63027892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with focused regression coverage for the corrected token-counting behavior.

<details open><summary><h3>Summary</h3></summary>

- Extends the internal chat-message type to represent additional structured fields.
- Preserves already serialized string values while JSON-serializing non-string matched values.
- Adds regression coverage for object-form tool calls, pre-serialized tool calls, and ordinary messages.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(tokenisation): count a tool call by ..."](https://github.com/langfuse/langfuse/commit/f8565db413d98535ac64a5d9918b21c796983bec)</sub>

<!-- /greptile_comment -->