### PR TITLE
fix(gateway): show credential names in model filters

### DIFF
--- a/web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/GatewayModelsView.tsx
+++ b/web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/GatewayModelsView.tsx
@@ -13,11 +13,15 @@ import {
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import type { LangfuseColumnDef } from "@/src/components/table/types";
-import { useSidebarFilterState } from "@/src/features/filters/hooks/useSidebarFilterState";
+import { useSidebarFilterState } from "@/src/features/filters";
 import { providerLabels } from "@/src/features/ai-gateway/constants/providerLabels";
 import { gatewayModelsFilterConfig } from "@/src/features/ai-gateway/constants/modelsFilterConfig";
 import { GATEWAY_MODELS_FIELD_REGISTRY } from "@/src/features/ai-gateway/constants/modelsSearchRegistry";
-import { TableSearchBar, toObservedOptions } from "@/src/features/search-bar";
+import {
+  TableSearchBar,
+  toObservedOptions,
+  withFieldOptions,
+} from "@/src/features/search-bar";
 import {
   filterGatewayModels,
   type GatewayModelRow,
@@ -124,6 +128,38 @@ export function GatewayModelsView({
     }),
     [models],
   );
+  const searchRegistry = useMemo(
+    () =>
+      withFieldOptions(
+        GATEWAY_MODELS_FIELD_REGISTRY,
+        "connection",
+        filterOptions.connection,
+      ),
+    [filterOptions.connection],
+  );
+  const connectionIdByName = useMemo(
+    () =>
+      new Map(
+        filterOptions.connection.map(({ value, displayValue }) => [
+          displayValue,
+          value,
+        ]),
+      ),
+    [filterOptions.connection],
+  );
+  const observedOptions = useMemo(
+    () =>
+      toObservedOptions(
+        {
+          ...filterOptions,
+          connection: filterOptions.connection.map(
+            ({ displayValue }) => displayValue,
+          ),
+        },
+        isLoading,
+      ),
+    [filterOptions, isLoading],
+  );
   const queryFilter = useSidebarFilterState(
     gatewayModelsFilterConfig,
     filterOptions,
@@ -182,10 +218,24 @@ export function GatewayModelsView({
           <TableSearchBar
             key={queryFilter.draftResetKey}
             tableName={TABLE_NAME}
-            registry={GATEWAY_MODELS_FIELD_REGISTRY}
+            registry={searchRegistry}
             filterState={queryFilter.searchBarFilterState}
-            setFilterState={queryFilter.setFilterState}
-            observed={toObservedOptions(filterOptions, isLoading)}
+            setFilterState={(filters) =>
+              queryFilter.setFilterState(
+                filters.map((filter) =>
+                  filter.column === "connection" &&
+                  filter.type === "arrayOptions"
+                    ? {
+                        ...filter,
+                        value: filter.value.map(
+                          (value) => connectionIdByName.get(value) ?? value,
+                        ),
+                      }
+                    : filter,
+                ),
+              )
+            }
+            observed={observedOptions}
             isV4={false}
             search={{
               query: searchQuery,

--- a/web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/GatewayModelsView.tsx
+++ b/web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/GatewayModelsView.tsx
@@ -26,6 +26,7 @@ import {
   filterGatewayModels,
   type GatewayModelRow,
 } from "./filterGatewayModels";
+import { getGatewayModelConnectionSearchOptions } from "./fns/getGatewayModelConnectionSearchOptions";
 
 const TABLE_NAME = gatewayModelsFilterConfig.tableName;
 
@@ -128,44 +129,49 @@ export function GatewayModelsView({
     }),
     [models],
   );
-  const searchRegistry = useMemo(
-    () =>
-      withFieldOptions(
-        GATEWAY_MODELS_FIELD_REGISTRY,
-        "connection",
-        filterOptions.connection,
-      ),
-    [filterOptions.connection],
-  );
-  const connectionIdByName = useMemo(
-    () =>
-      new Map(
-        filterOptions.connection.map(({ value, displayValue }) => [
-          displayValue,
-          value,
-        ]),
-      ),
-    [filterOptions.connection],
-  );
-  const observedOptions = useMemo(
-    () =>
-      toObservedOptions(
-        {
-          ...filterOptions,
-          connection: filterOptions.connection.map(
-            ({ displayValue }) => displayValue,
-          ),
-        },
-        isLoading,
-      ),
-    [filterOptions, isLoading],
-  );
   const queryFilter = useSidebarFilterState(
     gatewayModelsFilterConfig,
     filterOptions,
     {
       stateLocation: "url",
     },
+  );
+  const retainedConnectionIds = useMemo(
+    () =>
+      queryFilter.filterState.flatMap((filter) =>
+        filter.column === "connection" && filter.type === "arrayOptions"
+          ? filter.value
+          : [],
+      ),
+    [queryFilter.filterState],
+  );
+  const connectionSearchOptions = useMemo(
+    () =>
+      getGatewayModelConnectionSearchOptions(
+        filterOptions.connection,
+        retainedConnectionIds,
+      ),
+    [filterOptions.connection, retainedConnectionIds],
+  );
+  const searchRegistry = useMemo(
+    () =>
+      withFieldOptions(
+        GATEWAY_MODELS_FIELD_REGISTRY,
+        "connection",
+        connectionSearchOptions.registryOptions,
+      ),
+    [connectionSearchOptions.registryOptions],
+  );
+  const observedOptions = useMemo(
+    () =>
+      toObservedOptions(
+        {
+          ...filterOptions,
+          connection: connectionSearchOptions.observedValues,
+        },
+        isLoading,
+      ),
+    [connectionSearchOptions.observedValues, filterOptions, isLoading],
   );
   const filteredModels = useMemo(
     () => filterGatewayModels(models, searchQuery, queryFilter.filterState),
@@ -228,7 +234,10 @@ export function GatewayModelsView({
                     ? {
                         ...filter,
                         value: filter.value.map(
-                          (value) => connectionIdByName.get(value) ?? value,
+                          (value) =>
+                            connectionSearchOptions.connectionIdByDisplayValue.get(
+                              value,
+                            ) ?? value,
                         ),
                       }
                     : filter,

--- a/web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/fns/getGatewayModelConnectionSearchOptions.clienttest.ts
+++ b/web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/fns/getGatewayModelConnectionSearchOptions.clienttest.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { GATEWAY_MODELS_FIELD_REGISTRY } from "@/src/features/ai-gateway/constants/modelsSearchRegistry";
+import {
+  filterStateToQueryText,
+  planCommit,
+  withFieldOptions,
+} from "@/src/features/search-bar";
+import { getGatewayModelConnectionSearchOptions } from "./getGatewayModelConnectionSearchOptions";
+
+describe("getGatewayModelConnectionSearchOptions", () => {
+  it("keeps duplicate credential names tied to their connection IDs", () => {
+    const result = getGatewayModelConnectionSearchOptions(
+      [
+        { value: "connection-a", displayValue: "Production" },
+        { value: "connection-b", displayValue: "Production" },
+      ],
+      [],
+    );
+
+    expect(result.observedValues).toEqual([
+      "Production (connection-a)",
+      "Production (connection-b)",
+    ]);
+    expect(
+      result.connectionIdByDisplayValue.get("Production (connection-a)"),
+    ).toBe("connection-a");
+    expect(
+      result.connectionIdByDisplayValue.get("Production (connection-b)"),
+    ).toBe("connection-b");
+
+    const registry = withFieldOptions(
+      GATEWAY_MODELS_FIELD_REGISTRY,
+      "connection",
+      result.registryOptions,
+    );
+    const query = filterStateToQueryText(
+      [
+        {
+          column: "connection",
+          type: "arrayOptions",
+          operator: "any of",
+          value: ["connection-a"],
+        },
+      ],
+      {},
+      registry,
+    ).text;
+    const commit = planCommit(`${query} provider:OPENAI`, undefined, registry);
+
+    expect(query).toBe('connection:"Production (connection-a)"');
+    expect(commit).toMatchObject({
+      status: "committed",
+      filters: [
+        {
+          column: "connection",
+          value: ["Production (connection-a)"],
+        },
+        { column: "provider", value: ["OPENAI"] },
+      ],
+    });
+    if (commit.status !== "committed") return;
+    const connectionFilter = commit.filters.find(
+      (filter) => filter.column === "connection",
+    );
+    expect(connectionFilter?.type).toBe("arrayOptions");
+    if (connectionFilter?.type !== "arrayOptions") return;
+    expect(
+      result.connectionIdByDisplayValue.get(connectionFilter.value[0]!),
+    ).toBe("connection-a");
+  });
+
+  it("keeps unavailable connection IDs valid", () => {
+    const result = getGatewayModelConnectionSearchOptions(
+      [{ value: "connection-a", displayValue: "Production" }],
+      ["connection-missing"],
+    );
+
+    expect(result.registryOptions).toContainEqual({
+      value: "connection-missing",
+      displayValue: "connection-missing",
+    });
+    expect(result.connectionIdByDisplayValue.get("connection-missing")).toBe(
+      "connection-missing",
+    );
+
+    const registry = withFieldOptions(
+      GATEWAY_MODELS_FIELD_REGISTRY,
+      "connection",
+      result.registryOptions,
+    );
+    const query = filterStateToQueryText(
+      [
+        {
+          column: "connection",
+          type: "arrayOptions",
+          operator: "any of",
+          value: ["connection-missing"],
+        },
+      ],
+      {},
+      registry,
+    ).text;
+
+    expect(
+      planCommit(`${query} provider:OPENAI`, undefined, registry).status,
+    ).toBe("committed");
+  });
+});

--- a/web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/fns/getGatewayModelConnectionSearchOptions.ts
+++ b/web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/fns/getGatewayModelConnectionSearchOptions.ts
@@ -1,0 +1,39 @@
+type ConnectionOption = {
+  value: string;
+  displayValue: string;
+};
+
+export function getGatewayModelConnectionSearchOptions(
+  connectionOptions: ConnectionOption[],
+  retainedConnectionIds: string[],
+) {
+  const nameCounts = new Map<string, number>();
+  for (const { displayValue } of connectionOptions) {
+    nameCounts.set(displayValue, (nameCounts.get(displayValue) ?? 0) + 1);
+  }
+
+  const labeledOptions = connectionOptions.map(({ value, displayValue }) => ({
+    value,
+    displayValue:
+      nameCounts.get(displayValue) === 1
+        ? displayValue
+        : `${displayValue} (${value})`,
+  }));
+  const availableIds = new Set(connectionOptions.map(({ value }) => value));
+  const fallbackOptions = retainedConnectionIds
+    .filter((value) => !availableIds.has(value))
+    .map((value) => ({ value, displayValue: value }));
+  const registryOptions = [
+    ...connectionOptions.map(({ value }) => ({ value, displayValue: value })),
+    ...labeledOptions,
+    ...fallbackOptions,
+  ];
+
+  return {
+    registryOptions,
+    observedValues: labeledOptions.map(({ displayValue }) => displayValue),
+    connectionIdByDisplayValue: new Map(
+      registryOptions.map(({ value, displayValue }) => [displayValue, value]),
+    ),
+  };
+}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17351 app preview](https://pr-17351.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- show provider credential names in the Gateway model search bar instead of internal IDs
- keep internal IDs in filter state so existing links and filtering stay stable
- suggest credential names when writing a connection filter
- route cross-feature imports through their public surfaces

## Impacted package
- `web`

## Verification
- `pnpm --filter web run test-client 'src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/filterGatewayModels.clienttest.ts'`
- `pnpm --filter web run test-storybook 'src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/GatewayModelsView.stories.tsx'`
- `pnpm exec turbo run lint --filter=web --force`
- `pnpm exec prettier --check 'web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/GatewayModelsView.tsx'`
- `git diff --check`

## Manual test
1. Open Organization settings → AI Gateway → Models.
2. Select or exclude one provider credential in the filter sidebar.
3. Confirm the search bar shows the credential name, while filtering still returns the expected models.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63055832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 3/5</h2>

Fix connection identity preservation and canonical-ID validation before merging.

<details open><summary><h3>Summary</h3></summary>

- Duplicate credential names can cause a search-bar edit to switch the selected connection.
- Filters referencing credentials absent from current model results become invalid in the search editor.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(gateway): show credential names in m..."](https://github.com/langfuse/langfuse/commit/3679ab94336c8d510626754375cc636365ba8f22)</sub>

<!-- /greptile_comment -->