### PR TITLE
test(web): remove flaky tabs indicator story

### DIFF
--- a/web/src/components/design-system/Tabs/Tabs.stories.tsx
+++ b/web/src/components/design-system/Tabs/Tabs.stories.tsx
@@ -271,37 +271,6 @@ export const TruncatesLabel = meta.story({
   },
 });
 
-export const SlidesIndicator = meta.story({
-  name: "(Test) Slides Indicator",
-  args: {
-    defaultValue: "short",
-    children: (
-      <Tabs.List variant="outline">
-        <Tabs.Trigger value="short" label="Python" />
-        <Tabs.Trigger value="long" label="TypeScript" />
-      </Tabs.List>
-    ),
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const indicator = canvasElement.querySelector("[data-tabs-indicator]");
-
-    await expect(indicator).toBeInTheDocument();
-    const initialRect = indicator!.getBoundingClientRect();
-
-    const typeScriptTab = canvas.getByRole("tab", { name: "TypeScript" });
-    await userEvent.click(typeScriptTab);
-    await waitFor(() => {
-      const nextRect = indicator!.getBoundingClientRect();
-      const tabRect = typeScriptTab.getBoundingClientRect();
-      expect(nextRect.left).toBeGreaterThan(initialRect.left);
-      expect(nextRect.width).toBeGreaterThan(initialRect.width);
-      expect(Math.abs(nextRect.left - tabRect.left)).toBeLessThan(0.5);
-      expect(Math.abs(nextRect.width - tabRect.width)).toBeLessThan(0.5);
-    });
-  },
-});
-
 export const AlignsSlidingIndicatorInScaledContainer = meta.story({
   name: "(Test) Aligns Sliding Indicator In Scaled Container",
   args: {


### PR DESCRIPTION
## Summary
- remove the flaky Storybook interaction test for the Tabs sliding indicator
- keep the scaled-container indicator coverage in place

The removed test compares browser layout at a strict half-pixel boundary and failed intermittently across unrelated branches, including [this CI job](https://github.com/langfuse/langfuse/actions/runs/34596396650/job/103253033493).

## Impacted package
- `web`

## Verification
- `pnpm exec turbo run lint --force`
- `pnpm --filter web run test-storybook Tabs.stories.tsx`

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63050317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The change is safe to merge from a runtime perspective, but retaining the stable indicator movement assertions would avoid an unnecessary test-coverage regression.

<details open><summary><h3>Summary</h3></summary>

- Eliminates strict half-pixel comparisons that were intermittently failing.
- Also removes the only stable coverage that verifies the indicator moves and widens when switching between unequal-width tabs.
</details>

<sub>Reviews (1) · Last reviewed commit: ["test(web): remove flaky tabs indicator s..."](https://github.com/langfuse/langfuse/commit/2ac406abeab2f7694f5608c0728ad9fec3add593)</sub>

<!-- /greptile_comment -->