### PR TITLE
fix(web): make timeline hover tree rows selectable

### DIFF
--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
@@ -657,8 +657,8 @@ export const HoverPeeksTheNames = meta.story({
 });
 
 /**
- * The peek is a navigation surface, not a caption. Clicking a name used to hit
- * the overlay and do nothing — selection only lived on the bars underneath.
+ * The peek is a navigation surface, not a caption. Clicking a name selects
+ * the observation the same way clicking the bar does.
  */
 export const PeekRowClickSelects = meta.story({
   name: "(Test) Peek Row Click Selects",

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
@@ -656,6 +656,57 @@ export const HoverPeeksTheNames = meta.story({
   },
 });
 
+/**
+ * The peek is a navigation surface, not a caption. Clicking a name used to hit
+ * the overlay and do nothing — selection only lived on the bars underneath.
+ */
+export const PeekRowClickSelects = meta.story({
+  name: "(Test) Peek Row Click Selects",
+  args: {
+    roots: manySpans(40),
+    box: PHONE,
+    gutter: "auto",
+    pointer: "fine",
+    barColor: "type",
+    compress: false,
+    showReadout: true,
+    selectedId: null,
+    onSelect: fn(),
+    onHover: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const surface = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="timeline-dense-surface"]',
+    );
+    if (!surface) throw new Error("dense surface not found");
+    const rect = surface.getBoundingClientRect();
+    surface.dispatchEvent(
+      new PointerEvent("pointermove", {
+        bubbles: true,
+        pointerType: "mouse",
+        clientX: rect.left + 4,
+        clientY: rect.top + 120,
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        canvasElement.querySelector('[data-testid="timeline-dense-peek-row"]'),
+      ).not.toBeNull(),
+    );
+
+    const peekRow = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="timeline-dense-peek-row"]',
+    );
+    if (!peekRow) throw new Error("expected a peek row to click");
+    peekRow.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, detail: 1 }),
+    );
+
+    await expect(args.onSelect).toHaveBeenCalledTimes(1);
+    await expect(args.onSelect).toHaveBeenCalledWith(expect.any(String));
+  },
+});
+
 export const DoubleClickFocusesBothAxes = meta.story({
   name: "(Test) Double Click Focuses Both Axes",
   args: {

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
@@ -1259,6 +1259,16 @@ export function TimelineDense({
     endGesture();
   }, [endGesture]);
 
+  /**
+   * Shared by the bar rows and the hover peek tree. Selecting is not free
+   * (analytics + reopen the detail panel), and a double-click's second click
+   * must not fire it again.
+   */
+  const selectRowOnClick = (event: { detail: number }, nodeId: string) => {
+    if (event.detail > 1 || focusedByTap.current) return;
+    onSelect(nodeId);
+  };
+
   /** Double-click an element: both axes move to put it on screen, readably. */
   const focusRow = (index: number) => {
     const positioned = result.nodes.find((node) => node.index === index);
@@ -1544,16 +1554,7 @@ export function TimelineDense({
                 )}
                 style={{ top: `${y}px`, height: `${rowHeight}px` }}
                 data-testid="timeline-dense-row"
-                // A double-click delivers TWO clicks, and selecting is not free:
-                // it captures an analytics event and reopens the detail panel.
-                // The first click of the pair already selected the row, so the
-                // second one only focuses.
-                onClick={(event) => {
-                  // A double-click delivers two clicks; a double-TAP delivers two
-                  // clicks that both look like the first one.
-                  if (event.detail > 1 || focusedByTap.current) return;
-                  onSelect(node.id);
-                }}
+                onClick={(event) => selectRowOnClick(event, node.id)}
                 onDoubleClick={() => focusRow(node.index)}
               >
                 <GutterContent
@@ -1694,7 +1695,7 @@ export function TimelineDense({
                 <div
                   key={node.id}
                   className={cn(
-                    "absolute inset-x-0",
+                    "absolute inset-x-0 cursor-pointer",
                     rowWashClass({
                       selected: node.id === selectedId,
                       focused: node.index === focusIndex,
@@ -1702,6 +1703,9 @@ export function TimelineDense({
                     }),
                   )}
                   style={{ top: `${y}px`, height: `${rowHeight}px` }}
+                  data-testid="timeline-dense-peek-row"
+                  onClick={(event) => selectRowOnClick(event, node.id)}
+                  onDoubleClick={() => focusRow(node.index)}
                 >
                   <GutterContent
                     node={node}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17360 app preview](https://pr-17360.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Hovering the left edge of the compact timeline reveals the observation tree as a peek overlay. That overlay sat on top of the bars and swallowed clicks, so the tree looked like navigation but did nothing.

Peek rows now use the same select/focus handlers as the timeline rows: a click selects the observation and opens the detail panel; a double-click focuses it in the viewport.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test-storybook src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx` — `Tests  58 passed (58)` (includes `(Test) Peek Row Click Selects`)
- Pre-commit lint/format on the two touched files
- Browser: seeded `timeline-shapes --v4 --shape deep-ladder`, hovered the left rail, clicked `refine-step-2` in the peek tree; URL gained `observation=…-obs-2` and the detail header switched to that observation
- Skipped root `typecheck` / knip: isolated click-handler change, no new exports

CI `all-ci-passed` is green. Preview: [pr-17360 app preview](https://pr-17360.preview.langfuse.com)

## Test this

1. Open [pr-17360 app preview](https://pr-17360.preview.langfuse.com) (or `http://localhost:3000`) and any nested trace.
2. Switch to **Timeline**.
3. If names are hidden, hover the left rail until the tree floats over the bars.
4. Click a child name. Expect the observation to select and the detail panel to open, same as clicking its bar.
5. Double-click a peek name. Expect the viewport to focus that row.

Data: demo project is enough, or `pnpm run seed -- timeline-shapes --v4 --shape deep-ladder`.

## Proof

![Hover peek tree showing observation names over the timeline](https://cursor.com/artifacts/c/art-756c6081-4d7d-428a-a3de-dcca2fa8e6e4)
![After clicking refine-step-2 in the peek tree, the observation is selected](https://cursor.com/artifacts/c/art-60bd4f7a-a55a-49e6-bb28-abc7cd81b8ea)
<a href="https://cursor.com/agents/bc-459f97d4-a13a-4e58-a82d-d7ce291a8e1a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftimeline_hover_tree_click_selects.mp4"><img src="https://cursor.com/artifacts/c/art-342fd354-0833-4e9c-a2ff-6b83150a02bb" alt="timeline_hover_tree_click_selects.mp4" /></a>

## What to doubt

- I reused the existing `trace_detail:node_selected` event with source `timeline_compact`. Check that a peek click should not be a distinct source.
- Single click only selects (and reveal-pans if needed). Zoom/focus is still double-click, matching the bars. Tell me if a peek click should also focus.
- Touch taps on the left rail still toggle the peek, not select. That is the existing coarse-pointer contract.

## Mandatory Tasks

- [x] Self-reviewed
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LF-165](https://linear.app/clickhouse/issue/LF-165/timeline-hover-trace-tree-should-be-clickable)

<div><a href="https://cursor.com/agents/bc-459f97d4-a13a-4e58-a82d-d7ce291a8e1a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-459f97d4-a13a-4e58-a82d-d7ce291a8e1a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63076228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable correctness, security, or repository-rule violations identified.

<details open><summary><h3>Summary</h3></summary>

- A single click selects the corresponding observation and opens its detail surface.
- A double-click focuses the observation in the timeline viewport.
- A Storybook interaction test verifies peek-row selection.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Hover timeline rail] --> B[Peek observation tree]
  B -->|Single click| C[Select observation]
  C --> D[Open detail panel]
  B -->|Double-click| E[Focus observation in viewport]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(web): describe peek-row click as cu..."](https://github.com/langfuse/langfuse/commit/543971c97e9d9341eff5212b9d811b695dd48055)</sub>

<!-- /greptile_comment -->