### PR TITLE
chore(ci): add Dependabot config for Rust

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,17 @@ updates:
       default-days: 7
     ignore:
       - dependency-name: "*"
+
+  - package-ecosystem: cargo
+    directory: "/ai-gateway"
+    assignees:
+      - "hassiebp"
+      - "wochinge"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What does this PR do?

Adds weekly Dependabot updates for Rust dependencies in `ai-gateway`.

- Groups all Cargo dependency updates into one PR
- Applies the existing seven-day cooldown
- Assigns `hassiebp` and `wochinge` by default

## Type of change

- [x] Chore

## Mandatory Tasks

- [x] Self-reviewed the change

## Verification

- `Dependabot YAML parsed; weekly grouped Cargo config verified`
- `git diff --check`
- Commit hooks: `Tasks: 7 successful, 7 total`; `Cached: 6 cached, 7 total`

Full test suite skipped because this only changes Dependabot configuration.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63031906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The configuration appears safe to merge, though Cargo dependency PRs should be included in the gateway end-to-end test filter.

<details open><summary><h3>Summary</h3></summary>

- Groups all Cargo updates into one pull request.
- Applies a seven-day cooldown.
- Assigns the configured maintainers.
- Cargo-only update PRs currently bypass the gateway end-to-end test filter.
</details>

<sub>Reviews (1) · Last reviewed commit: ["chore(ci): add Dependabot config for Rus..."](https://github.com/langfuse/langfuse/commit/f060d9e13b345fd4bdbdbf34378bfc8d7f359d7e)</sub>

<!-- /greptile_comment -->