### PR TITLE
fix(charts): prevent compact axes from recursing across zero

### DIFF
--- a/web/src/features/widgets/chart-library/Chart.clienttest.tsx
+++ b/web/src/features/widgets/chart-library/Chart.clienttest.tsx
@@ -21,7 +21,11 @@ class ResizeObserverStub {
 (global as typeof globalThis & { ResizeObserver: unknown }).ResizeObserver =
   ResizeObserverStub;
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 const point = (metric: DataPoint["metric"], dimension?: string): DataPoint => ({
   time_dimension: "2026-01-01T00:00:00Z",
@@ -73,4 +77,42 @@ describe("Chart dispatcher — empty-state guard (LFE-14333)", () => {
     render(<Chart chartType="BAR_TIME_SERIES" data={[]} rowLimit={100} />);
     expect(screen.getByText("No data")).toBeInTheDocument();
   });
+});
+
+it("renders a compact bar chart whose values cross zero", () => {
+  const bounds = new DOMRect(0, 0, 500, 63);
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+    function (this: HTMLElement) {
+      return this.id === "recharts_measurement_span"
+        ? new DOMRect(0, 0, 8, 12)
+        : bounds;
+    },
+  );
+  vi.stubGlobal(
+    "ResizeObserver",
+    class implements ResizeObserver {
+      constructor(private readonly callback: ResizeObserverCallback) {}
+      observe(target: Element) {
+        this.callback(
+          [{ target, contentRect: bounds } as ResizeObserverEntry],
+          this,
+        );
+      }
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+
+  const { container } = render(
+    <Chart
+      chartType="VERTICAL_BAR"
+      data={[point(-1, "negative"), point(1, "positive")]}
+      rowLimit={100}
+      zeroBaseline
+      hideXAxisLabels
+    />,
+  );
+
+  expect(container.querySelectorAll(".recharts-bar-rectangle")).toHaveLength(2);
+  expect(screen.getByText("0")).toBeInTheDocument();
 });

--- a/web/src/features/widgets/chart-library/useChartTickBudget.ts
+++ b/web/src/features/widgets/chart-library/useChartTickBudget.ts
@@ -39,11 +39,12 @@ export function useChartTickBudget() {
       ? Math.max(2, Math.floor((size.width - AXIS_GUTTER_PX) / APPROX_LABEL_PX))
       : 6;
 
+  // Recharts needs at least three ticks when an axis crosses zero.
   const maxYTicks =
     size.height > 0
       ? Math.min(
           DEFAULT_Y_TICK_COUNT,
-          Math.max(2, Math.floor(size.height / APPROX_Y_LABEL_PX)),
+          Math.max(3, Math.floor(size.height / APPROX_Y_LABEL_PX)),
         )
       : DEFAULT_Y_TICK_COUNT;
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17365 app preview](https://pr-17365.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Keep compact bar charts from crashing when their values cross zero. Supersedes #17361.

## Why

A 63px chart can request only two Y-axis ticks. Recharts pins a tick at zero, so a domain such as `[-1, 1]` needs at least three ticks. Its attempt to fit two recurses until the stack overflows; interrupted Decimal calculations can also raise shared precision and cause later charts to throw `LN10 precision limit exceeded`.

## What

Require at least three Y ticks in the shared chart-size budget. Add one regression to the existing chart suite that renders the real compact bar chart and verifies both bars and the zero tick. This applies the constraint behind [Recharts' upstream fix](https://github.com/recharts/recharts/pull/7622) at the application boundary.

## Result

The same 63px chart with values −1 and +1 throws the LN10 error before this change and renders correctly afterward in Chrome. The failure is prevented at its source; existing error reporting remains intact.

<details>
<summary>Verification and reproduction</summary>

Impacted package: `web`.

- Regression confirmed failing before the fix: `Tests 1 failed | 5 passed (6)`, with `Maximum call stack size exceeded` in Recharts tick calculation.
- `pnpm --filter web run test-client src/features/widgets/chart-library/Chart.clienttest.tsx`: `Tests 6 passed (6)`.
- Production-mode browser bundles of the actual `VerticalBarChart` and `useChartTickBudget`: `Browser checks: 2 scenarios passed (actual component, 63px).` Before: LN10 error and no bars. After: two bars and labels −1, 0, +1, with no runtime errors.
- Formatting: `All matched files use Prettier code style!`.
- `pnpm run lint --force`: `Tasks: 8 successful, 8 total`; `Cached: 0 cached, 8 total`.
- `pnpm exec knip`: exit 0.
- GitHub Actions: `all-ci-passed` succeeded.
- `pnpm run format:check`: `All matched files use Prettier code style!`.

The exact negative/positive experiment-score shape is not available in the current seed CLI, so the regression uses a synthetic component fixture without database writes. No type or API contract changed; full application typecheck was not run.

Preview smoke verified at this commit: open the [app preview](https://pr-17365.preview.langfuse.com) to establish the demo session, then open [Home](https://pr-17365.preview.langfuse.com/project/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a) for populated score cards and a rendered chart, and [Experiments](https://pr-17365.preview.langfuse.com/project/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a/experiments) for the table/filter shell. Both pages returned HTTP 200 with no console or page errors. The preview seed has no experiment runs, so that page correctly shows its empty state; the focused automated test and browser fixture above reproduce the mixed-sign chart independently of preview data.

</details>


![Before: compact chart crashes with LN10 error](https://github.com/user-attachments/assets/879c86fd-a6f0-42e3-8103-aa1e3bc1d44f)

![After: both bars and the zero tick render at 63px](https://github.com/user-attachments/assets/03aef3a2-4dc9-45e5-897d-9245292746ac)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63088745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge and directly covers the reported compact mixed-sign chart failure.

<details open><summary><h3>Summary</h3></summary>

- Raises the minimum Y-axis tick budget from two to three.
- Adds a regression test rendering a 63px mixed-sign bar chart.
- Restores test mocks and stubbed globals after each chart test.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(charts): prevent compact axes from r..."](https://github.com/langfuse/langfuse/commit/babd5d39742fbe7572413f71625dc8a187351ed4)</sub>

<!-- /greptile_comment -->

🤖 Created with Codex.
