### PR TITLE
fix(ci): use Azure Ubuntu archive fallback

### DIFF
--- a/scripts/ci/install-playwright.sh
+++ b/scripts/ci/install-playwright.sh
@@ -6,7 +6,9 @@ readonly APT_MIRRORS_FILE="${PLAYWRIGHT_APT_MIRRORS_FILE:-/etc/apt/blacksmith-ub
 readonly APT_SOURCES_FILE="${PLAYWRIGHT_APT_SOURCES_FILE:-/etc/apt/sources.list.d/ubuntu.sources}"
 readonly APT_CONFIG_FILE="${PLAYWRIGHT_APT_CONFIG_FILE:-/etc/apt/apt.conf.d/80-playwright-network-retries}"
 readonly FALLBACK_MIRRORS=(
-  "https://azure.archive.ubuntu.com/ubuntu/"
+  "https://azure.archive.ubuntu.com/ubuntu/"$'\tpriority:0'
+  "https://mirror.pilotfiber.com/ubuntu/"$'\tpriority:1'
+  "https://mirror.tzulo.com/ubuntu/"$'\tpriority:1'
 )
 
 sudo tee "${APT_CONFIG_FILE}" > /dev/null <<'EOF'
@@ -14,9 +16,8 @@ Acquire::Retries "3";
 EOF
 
 if [[ -f "${APT_MIRRORS_FILE}" && -f "${APT_SOURCES_FILE}" ]]; then
-  # Prefer the Azure-hosted archive while Canonical's primary endpoints are degraded.
-  for mirror in "${FALLBACK_MIRRORS[@]}"; do
-    mirror_entry="${mirror}"$'\tpriority:0'
+  # Prefer the Azure-hosted archive, then fall back to independent mirrors.
+  for mirror_entry in "${FALLBACK_MIRRORS[@]}"; do
     if ! grep -Fqx "${mirror_entry}" "${APT_MIRRORS_FILE}"; then
       printf '%s\n' "${mirror_entry}" | sudo tee -a "${APT_MIRRORS_FILE}" > /dev/null
     fi

--- a/scripts/ci/install-playwright.sh
+++ b/scripts/ci/install-playwright.sh
@@ -5,9 +5,8 @@ set -euo pipefail
 readonly APT_MIRRORS_FILE="${PLAYWRIGHT_APT_MIRRORS_FILE:-/etc/apt/blacksmith-ubuntu-mirrors.txt}"
 readonly APT_SOURCES_FILE="${PLAYWRIGHT_APT_SOURCES_FILE:-/etc/apt/sources.list.d/ubuntu.sources}"
 readonly APT_CONFIG_FILE="${PLAYWRIGHT_APT_CONFIG_FILE:-/etc/apt/apt.conf.d/80-playwright-network-retries}"
-readonly COMMUNITY_MIRRORS=(
-  "https://mirror.pilotfiber.com/ubuntu/"
-  "https://mirror.tzulo.com/ubuntu/"
+readonly FALLBACK_MIRRORS=(
+  "https://azure.archive.ubuntu.com/ubuntu/"
 )
 
 sudo tee "${APT_CONFIG_FILE}" > /dev/null <<'EOF'
@@ -15,8 +14,8 @@ Acquire::Retries "3";
 EOF
 
 if [[ -f "${APT_MIRRORS_FILE}" && -f "${APT_SOURCES_FILE}" ]]; then
-  # Prefer the independent mirrors while Canonical's endpoints are degraded.
-  for mirror in "${COMMUNITY_MIRRORS[@]}"; do
+  # Prefer the Azure-hosted archive while Canonical's primary endpoints are degraded.
+  for mirror in "${FALLBACK_MIRRORS[@]}"; do
     mirror_entry="${mirror}"$'\tpriority:0'
     if ! grep -Fqx "${mirror_entry}" "${APT_MIRRORS_FILE}"; then
       printf '%s\n' "${mirror_entry}" | sudo tee -a "${APT_MIRRORS_FILE}" > /dev/null


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17362 app preview](https://pr-17362.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- add `azure.archive.ubuntu.com` as the preferred Ubuntu archive fallback
- retain the Pilot Fiber and tzulo mirrors as secondary fallbacks
- assign explicit priorities so APT tries Azure first and chooses between the backup mirrors only if needed

## Impacted areas

- CI Playwright dependency installation

## Verification

- `bash -n scripts/ci/install-playwright.sh`
- `shellcheck scripts/ci/install-playwright.sh`
- `git diff --check`
- mocked installer check for all prioritized mirror entries, the security source rewrite, and the Playwright command
- pre-commit formatting and lint checks

APT mirror priorities: https://manpages.ubuntu.com/manpages/noble/man1/apt-transport-mirror.1.html#Fallback_order_for_mirrors
