### PR TITLE
perf(tokenisation): drop the unicode pass that never changes its input

### DIFF
--- a/worker/src/__tests__/tokenisationUnicode.unit.test.ts
+++ b/worker/src/__tests__/tokenisationUnicode.unit.test.ts
@@ -1,0 +1,42 @@
+import { encoding_for_model } from "tiktoken";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { type Model } from "@langfuse/shared";
+
+import { tokenCount } from "../features/tokenisation/usage";
+
+const gpt4o = {
+  id: "model-gpt-4o",
+  tokenizerId: "openai",
+  tokenizerConfig: {
+    tokenizerModel: "gpt-4o",
+    tokensPerMessage: 3,
+    tokensPerName: 1,
+  },
+} as unknown as Model;
+
+const encoding = encoding_for_model("gpt-4o");
+
+afterAll(() => {
+  encoding.free();
+});
+
+describe("token count of text outside the basic plane", () => {
+  // Text was passed through a pass that hex-encoded astral characters before
+  // counting. It never actually did so, because indexing a string yields UTF-16
+  // code units and an astral character arrives as a lone surrogate. These pin
+  // the counts to what the tokeniser itself reports, so a later change that
+  // revives the encoding is caught rather than silently repricing every
+  // observation containing an emoji.
+  it.each([
+    ["an emoji", "hello 😀 world"],
+    ["a musical symbol", "𝄞 clef"],
+    ["a multi-person emoji sequence", "👨‍👩‍👧‍👦 family"],
+    ["a regional indicator pair", "🇮🇳 flag"],
+    ["text with no astral characters", "plain ascii text"],
+  ])("counts %s as the tokeniser does", (_label, text) => {
+    expect(tokenCount({ model: gpt4o, text })).toBe(
+      encoding.encode(text, "all").length,
+    );
+  });
+});

--- a/worker/src/features/tokenisation/usage.ts
+++ b/worker/src/features/tokenisation/usage.ts
@@ -167,10 +167,8 @@ const getTokensByModel = (model: TiktokenModel, text: string) => {
 
     encoding = get_encoding("cl100k_base");
   }
-  const cleandedText = unicodeToBytesInString(text);
-
   logger.debug(`Tokenized data for model: ${model}`);
-  return encoding?.encode(cleandedText, "all").length;
+  return encoding?.encode(text, "all").length;
 };
 
 interface Tokenizer {
@@ -203,25 +201,4 @@ function isChatMessageArray(value: unknown): value is ChatMessage[] {
       typeof item.content === "string" &&
       (!("name" in item) || typeof item.name === "string"),
   );
-}
-
-function unicodeToBytesInString(input: string): string {
-  let result = "";
-  for (let i = 0; i < input.length; i++) {
-    const char = input[i];
-    if (char && /[\u{10000}-\u{10FFFF}]/u.test(char)) {
-      const bytes = unicodeToBytes(char);
-      result += Array.from(bytes)
-        .map((b) => b.toString(16))
-        .join("");
-    } else {
-      result += char;
-    }
-  }
-  return result;
-}
-
-function unicodeToBytes(input: string): Uint8Array {
-  const encoder = new TextEncoder();
-  return encoder.encode(input);
 }


### PR DESCRIPTION
Closes #17346.

### The pass does nothing

`getTokensByModel` sends every string through `unicodeToBytesInString` before counting. That function hex-encodes astral characters, but it walks the string with `input[i]`, which yields a UTF-16 code unit. An astral character therefore arrives as a lone surrogate, and `/[\u{10000}-\u{10FFFF}]/u` does not match a lone surrogate. The branch cannot fire for any input, so the function returns its argument unchanged.

### It is not free

Counting a 216,000 character prompt with the `gpt-4o` encoder:

| step | ms |
|--|--|
| `unicodeToBytesInString` | 51.7 |
| `encode` | 59.9 |

Roughly 46% of the time spent counting goes to a transformation that returns its input. The worker pays it on every observation whose usage the provider did not report.

### The guard is not needed

tiktoken 1.0.20 encodes astral text without error:

| input | tokens |
|--|--|
| `hello 😀 world` | 3 |
| `𝄞 clef` | 5 |
| `👨‍👩‍👧‍👦 family` | 12 |
| `🇮🇳 flag` | 5 |

### Change

Pass the text straight to `encode` and delete `unicodeToBytesInString` and `unicodeToBytes`, which had no other caller.

Counts are unchanged, because the function was already the identity. That is the part worth checking rather than taking on trust, so the new test in `worker/src/__tests__/tokenisationUnicode.unit.test.ts` asserts the count for each of those strings equals what the tokeniser returns directly, and it passes both on `main` and on this branch.

The test earns its place going forward: it fails if someone revives the hex-encoding, which would silently reprice every observation containing an emoji.

`tsc --noEmit` on the worker package is clean.

### Note

Found while working on #17337, which touches this function's caller but is otherwise unrelated. This branch is cut from `main`, not from that one, so the two are independent.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63048575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

<details open><summary><h3>Summary</h3></summary>

- Passes input directly to the tiktoken encoder, avoiding an identity transformation.
- Covers emoji, musical symbols, multi-person sequences, regional indicators, and ASCII text.
- Preserves existing token counts while reducing tokenization overhead.
</details>

<sub>Reviews (1) · Last reviewed commit: ["perf(tokenisation): drop the unicode pas..."](https://github.com/langfuse/langfuse/commit/a1d521582247b612f29aa1088e9ffc1edeabd13e)</sub>

<!-- /greptile_comment -->