### PR TITLE
feat(observations): require a prunable companion for input/output content filters

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.events-full-routing.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.events-full-routing.test.ts
@@ -2,13 +2,16 @@ import { describe, expect, it } from "vitest";
 
 import {
   BooleanObjectFilter,
+  DateTimeFilter,
   FilterList,
   filtersRequireEventsFull,
+  inputOutputContentFilterMissingCompanion,
   metadataFilterIsEventsCoreSafe,
   NullFilter,
   NumberObjectFilter,
   StringFilter,
   StringObjectFilter,
+  StringOptionsFilter,
 } from "./clickhouse-filter";
 
 // events_core_mv truncates metadata values to leftUTF8(v, 200), so the safety
@@ -197,5 +200,188 @@ describe("filtersRequireEventsFull input/output routing", () => {
         ]),
       ),
     ).toBe(true);
+  });
+});
+
+const ioFilter = (
+  operator: StringFilter["operator"],
+  field: "input" | "output" = "output",
+) =>
+  new StringFilter({
+    clickhouseTable: "events_full",
+    field,
+    operator,
+    value: "needle",
+  });
+
+const idFilter = (
+  field: "trace_id" | "span_id" | "user_id" | "session_id",
+  operator: StringFilter["operator"] = "=",
+) =>
+  new StringFilter({
+    clickhouseTable: "events_full",
+    field,
+    operator,
+    value: "id-value",
+  });
+
+const idAnyOfFilter = (
+  field: "trace_id" | "span_id" | "user_id" | "session_id",
+) =>
+  new StringOptionsFilter({
+    clickhouseTable: "events_full",
+    field,
+    operator: "any of",
+    values: ["id-value"],
+  });
+
+const startTime = (operator: DateTimeFilter["operator"], value: Date) =>
+  new DateTimeFilter({
+    clickhouseTable: "events_full",
+    field: "start_time",
+    operator,
+    value,
+  });
+
+const T0 = new Date("2026-01-01T00:00:00.000Z");
+const plusDays = (base: Date, days: number) =>
+  new Date(base.getTime() + days * 24 * 60 * 60 * 1000);
+
+describe("inputOutputContentFilterMissingCompanion", () => {
+  it("returns false when there is no input/output substring scan", () => {
+    expect(
+      inputOutputContentFilterMissingCompanion(
+        new FilterList([idFilter("trace_id")]),
+      ),
+    ).toBe(false);
+  });
+
+  it("treats an input/output exact `=` as index-accelerated (not a scan)", () => {
+    expect(
+      inputOutputContentFilterMissingCompanion(new FilterList([ioFilter("=")])),
+    ).toBe(false);
+  });
+
+  it("treats input/output `is not empty` as a plain non-scan check", () => {
+    expect(
+      inputOutputContentFilterMissingCompanion(
+        new FilterList([ioFilter("is not empty")]),
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    "contains",
+    "does not contain",
+    "matches",
+    "starts with",
+    "ends with",
+  ] as const)("flags a lone input/output `%s` scan", (operator) => {
+    expect(
+      inputOutputContentFilterMissingCompanion(
+        new FilterList([ioFilter(operator)]),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts an exact `=` on input/output as a companion for a sibling scan", () => {
+    expect(
+      inputOutputContentFilterMissingCompanion(
+        new FilterList([
+          ioFilter("contains", "input"),
+          ioFilter("=", "output"),
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it.each(["trace_id", "span_id", "user_id", "session_id"] as const)(
+    "accepts a `%s` equality companion",
+    (field) => {
+      expect(
+        inputOutputContentFilterMissingCompanion(
+          new FilterList([ioFilter("matches"), idFilter(field)]),
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it.each(["trace_id", "span_id", "user_id", "session_id"] as const)(
+    "accepts a `%s` `any of` (IN) companion",
+    (field) => {
+      expect(
+        inputOutputContentFilterMissingCompanion(
+          new FilterList([ioFilter("matches"), idAnyOfFilter(field)]),
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it("does not accept a non-equality id companion", () => {
+    expect(
+      inputOutputContentFilterMissingCompanion(
+        new FilterList([ioFilter("matches"), idFilter("trace_id", "contains")]),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not accept a non-selective column equality (e.g. name)", () => {
+    expect(
+      inputOutputContentFilterMissingCompanion(
+        new FilterList([
+          ioFilter("matches"),
+          new StringFilter({
+            clickhouseTable: "events_full",
+            field: "name",
+            operator: "=",
+            value: "chat",
+          }),
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a metadata equality companion", () => {
+    expect(
+      inputOutputContentFilterMissingCompanion(
+        new FilterList([ioFilter("matches"), metadataString("=", "value")]),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not accept a metadata substring as a companion", () => {
+    expect(
+      inputOutputContentFilterMissingCompanion(
+        new FilterList([ioFilter("matches"), metadataString("contains", "v")]),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a lower-bound-only start_time window", () => {
+    expect(
+      inputOutputContentFilterMissingCompanion(
+        new FilterList([ioFilter("matches"), startTime(">=", T0)]),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects an upper-bound-only start_time window", () => {
+    expect(
+      inputOutputContentFilterMissingCompanion(
+        new FilterList([ioFilter("matches"), startTime("<", T0)]),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a both-ends start_time window of any span", () => {
+    expect(
+      inputOutputContentFilterMissingCompanion(
+        new FilterList([
+          ioFilter("matches"),
+          startTime(">=", T0),
+          startTime("<", plusDays(T0, 90)),
+        ]),
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.events-full-routing.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.events-full-routing.test.ts
@@ -357,12 +357,12 @@ describe("inputOutputContentFilterMissingCompanion", () => {
     ).toBe(true);
   });
 
-  it("rejects a lower-bound-only start_time window", () => {
+  it("accepts a start_time lower bound alone (no end timestamp required)", () => {
     expect(
       inputOutputContentFilterMissingCompanion(
         new FilterList([ioFilter("matches"), startTime(">=", T0)]),
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("rejects an upper-bound-only start_time window", () => {
@@ -373,7 +373,7 @@ describe("inputOutputContentFilterMissingCompanion", () => {
     ).toBe(true);
   });
 
-  it("accepts a both-ends start_time window of any span", () => {
+  it("accepts a both-ends start_time window", () => {
     expect(
       inputOutputContentFilterMissingCompanion(
         new FilterList([

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -858,7 +858,7 @@ export const filtersRequireEventsFull = (filters: FilterList): boolean =>
 // gates that funnel into this path — the public-API indexed-operator check
 // (which blesses an exact `=` on input/output, index-accelerated via the text
 // token index) and the MCP expensive-access check (which blesses an id-list, a
-// traceId, or any both-ends start_time window) — so a request those gates admit
+// traceId, or a both-ends start_time window) — so a request those gates admit
 // is never contradicted here.
 
 // Equality (`=`) or IN (`any of`) on these columns hits a bloom_filter skipping
@@ -892,34 +892,26 @@ const isSelectiveIdCompanion = (filter: Filter): boolean =>
 const isMetadataEqualityFilter = (filter: Filter): boolean =>
   filter.operator === "=" && isFtsMetadataField(filter.field);
 
-// True when start_time is bounded on both ends (any span). Bounding is the
-// nudge; we intentionally do not cap the span, both because we cannot know a
-// safe span at build time and to stay consistent with the upstream MCP gate,
-// which accepts any both-ends window.
-const hasBothEndsStartTimeWindow = (filters: FilterList): boolean => {
-  let hasLower = false;
-  let hasUpper = false;
-  filters.forEach((filter) => {
-    if (
-      !(filter instanceof DateTimeFilter) ||
-      bareFtsField(filter.field) !== "start_time"
-    ) {
-      return;
-    }
-    if (filter.operator === ">" || filter.operator === ">=") {
-      hasLower = true;
-    } else if (filter.operator === "<" || filter.operator === "<=") {
-      hasUpper = true;
-    }
-  });
-  return hasLower && hasUpper;
-};
+// True when start_time carries a lower bound (`>=`/`>`). We require only the
+// lower bound, not a matching upper bound: forcing an end timestamp pushes
+// callers to synthesize a `now` value they do not actually want, and a lower
+// bound already prunes granules below it. We do not cap the span because we
+// cannot know a safe span at build time. On plans with a data-access retention
+// floor the endpoint injects this lower bound, so their scans are inherently
+// retention-bounded; unlimited plans must supply their own.
+const hasStartTimeLowerBound = (filters: FilterList): boolean =>
+  filters.some(
+    (filter) =>
+      filter instanceof DateTimeFilter &&
+      bareFtsField(filter.field) === "start_time" &&
+      (filter.operator === ">" || filter.operator === ">="),
+  );
 
 /**
  * True when the filter list contains an input/output substring scan but no
  * companion filter the events_full indexes can prune on (an exact `=` on
  * input/output, an equality/IN on an indexed id column, a metadata equality, or
- * a both-ends start_time window). The caller decides how to react.
+ * a start_time lower bound). The caller decides how to react.
  */
 export const inputOutputContentFilterMissingCompanion = (
   filters: FilterList,
@@ -933,6 +925,6 @@ export const inputOutputContentFilterMissingCompanion = (
         isIoEqualityCompanion(filter) ||
         isSelectiveIdCompanion(filter) ||
         isMetadataEqualityFilter(filter),
-    ) || hasBothEndsStartTimeWindow(filters);
+    ) || hasStartTimeLowerBound(filters);
   return !hasCompanion;
 };

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -8,6 +8,7 @@ import { clickhouseCompliantRandomCharacters } from "../../repositories";
 import { escapeSqlLikePattern } from "../../utils/sqlLike";
 import {
   assertValidFtsMatchFilter,
+  bareFtsField,
   FTS_OPERATOR_DESCRIPTORS,
   isFtsEventsTable,
   isFtsMetadataField,
@@ -844,3 +845,94 @@ const filterRequiresEventsFull = (filter: Filter): boolean => {
 
 export const filtersRequireEventsFull = (filters: FilterList): boolean =>
   filters.some(filterRequiresEventsFull);
+
+// An input/output substring search (`contains`/`matches`/`starts with`/... →
+// position()/startsWith()) scans the largest events_full columns and has no
+// index that reliably prunes for common tokens, so on its own it is a confirmed
+// timeout class. We cannot know a value's true selectivity at build time, so
+// the mitigation is deliberately weak and structural: require the caller to
+// pair the substring filter with *some* predicate the events_full indexes can
+// prune on, keeping the scan over a smaller candidate set. It nudges; it does
+// not guarantee selectivity (a non-selective id/metadata value still slips
+// through). The accepted companions are a superset of the two upstream scope
+// gates that funnel into this path — the public-API indexed-operator check
+// (which blesses an exact `=` on input/output, index-accelerated via the text
+// token index) and the MCP expensive-access check (which blesses an id-list, a
+// traceId, or any both-ends start_time window) — so a request those gates admit
+// is never contradicted here.
+
+// Equality (`=`) or IN (`any of`) on these columns hits a bloom_filter skipping
+// index on events_full.
+const SELECTIVE_ID_COMPANION_FIELDS: ReadonlySet<string> = new Set([
+  "trace_id",
+  "span_id",
+  "user_id",
+  "session_id",
+]);
+
+// Operators on input/output that do NOT scan: an exact `=` prunes via the text
+// token index, and `is not empty` compiles to a plain `!= ''` check.
+const NON_SCAN_IO_OPERATORS: ReadonlySet<ClickhouseOperator> = new Set([
+  "=",
+  "is not empty",
+]);
+
+const isIoContentScanFilter = (filter: Filter): boolean =>
+  isFtsTextField(filter.field) && !NON_SCAN_IO_OPERATORS.has(filter.operator);
+
+// An exact `=` on input/output is itself index-accelerated (text token index),
+// so it prunes a sibling substring scan to a small candidate set.
+const isIoEqualityCompanion = (filter: Filter): boolean =>
+  isFtsTextField(filter.field) && filter.operator === "=";
+
+const isSelectiveIdCompanion = (filter: Filter): boolean =>
+  (filter.operator === "=" || filter.operator === "any of") &&
+  SELECTIVE_ID_COMPANION_FIELDS.has(bareFtsField(filter.field));
+
+const isMetadataEqualityFilter = (filter: Filter): boolean =>
+  filter.operator === "=" && isFtsMetadataField(filter.field);
+
+// True when start_time is bounded on both ends (any span). Bounding is the
+// nudge; we intentionally do not cap the span, both because we cannot know a
+// safe span at build time and to stay consistent with the upstream MCP gate,
+// which accepts any both-ends window.
+const hasBothEndsStartTimeWindow = (filters: FilterList): boolean => {
+  let hasLower = false;
+  let hasUpper = false;
+  filters.forEach((filter) => {
+    if (
+      !(filter instanceof DateTimeFilter) ||
+      bareFtsField(filter.field) !== "start_time"
+    ) {
+      return;
+    }
+    if (filter.operator === ">" || filter.operator === ">=") {
+      hasLower = true;
+    } else if (filter.operator === "<" || filter.operator === "<=") {
+      hasUpper = true;
+    }
+  });
+  return hasLower && hasUpper;
+};
+
+/**
+ * True when the filter list contains an input/output substring scan but no
+ * companion filter the events_full indexes can prune on (an exact `=` on
+ * input/output, an equality/IN on an indexed id column, a metadata equality, or
+ * a both-ends start_time window). The caller decides how to react.
+ */
+export const inputOutputContentFilterMissingCompanion = (
+  filters: FilterList,
+): boolean => {
+  if (!filters.some(isIoContentScanFilter)) {
+    return false;
+  }
+  const hasCompanion =
+    filters.some(
+      (filter) =>
+        isIoEqualityCompanion(filter) ||
+        isSelectiveIdCompanion(filter) ||
+        isMetadataEqualityFilter(filter),
+    ) || hasBothEndsStartTimeWindow(filters);
+  return !hasCompanion;
+};

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -20,6 +20,7 @@ export {
   NullFilter,
   encodeBooleanScoreEntry,
   filtersRequireEventsFull,
+  inputOutputContentFilterMissingCompanion,
   metadataFilterIsEventsCoreSafe,
   type ClickhouseOperator,
 } from "./clickhouse-sql/clickhouse-filter";

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -1424,7 +1424,7 @@ const IO_CONTENT_FILTER_COMPANION_ERROR =
   "with`) must be combined with at least one of: an equality or `any of` " +
   "filter on trace_id, span_id (id), user_id, or session_id; a metadata " +
   "equality (`=`) filter; an exact `=` match on input/output; or a start_time " +
-  "window bounded on both ends. These columns are the largest on the events " +
+  "lower bound (fromStartTime). These columns are the largest on the events " +
   "table and have no index that reliably prunes a substring scan, so an " +
   "unpaired content filter reads the full table and times out.";
 

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -46,6 +46,7 @@ import {
   createPublicApiTracesColumnMapping,
   deriveFilters,
   filtersRequireEventsFull,
+  inputOutputContentFilterMissingCompanion,
   isFtsAcceleratedIoOperator,
   isFtsEventsTable,
   isFtsTextField,
@@ -1418,6 +1419,25 @@ const validateIndexedInputOutputFilters = (filter: FilterList) => {
   }
 };
 
+const IO_CONTENT_FILTER_COMPANION_ERROR =
+  "Input/output substring filters (`contains`/`matches`/`starts with`/`ends " +
+  "with`) must be combined with at least one of: an equality or `any of` " +
+  "filter on trace_id, span_id (id), user_id, or session_id; a metadata " +
+  "equality (`=`) filter; an exact `=` match on input/output; or a start_time " +
+  "window bounded on both ends. These columns are the largest on the events " +
+  "table and have no index that reliably prunes a substring scan, so an " +
+  "unpaired content filter reads the full table and times out.";
+
+// Reject an input/output content scan that is not paired with a companion
+// filter the events_full indexes can prune on. See
+// inputOutputContentFilterMissingCompanion for why this is a weak nudge rather
+// than a real selectivity guarantee.
+const validateInputOutputContentFilterHasCompanion = (filter: FilterList) => {
+  if (inputOutputContentFilterMissingCompanion(filter)) {
+    throw new InvalidRequestError(IO_CONTENT_FILTER_COMPANION_ERROR);
+  }
+};
+
 /**
  * Build observation query components: an EventsQueryBuilder (with JOINs and filters but
  * without CTEs) and any external CTEs that should be composed at the outer level.
@@ -1453,6 +1473,7 @@ function buildObservationsQueryComponents(
 
   if (!options.allowUnindexedIoFilters) {
     validateIndexedInputOutputFilters(observationsFilter);
+    validateInputOutputContentFilterHasCompanion(observationsFilter);
   }
 
   // Determine if we need to join traces (check both simple params and advanced filters)

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -1158,12 +1158,11 @@ describe("/api/public/v2/observations API Endpoint", () => {
         expect.arrayContaining([tokenMatchId, punctuationMatchId]),
       );
 
-      // A both-ends start_time window is a valid companion without traceId.
+      // A start_time lower bound alone is a valid companion (no end timestamp
+      // required) without traceId.
       const ioWindowResponse = await getObservations(
         `/api/public/v2/observations?fields=basic,io&fromStartTime=${encodeURIComponent(
           new Date(timestamp.getTime() - 1000).toISOString(),
-        )}&toStartTime=${encodeURIComponent(
-          new Date(timestamp.getTime() + 60000).toISOString(),
         )}&filter=${encodeURIComponent(ioFilterParam)}`,
       );
       expect(ioWindowResponse.status).toBe(200);

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -1134,6 +1134,43 @@ describe("/api/public/v2/observations API Endpoint", () => {
       );
       expect(ioIds).not.toContain(embeddedOnlyId);
 
+      // An `id any of` list is a valid companion for the content scan even
+      // without traceId (mirrors the MCP expensive-access scope).
+      const ioIdListFilterParam = JSON.stringify([
+        {
+          type: "string",
+          column: "output",
+          operator: "matches",
+          value: "needle",
+        },
+        {
+          type: "stringOptions",
+          column: "id",
+          operator: "any of",
+          value: [tokenMatchId, punctuationMatchId],
+        },
+      ]);
+      const ioIdListResponse = await getObservations(
+        `/api/public/v2/observations?fields=basic,io&filter=${encodeURIComponent(ioIdListFilterParam)}`,
+      );
+      expect(ioIdListResponse.status).toBe(200);
+      expect(ioIdListResponse.body.data.map((obs: any) => obs.id)).toEqual(
+        expect.arrayContaining([tokenMatchId, punctuationMatchId]),
+      );
+
+      // A both-ends start_time window is a valid companion without traceId.
+      const ioWindowResponse = await getObservations(
+        `/api/public/v2/observations?fields=basic,io&fromStartTime=${encodeURIComponent(
+          new Date(timestamp.getTime() - 1000).toISOString(),
+        )}&toStartTime=${encodeURIComponent(
+          new Date(timestamp.getTime() + 60000).toISOString(),
+        )}&filter=${encodeURIComponent(ioFilterParam)}`,
+      );
+      expect(ioWindowResponse.status).toBe(200);
+      expect(ioWindowResponse.body.data.map((obs: any) => obs.id)).toEqual(
+        expect.arrayContaining([tokenMatchId, punctuationMatchId]),
+      );
+
       const ioPhraseFilterParam = JSON.stringify([
         {
           type: "string",
@@ -1209,6 +1246,26 @@ describe("/api/public/v2/observations API Endpoint", () => {
       );
       expect(containsOnlyResponse.status).toBe(400);
 
+      // An indexed `matches` scan without a companion the events indexes can
+      // prune on still reads the full table, so it is rejected.
+      const matchesOnlyFilter = JSON.stringify([
+        {
+          type: "string",
+          column: "output",
+          operator: "matches",
+          value: "needle",
+        },
+      ]);
+      const matchesOnlyResponse = await getRaw(
+        `/api/public/v2/observations?fields=basic&filter=${encodeURIComponent(matchesOnlyFilter)}`,
+      );
+      expect(matchesOnlyResponse.status).toBe(400);
+      expect(JSON.stringify(matchesOnlyResponse.body)).toContain(
+        "must be combined with",
+      );
+
+      // An indexed `matches` without a companion still reads the full table,
+      // so an IO content scan is rejected on its own.
       const matchesAndContainsFilter = JSON.stringify([
         {
           type: "string",
@@ -1226,7 +1283,10 @@ describe("/api/public/v2/observations API Endpoint", () => {
       const matchesAndContainsResponse = await getRaw(
         `/api/public/v2/observations?fields=basic&filter=${encodeURIComponent(matchesAndContainsFilter)}`,
       );
-      expect(matchesAndContainsResponse.status).toBe(200);
+      expect(matchesAndContainsResponse.status).toBe(400);
+      expect(JSON.stringify(matchesAndContainsResponse.body)).toContain(
+        "must be combined with",
+      );
 
       const metadataMatchesAndIoContainsFilter = JSON.stringify([
         {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17358 app preview](https://pr-17358.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Content search on `input`/`output` (`contains`/`matches`/substring → `position()`) scans the largest `events_full` columns, and the text indexes prune weakly for common tokens. On its own such a filter is a confirmed full-table-scan / timeout class.

This adds a build-time guardrail: on the v2 public observations API and the MCP read path, an input/output substring filter is rejected (HTTP 400) unless it is paired with at least one companion the `events_full` indexes can prune on:

- an exact `=` on input/output (index-accelerated via the text token index),
- an equality or `any of` on `trace_id` / `span_id` (id) / `user_id` / `session_id`,
- a metadata `=`, or
- a `start_time` window bounded on both ends.

We cannot know a value's true selectivity at build time, so this is a deliberately structural **nudge**, not a selectivity guarantee — a non-selective id/metadata value still passes. The accepted companion set is a **superset** of the two upstream scope gates that already funnel into this path (the public-API indexed-operator check and the MCP expensive-access check), so any request those gates admit is never contradicted here.

The v1 public API path keeps its existing exemption (`allowUnindexedIoFilters: true`) for backwards compatibility, so this does not change v1 behavior. The v2 endpoint is preview-gated.

Note for reviewers: the v2 servertest suite is gated behind the preview env flag and is skipped in default CI; the always-on regression guard is the new unit coverage in `clickhouse-filter.events-full-routing.test.ts`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

Behavior note: this rejects some previously-accepted requests on the **preview** v2 API and MCP path (input/output substring filters without a companion). v1 and other GA endpoints are unchanged.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Added unit tests covering the companion classification (id `=`/`any of`, metadata `=`, io `=`, both-ends time window, non-scan operators) and API-seam assertions on the v2 endpoint.
- Ran `lint` and `typecheck` (both green) plus the shared unit suite.

---
🤖 Written by Claude (an AI agent) on behalf of Niklas

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63075200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no actionable correctness, security, or repository-rule violations were identified.

<details open><summary><h3>Summary</h3></summary>

- Classifies indexed ID, metadata, exact I/O, and bounded-time predicates as acceptable companions.
- Applies validation while constructing unified-events observation queries.
- Adds always-on unit coverage for companion classification and preview-gated API seam coverage for accepted and rejected requests.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Observation request] --> B[Derive events filters]
  B --> C{V1 compatibility exemption?}
  C -->|Yes| F[Build ClickHouse query]
  C -->|No| D{Input/output content scan?}
  D -->|No| F
  D -->|Yes| E{Indexed companion present?}
  E -->|Yes| F
  E -->|No| G[Reject request with HTTP 400]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat(observations): require a prunable c..."](https://github.com/langfuse/langfuse/commit/a55aadca6fcde37f83621eb71b6e850e93b9cfde)</sub>

<!-- /greptile_comment -->