### PR TITLE
fix(scores): display two decimals with precision on hover

### DIFF
--- a/web/src/components/scores-table-cell.tsx
+++ b/web/src/components/scores-table-cell.tsx
@@ -97,7 +97,7 @@ export const ScoresTableCell = ({
           className="truncate"
           title={valueTitle ? `${valueTitle}: ${value}` : value}
         >
-          {value}
+          {aggregate.type === "NUMERIC" ? aggregate.average.toFixed(2) : value}
         </span>
         {aggregate.comment && (
           <HoverCard>
@@ -143,7 +143,9 @@ export const ScoresTableCell = ({
 
   if (aggregate.type === "NUMERIC") {
     return (
-      <span className="rounded-sm">{`Ø ${aggregate.average.toFixed(4)}`}</span>
+      <span className="rounded-sm" title={aggregate.average.toFixed(4)}>
+        {`Ø ${aggregate.average.toFixed(2)}`}
+      </span>
     );
   }
 

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -614,6 +614,14 @@ export default function ScoresTable({
       accessorKey: "value",
       header: "Value",
       id: "value",
+      cell: ({ row }) =>
+        row.original.dataType === "NUMERIC" && row.original.value !== "" ? (
+          <span title={Number(row.original.value).toFixed(4)}>
+            {Number(row.original.value).toFixed(2)}
+          </span>
+        ) : (
+          row.original.value
+        ),
       enableHiding: true,
       enableSorting: true,
       size: 100,
@@ -974,9 +982,7 @@ export default function ScoresTable({
       dataType: score.dataType,
       value:
         isNumericDataType(score.dataType) && isPresent(score.value)
-          ? score.value % 1 === 0
-            ? String(score.value)
-            : score.value.toFixed(4)
+          ? String(score.value)
           : (score.stringValue ?? ""),
       author: {
         userId: score.authorUserId ?? undefined,
@@ -1022,9 +1028,7 @@ export default function ScoresTable({
         dataType: score.dataType,
         value:
           isNumericDataType(score.dataType) && isPresent(score.value)
-            ? score.value % 1 === 0
-              ? String(score.value)
-              : score.value.toFixed(4)
+            ? String(score.value)
             : (score.stringValue ?? ""),
         author: {
           userId: score.authorUserId ?? undefined,

--- a/web/src/features/evals/components/eval-log.tsx
+++ b/web/src/features/evals/components/eval-log.tsx
@@ -130,7 +130,7 @@ export default function EvalLogTable({
           return undefined;
         }
         if (typeof value === "number") {
-          return value % 1 === 0 ? value : value.toFixed(4);
+          return <span title={value.toFixed(4)}>{value.toFixed(2)}</span>;
         }
         return value;
       },

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -247,7 +247,7 @@ const formatScoreAggregateValue = (
 ): string => {
   if (!aggregate) return "nothing";
   return aggregate.type === "NUMERIC"
-    ? aggregate.average.toFixed(4)
+    ? aggregate.average.toFixed(2)
     : (aggregate.values[0] ?? "nothing");
 };
 

--- a/web/src/features/scores/components/ScoreRow.tsx
+++ b/web/src/features/scores/components/ScoreRow.tsx
@@ -57,7 +57,9 @@ const ScoreValueSection = ({
       {aggregate ? (
         <>
           <span className="line-clamp-1 font-bold">
-            {resolveScoreValue(aggregate)}
+            {aggregate.type === "NUMERIC"
+              ? aggregate.average.toFixed(2)
+              : resolveScoreValue(aggregate)}
           </span>
           {diff && (
             <DiffLabel diff={diff} formatValue={(value) => value.toFixed(2)} />


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17345 app preview](https://pr-17345.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Numeric scores currently show four decimal places in compact views. Display two decimals in the shared score cell and detail row, scores table, and evaluator log; retain four decimals in hover titles or the existing detail hover card. Keep the experiment comparison hover sentence consistent with its displayed value.

Example: `0.1234` displays as `0.12`, with `0.1234` on hover. Score values are unchanged in storage; the scores table formats at render time to avoid rounding twice.

Impacted package: web.

Validation: focused ESLint on the five changed files passed (exit 0); Prettier reported `All matched files use Prettier code style!`; `git diff --check` passed. No additional unit tests for this presentation-only change. Full typecheck and browser verification were not run locally.

Preview: https://pr-17345.preview.langfuse.com

Review: open a project with fractional numeric scores, inspect a score cell in observations or experiments and hover its value; confirm two decimals inline and four on hover. Repeat in the Scores page, score detail hover card, and evaluator log.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63040968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with the intended two-decimal presentation and four-decimal hover precision applied consistently.

<details open><summary><h3>Summary</h3></summary>

- Formats shared score cells and aggregate cells to two decimals with four-decimal titles.
- Formats Scores-page and evaluator-log numeric values at render time.
- Keeps score-detail hover content at four decimals.
- Aligns experiment comparison hover sentences with the displayed two-decimal value.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(scores): display two decimals with p..."](https://github.com/langfuse/langfuse/commit/6f01d6f62a08f62328f5c688f911c02a9ce88555)</sub>

<!-- /greptile_comment -->