### PR TITLE
perf(filter-options): accelerate metadata equality with a text-index prefilter

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/fts.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/fts.ts
@@ -109,13 +109,22 @@ const ftsTextIndexedSubstringCondition = (
 ): string =>
   `(position(${normalizeFtsTextExpr(fieldExpr)}, ${normalizeFtsTextExpr(valueParam)}) > 0 AND ${ftsTextTokenPredicate(fieldExpr, valueParam)})`;
 
-const ftsMetadataArrayHas = (arrayExpr: string, valueParam: string): string =>
-  `has(${arrayExpr}, ${valueParam})`;
-
 const ftsMetadataArrayTokenConjunct = (
   arrayExpr: string,
   valueParam: string,
 ): string => ftsTokenPrefilterPredicate(arrayExpr, valueParam, false);
+
+// Text-index prefilter for exact metadata equality. The stored value equals the
+// search value, so it trivially contains all of the value's tokens: a
+// correctness-safe superset that engages `idx_fts_metadata_values`. Guard against
+// tokenless values (e.g. "!!!"), where `tokens()` is empty and the prefilter
+// would otherwise exclude legitimate matches; the exact `= value` check remains
+// the precise post-filter. Metadata is case-sensitive, so tokens are not lowered.
+const ftsMetadataArrayEqualityTokenConjunct = (
+  arrayExpr: string,
+  valueParam: string,
+): string =>
+  `(empty(${ftsSearchTokensExpr(valueParam, false)}) OR ${ftsMetadataArrayTokenConjunct(arrayExpr, valueParam)})`;
 
 type FtsMetadataArrayConditionContext = {
   hasKey: string;
@@ -155,7 +164,7 @@ export const FTS_OPERATOR_DESCRIPTORS = {
       valueAccessor,
       valueParam,
     }) =>
-      `${hasKey} AND ${ftsMetadataArrayHas(valuesColumn, valueParam)} AND (${valueAccessor} = ${valueParam})`,
+      `${hasKey} AND ${ftsMetadataArrayEqualityTokenConjunct(valuesColumn, valueParam)} AND (${valueAccessor} = ${valueParam})`,
   },
   [FTS_MATCH_OPERATOR]: {
     textCondition: (fieldExpr, valueParam, _exactCondition) =>

--- a/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
+++ b/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
@@ -516,6 +516,37 @@ describe("createFilterFromFilterState filter type validation", () => {
     expect(Object.values(params)).toEqual(["source", "needle"]);
   });
 
+  it("accelerates event metadata equality with a text-index prefilter", () => {
+    const filters = [
+      {
+        column: "metadata",
+        type: "stringObject",
+        operator: "=",
+        key: "source",
+        value: "needle",
+      },
+    ] satisfies EventsTableFilterState;
+
+    const [result] = createFilterFromFilterState(
+      filters,
+      [mappings.eventMetadata],
+      columnDefinitions,
+    );
+
+    const { query, params } = result.apply();
+
+    expect(query).toContain("has(e.metadata_names,");
+    // `hasAllTokens` engages idx_fts_metadata_values as a correctness-safe superset.
+    expect(query).toContain("hasAllTokens(e.metadata_values,");
+    // Exact equality remains the precise post-filter.
+    expect(query).toContain("e.metadata_values[indexOf(e.metadata_names,");
+    // Equality is served by the index alone; no non-indexed array scan.
+    expect(query).not.toMatch(/has\(e\.metadata_values,/);
+    // Metadata is case-sensitive: tokens are not lowered.
+    expect(query).not.toContain("lower(");
+    expect(Object.values(params)).toEqual(["source", "needle"]);
+  });
+
   it("adds ngram prefilter params for event metadata substring filters", () => {
     const filters = [
       {

--- a/web/src/__tests__/server/fts-rewrites.servertest.ts
+++ b/web/src/__tests__/server/fts-rewrites.servertest.ts
@@ -217,7 +217,9 @@ maybeEventsTable("FTS filter rewrites", () => {
       }).apply();
 
       if (operator === "=") {
-        expect(rewritten.query).toContain("has(e.metadata_values,");
+        // Equality prefilters with the text index; no non-indexed array scan.
+        expect(rewritten.query).toContain("hasAllTokens(e.metadata_values,");
+        expect(rewritten.query).not.toMatch(/has\(e\.metadata_values,/);
       } else if (NGRAM_METADATA_OPERATORS.has(operator)) {
         expect(rewritten.query).toContain(
           "like(arrayStringConcat(e.metadata_values),",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17353 app preview](https://pr-17353.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Metadata `=` filters on the events table pruned `metadata_values` only through the key predicate: the value check was `has(metadata_values, v)`, which engages no data-skipping index (there is no `bloom_filter` on `metadata_values`, and `text()` does not serve `has()` element-equality).

This adds a `hasAllTokens(metadata_values, arraySlice(arrayDistinct(tokens(v)), 1, 64))` prefilter to the equality branch, reusing the same 64-token slice the `matches` branch already uses. For exact equality the stored value equals `v`, so it trivially contains all of `v`'s tokens — `hasAllTokens` is a correctness-safe superset that engages the `text()` index (`idx_fts_metadata_values`), while the exact `= v` check stays the precise post-filter. Tokenless values (e.g. `!!!`) are guarded with `empty(tokens(v)) OR ...` so equality still matches them, mirroring the existing text `=` path.

The now-redundant non-indexed `has(metadata_values, v)` array scan is dropped (it was implied by the exact `= v` check).

Prod `EXPLAIN indexes=1` on a selective value showed the text/`hasAllTokens` path pruning ~20× harder than the ngram `like` (54→2 vs 68→43 granules).

Scope: opportunistic latency/cost improvement (metadata `=` was not a timeout class). No index or migration changes. Deliberately not extended to `contains`/`starts with`/`ends with`, where `hasAllTokens` is not a correctness-safe superset for substring.

## Type of change

- [x] Performance improvement

## Checklist

- [x] Unit test pins the new equality SQL shape (`createFilterFromFilterState-filterTypeValidation.servertest.ts`)
- [x] `lint`, `typecheck`, and `knip` pass

🤖 Written by Claude (an AI agent) on behalf of Niklas


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63058765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The implementation appears safe to merge, with a non-blocking test-coverage gap around the new guard and token bound.

<details open><summary><h3>Summary</h3></summary>

- Adds an empty-token guard so punctuation-only values continue to match.
- Reuses the existing 64-token prefilter limit and case-sensitive metadata behavior.
- Adds a generated-SQL test for the event metadata equality path, though it does not pin all newly introduced safeguards.
</details>

<sub>Reviews (1) · Last reviewed commit: ["perf(filter-options): accelerate metadat..."](https://github.com/langfuse/langfuse/commit/ea5e8defc9f9ee4a0a762be9c990eb04defa6d81)</sub>

<!-- /greptile_comment -->