### PR TITLE
fix(gateway): collapse model badges when space is limited

### DIFF
--- a/web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/GatewayModelsView.stories.tsx
+++ b/web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/GatewayModelsView.stories.tsx
@@ -27,8 +27,22 @@ const models = [
         connectionName: "Primary",
         provider: "OPENAI",
       },
+      {
+        connectionId: "connection-fallback",
+        connectionName: "Fallback",
+        provider: "OPENAI",
+      },
+      {
+        connectionId: "connection-secondary",
+        connectionName: "Secondary production",
+        provider: "OPENAI",
+      },
     ],
-    apiFormats: ["OpenAI Responses", "OpenAI Chat Completions"],
+    apiFormats: [
+      "OpenAI Responses",
+      "OpenAI Chat Completions",
+      "Anthropic Messages",
+    ],
   },
   {
     id: "claude-sonnet-4-5",

--- a/web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/GatewayModelsView.tsx
+++ b/web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/GatewayModelsView.tsx
@@ -3,8 +3,14 @@ import { RefreshCw } from "lucide-react";
 
 import Header from "@/src/components/layouts/header";
 import { Alert } from "@/src/components/design-system/Alert/Alert";
+import { SingleLineOverflowList } from "@/src/components/SingleLineOverflowList";
 import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
 import { DataTable } from "@/src/components/table/data-table";
 import {
   DataTableControls,
@@ -48,16 +54,33 @@ const columns: LangfuseColumnDef<GatewayModelRow, unknown>[] = [
     header: "Available via",
     size: 360,
     cell: ({ row }) => (
-      <div className="flex flex-wrap gap-1">
-        {row.original.availableVia.map((connection) => (
-          <Badge
-            key={`${connection.provider}:${connection.connectionName}`}
-            variant="outline-solid"
-          >
+      <SingleLineOverflowList
+        items={row.original.availableVia}
+        additionalOverflowCount={0}
+        getKey={(connection) => connection.connectionId}
+        renderItem={(connection) => (
+          <Badge variant="outline-solid">
             {connection.connectionName} · {providerLabels[connection.provider]}
           </Badge>
-        ))}
-      </div>
+        )}
+        renderOverflow={({ hiddenItems, overflowItemCount }) => (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex" tabIndex={0}>
+                <Badge variant="outline-solid">+{overflowItemCount}</Badge>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              {hiddenItems
+                .map(
+                  (connection) =>
+                    `${connection.connectionName} · ${providerLabels[connection.provider]}`,
+                )
+                .join(", ")}
+            </TooltipContent>
+          </Tooltip>
+        )}
+      />
     ),
   },
   {
@@ -66,13 +89,24 @@ const columns: LangfuseColumnDef<GatewayModelRow, unknown>[] = [
     header: "API formats",
     size: 280,
     cell: ({ row }) => (
-      <div className="flex flex-wrap gap-1">
-        {row.original.apiFormats.map((format) => (
-          <Badge key={format} variant="secondary">
-            {format}
-          </Badge>
-        ))}
-      </div>
+      <SingleLineOverflowList
+        items={row.original.apiFormats}
+        additionalOverflowCount={0}
+        getKey={(format) => format}
+        renderItem={(format) => <Badge variant="secondary">{format}</Badge>}
+        renderOverflow={({ hiddenItems, overflowItemCount }) => (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex" tabIndex={0}>
+                <Badge variant="secondary">+{overflowItemCount}</Badge>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              {hiddenItems.join(", ")}
+            </TooltipContent>
+          </Tooltip>
+        )}
+      />
     ),
   },
 ];

--- a/web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/GatewayModelsView.tsx
+++ b/web/src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/GatewayModelsView.tsx
@@ -59,7 +59,7 @@ const columns: LangfuseColumnDef<GatewayModelRow, unknown>[] = [
         additionalOverflowCount={0}
         getKey={(connection) => connection.connectionId}
         renderItem={(connection) => (
-          <Badge variant="outline-solid">
+          <Badge variant="secondary">
             {connection.connectionName} · {providerLabels[connection.provider]}
           </Badge>
         )}
@@ -67,7 +67,7 @@ const columns: LangfuseColumnDef<GatewayModelRow, unknown>[] = [
           <Tooltip>
             <TooltipTrigger asChild>
               <span className="inline-flex" tabIndex={0}>
-                <Badge variant="outline-solid">+{overflowItemCount}</Badge>
+                <Badge variant="secondary">+{overflowItemCount}</Badge>
               </span>
             </TooltipTrigger>
             <TooltipContent className="max-w-xs">


### PR DESCRIPTION
## Summary
- collapse overflowing provider badges into a `+N` badge
- apply the same behavior to API format badges
- show hidden values in a tooltip
- add overflowing values to the existing Storybook fixture

## Verification
- `pnpm --filter web run test-storybook 'src/features/ai-gateway/components/GatewayModelsPage/components/GatewayModelsView/GatewayModelsView.stories.tsx'` — 6 tests passed
- `pnpm exec turbo run lint --filter=web --force` — 4 tasks successful, 0 cached
- `git diff --check`

Browser verification was skipped at the request of the reviewer, who will check the layout manually.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63100807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no actionable correctness, security, or repository-rule violations identified.

<details open><summary><h3>Summary</h3></summary>

- Uses the existing `SingleLineOverflowList` component for both affected columns.
- Preserves hidden provider and format labels in overflow tooltips.
- Expands the Storybook fixture to exercise overflow with additional connections and API formats.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(gateway): collapse model badges when..."](https://github.com/langfuse/langfuse/commit/3cdf861b968b1f97ccb4693b551a65c3cab9c585)</sub>

<!-- /greptile_comment -->