### PR TITLE
chore: Simplify pre-commit output

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,6 +6,8 @@ current_branch=$(git rev-parse --abbrev-ref HEAD)
 # Define the protected branch
 protected_branch="main"
 
+echo "Running pre-commit checks..."
+
 run_check() {
   label="$1"
   shift

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,13 +6,33 @@ current_branch=$(git rev-parse --abbrev-ref HEAD)
 # Define the protected branch
 protected_branch="main"
 
+run_check() {
+  label="$1"
+  shift
+  start_time=$(node -p "Date.now()")
+
+  if output=$("$@" 2>&1); then
+    elapsed_ms=$(($(node -p "Date.now()") - start_time))
+    printf '%s passed in %d.%03ds.\n' "$label" "$((elapsed_ms / 1000))" "$((elapsed_ms % 1000))"
+  else
+    printf '%s\n' "$output"
+    elapsed_ms=$(($(node -p "Date.now()") - start_time))
+    printf '%s failed after %d.%03ds.\n' "$label" "$((elapsed_ms / 1000))" "$((elapsed_ms % 1000))"
+    return 1
+  fi
+}
+
+run_format_check() {
+  run_check "Formatting" pnpm run format:check
+}
+
 run_lint() {
   if [ -n "${LANGFUSE_PRE_COMMIT_SKIP_LINT-}" ]; then
     echo "Skipping lint because LANGFUSE_PRE_COMMIT_SKIP_LINT is set."
     return 0
   fi
 
-  pnpm run lint --filter=!ai-gateway
+  run_check "Lint" pnpm run lint --filter=!ai-gateway
 }
 
 # Check if the current branch is the protected branch
@@ -21,7 +41,7 @@ if [ "$current_branch" = "$protected_branch" ]; then
   read -r answer </dev/tty
   if [ "$answer" != "${answer#[Yy]}" ]; then
     # Commit approved, run checks
-    pnpm run format:check
+    run_format_check
     run_lint
   else
     echo "Commit to $protected_branch branch has been canceled."
@@ -30,5 +50,5 @@ if [ "$current_branch" = "$protected_branch" ]; then
 fi
 
 # If not the protected branch, run checks
-pnpm run format:check
+run_format_check
 run_lint


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17349 app preview](https://pr-17349.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63051674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with a non-blocking usability concern caused by hiding all progress during potentially long checks.

<details open><summary><h3>Summary</h3></summary>

- Applies the wrapper to formatting and lint checks on protected and regular branches.
- Preserves the existing lint-skip environment variable.
- Leaves the hook silent while checks execute, reducing progress visibility during long runs.
</details>

<sub>Reviews (1) · Last reviewed commit: ["chore: Simplify pre-commit output"](https://github.com/langfuse/langfuse/commit/87d0fdfed3e317ec72d4fc940237dd0f5defa66d)</sub>

<!-- /greptile_comment -->