### PR TITLE
refactor(web): Use `SelectInput` over `ui/select` in some places

### DIFF
--- a/web/src/components/design-system/SelectInput/SelectInput.tsx
+++ b/web/src/components/design-system/SelectInput/SelectInput.tsx
@@ -46,7 +46,7 @@ type SelectInputProps<V> = {
   placeholder: string;
 } & Pick<
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>,
-  "id" | "aria-describedby" | "aria-invalid"
+  "id" | "aria-describedby" | "aria-invalid" | "aria-label" | "disabled"
 >;
 
 function isSelectGroup<V>(node: SelectInputNode<V>): node is SelectGroup<V> {

--- a/web/src/ee/features/sso-settings/components/SSOSettings.tsx
+++ b/web/src/ee/features/sso-settings/components/SSOSettings.tsx
@@ -16,6 +16,7 @@ import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
 import { Card } from "@/src/components/ui/card";
 import { Checkbox } from "@/src/components/design-system/Checkbox/Checkbox";
+import { SelectInput } from "@/src/components/design-system/SelectInput/SelectInput";
 import {
   Dialog,
   DialogBody,
@@ -35,13 +36,6 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/src/components/ui/select";
 import {
   Table,
   TableBody,
@@ -426,21 +420,15 @@ function SsoConfigDialog({
                     <FormItem>
                       <FormLabel>Provider</FormLabel>
                       <FormControl>
-                        <Select
+                        <SelectInput
                           value={field.value}
                           onValueChange={field.onChange}
-                        >
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select an SSO provider" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {SSO_PROVIDERS.map((p) => (
-                              <SelectItem key={p.id} value={p.id}>
-                                {p.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
+                          placeholder="Select an SSO provider"
+                          options={SSO_PROVIDERS.map((provider) => ({
+                            value: provider.id,
+                            label: provider.label,
+                          }))}
+                        />
                       </FormControl>
                       <FormMessage />
                     </FormItem>

--- a/web/src/features/annotation-queues/components/AddTracesToAnnotationQueueSelectDialogContent.tsx
+++ b/web/src/features/annotation-queues/components/AddTracesToAnnotationQueueSelectDialogContent.tsx
@@ -1,5 +1,6 @@
 import { ActionButton } from "@/src/components/ActionButton";
 import Spinner from "@/src/components/design-system/Spinner/Spinner";
+import { SelectInput } from "@/src/components/design-system/SelectInput/SelectInput";
 import { Button } from "@/src/components/ui/button";
 import {
   DialogBody,
@@ -15,13 +16,6 @@ import {
   FormItem,
   FormMessage,
 } from "@/src/components/ui/form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/src/components/ui/select";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 
@@ -111,28 +105,20 @@ export function AddTracesToAnnotationQueueSelectDialogContent({
               name="targetId"
               render={({ field }) => (
                 <FormItem>
-                  <Select
-                    onValueChange={field.onChange}
-                    value={field.value}
-                    disabled={isQueueOptionsLoading}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue
-                          placeholder={
-                            isQueueOptionsLoading ? "Loading..." : "Select..."
-                          }
-                        />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {queueOptions.map((option) => (
-                        <SelectItem key={option.id} value={option.id}>
-                          {option.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <FormControl>
+                    <SelectInput
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      disabled={isQueueOptionsLoading}
+                      placeholder={
+                        isQueueOptionsLoading ? "Loading..." : "Select..."
+                      }
+                      options={queueOptions.map((option) => ({
+                        value: option.id,
+                        label: option.name,
+                      }))}
+                    />
+                  </FormControl>
                   <FormMessage />
                 </FormItem>
               )}

--- a/web/src/features/blobstorage-integration/components/ExportScheduleFields.tsx
+++ b/web/src/features/blobstorage-integration/components/ExportScheduleFields.tsx
@@ -8,13 +8,7 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/src/components/ui/select";
+import { SelectInput } from "@/src/components/design-system/SelectInput/SelectInput";
 import {
   BlobStorageExportMode,
   BlobStorageIntegrationFileType,
@@ -39,19 +33,17 @@ export const ExportScheduleFields = ({
           <FormItem>
             <FormLabel>Export Frequency</FormLabel>
             <FormControl>
-              <Select value={field.value} onValueChange={field.onChange}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select frequency" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="every_20_minutes">
-                    Every 20 Minutes
-                  </SelectItem>
-                  <SelectItem value="hourly">Hourly</SelectItem>
-                  <SelectItem value="daily">Daily</SelectItem>
-                  <SelectItem value="weekly">Weekly</SelectItem>
-                </SelectContent>
-              </Select>
+              <SelectInput
+                value={field.value}
+                onValueChange={field.onChange}
+                placeholder="Select frequency"
+                options={[
+                  { value: "every_20_minutes", label: "Every 20 Minutes" },
+                  { value: "hourly", label: "Hourly" },
+                  { value: "daily", label: "Daily" },
+                  { value: "weekly", label: "Weekly" },
+                ]}
+              />
             </FormControl>
             <FormDescription>
               How often the data should be exported. Changes are taken into
@@ -69,17 +61,29 @@ export const ExportScheduleFields = ({
           <FormItem>
             <FormLabel>File Type</FormLabel>
             <FormControl>
-              <Select value={field.value} onValueChange={field.onChange}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select file type" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="PARQUET">Parquet</SelectItem>
-                  <SelectItem value="JSONL">JSONL</SelectItem>
-                  <SelectItem value="CSV">CSV</SelectItem>
-                  <SelectItem value="JSON">JSON</SelectItem>
-                </SelectContent>
-              </Select>
+              <SelectInput
+                value={field.value}
+                onValueChange={field.onChange}
+                placeholder="Select file type"
+                options={[
+                  {
+                    value: BlobStorageIntegrationFileType.PARQUET,
+                    label: "Parquet",
+                  },
+                  {
+                    value: BlobStorageIntegrationFileType.JSONL,
+                    label: "JSONL",
+                  },
+                  {
+                    value: BlobStorageIntegrationFileType.CSV,
+                    label: "CSV",
+                  },
+                  {
+                    value: BlobStorageIntegrationFileType.JSON,
+                    label: "JSON",
+                  },
+                ]}
+              />
             </FormControl>
             <FormDescription>
               {field.value === BlobStorageIntegrationFileType.PARQUET
@@ -98,22 +102,25 @@ export const ExportScheduleFields = ({
           <FormItem>
             <FormLabel>Export Mode</FormLabel>
             <FormControl>
-              <Select value={field.value} onValueChange={field.onChange}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select export mode" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={BlobStorageExportMode.FULL_HISTORY}>
-                    Full history
-                  </SelectItem>
-                  <SelectItem value={BlobStorageExportMode.FROM_TODAY}>
-                    Today
-                  </SelectItem>
-                  <SelectItem value={BlobStorageExportMode.FROM_CUSTOM_DATE}>
-                    Custom date
-                  </SelectItem>
-                </SelectContent>
-              </Select>
+              <SelectInput
+                value={field.value}
+                onValueChange={field.onChange}
+                placeholder="Select export mode"
+                options={[
+                  {
+                    value: BlobStorageExportMode.FULL_HISTORY,
+                    label: "Full history",
+                  },
+                  {
+                    value: BlobStorageExportMode.FROM_TODAY,
+                    label: "Today",
+                  },
+                  {
+                    value: BlobStorageExportMode.FROM_CUSTOM_DATE,
+                    label: "Custom date",
+                  },
+                ]}
+              />
             </FormControl>
             <FormDescription>
               Choose when to start exporting data. &quot;Today&quot; and

--- a/web/src/features/blobstorage-integration/components/ExportSourceField.tsx
+++ b/web/src/features/blobstorage-integration/components/ExportSourceField.tsx
@@ -1,6 +1,7 @@
 import { useWatch } from "react-hook-form";
 import { Info, ExternalLink } from "lucide-react";
 import { Alert } from "@/src/components/design-system/Alert/Alert";
+import { SelectInput } from "@/src/components/design-system/SelectInput/SelectInput";
 import {
   FormControl,
   FormDescription,
@@ -9,13 +10,6 @@ import {
   FormLabel,
   FormMessage,
 } from "@/src/components/ui/form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/src/components/ui/select";
 import {
   Tooltip,
   TooltipContent,
@@ -99,30 +93,26 @@ export const ExportSourceField = ({
                   </TooltipContent>
                 </Tooltip>
               </FormLabel>
-              <Select
-                onValueChange={field.onChange}
-                value={field.value}
-                disabled={exportSourceLocked}
-              >
-                <FormControl>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select data to export" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  {exportSourceOptions.map((option) => (
-                    <SelectItem
-                      key={option.value}
-                      value={option.value}
-                      disabled={option.unavailable}
-                    >
-                      {option.unavailable
-                        ? `${option.label} (not available on this deployment)`
-                        : option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <FormControl>
+                <SelectInput
+                  onValueChange={field.onChange}
+                  value={field.value}
+                  disabled={exportSourceLocked}
+                  placeholder="Select data to export"
+                  options={exportSourceOptions.map((option) => {
+                    if (option.unavailable) {
+                      return {
+                        value: option.value,
+                        label: `${option.label} (not available on this deployment)`,
+                        disabled: true as const,
+                        disabledReason: "Not available on this deployment.",
+                      };
+                    }
+
+                    return { value: option.value, label: option.label };
+                  })}
+                />
+              </FormControl>
               <FormDescription>
                 Choose which data sources to export to blob storage. Scores are
                 always included.

--- a/web/src/features/blobstorage-integration/components/StorageProviderFields.tsx
+++ b/web/src/features/blobstorage-integration/components/StorageProviderFields.tsx
@@ -9,14 +9,8 @@ import {
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
 import { PasswordInput } from "@/src/components/design-system/PasswordInput/PasswordInput";
+import { SelectInput } from "@/src/components/design-system/SelectInput/SelectInput";
 import { Switch } from "@/src/components/design-system/Switch/Switch";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/src/components/ui/select";
 import { BlobStorageIntegrationType } from "@langfuse/shared";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { type BlobStorageFormControl } from "@/src/features/blobstorage-integration/components/formValues";
@@ -44,20 +38,22 @@ export const StorageProviderFields = ({
           <FormItem>
             <FormLabel>Storage Provider</FormLabel>
             <FormControl>
-              <Select value={field.value} onValueChange={field.onChange}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select provider" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="S3">AWS S3</SelectItem>
-                  <SelectItem value="S3_COMPATIBLE">
-                    S3 Compatible Storage
-                  </SelectItem>
-                  <SelectItem value="AZURE_BLOB_STORAGE">
-                    Azure Blob Storage
-                  </SelectItem>
-                </SelectContent>
-              </Select>
+              <SelectInput
+                value={field.value}
+                onValueChange={field.onChange}
+                placeholder="Select provider"
+                options={[
+                  { value: BlobStorageIntegrationType.S3, label: "AWS S3" },
+                  {
+                    value: BlobStorageIntegrationType.S3_COMPATIBLE,
+                    label: "S3 Compatible Storage",
+                  },
+                  {
+                    value: BlobStorageIntegrationType.AZURE_BLOB_STORAGE,
+                    label: "Azure Blob Storage",
+                  },
+                ]}
+              />
             </FormControl>
             <FormDescription>
               Choose your cloud storage provider

--- a/web/src/features/projects/components/TransferProjectDialogContent.tsx
+++ b/web/src/features/projects/components/TransferProjectDialogContent.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Alert } from "@/src/components/design-system/Alert/Alert";
+import { SelectInput } from "@/src/components/design-system/SelectInput/SelectInput";
 import { Button } from "@/src/components/ui/button";
 import {
   DialogBody,
@@ -18,13 +19,6 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/src/components/ui/select";
 import { TriangleAlert } from "lucide-react";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
@@ -105,25 +99,16 @@ export function TransferProjectDialogContent({
                 <FormItem>
                   <FormLabel>Select New Organization</FormLabel>
                   <FormControl>
-                    <Select
+                    <SelectInput
                       onValueChange={field.onChange}
                       value={field.value}
                       disabled={isPending}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select organization" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {organizations.map((organization) => (
-                          <SelectItem
-                            key={organization.id}
-                            value={organization.id}
-                          >
-                            {organization.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                      placeholder="Select organization"
+                      options={organizations.map((organization) => ({
+                        value: organization.id,
+                        label: organization.name,
+                      }))}
+                    />
                   </FormControl>
                   <FormDescription>
                     Transfer this project to another organization where you have

--- a/web/src/features/prompts/components/PromptSelectionDialog.tsx
+++ b/web/src/features/prompts/components/PromptSelectionDialog.tsx
@@ -9,13 +9,7 @@ import {
   DialogBody,
 } from "@/src/components/ui/dialog";
 import { Button } from "@/src/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/src/components/ui/select";
+import { SelectInput } from "@/src/components/design-system/SelectInput/SelectInput";
 import { Label } from "@/src/components/ui/label";
 import { api } from "@/src/utils/api";
 import { CopyIcon, ExternalLinkIcon } from "lucide-react";
@@ -115,24 +109,21 @@ export function PromptSelectionDialog({
 
             <div className="flex flex-col gap-2">
               <Label htmlFor="prompt-name">Prompt name</Label>
-              <Select
+              <SelectInput
+                id="prompt-name"
                 value={selectedPromptName}
                 onValueChange={(value) => {
                   setSelectedPromptName(value);
                   setSelectedVersionOrLabel("");
                 }}
-              >
-                <SelectTrigger id="prompt-name">
-                  <SelectValue placeholder="Select a text prompt" />
-                </SelectTrigger>
-                <SelectContent>
-                  {promptOptions?.map((prompt) => (
-                    <SelectItem key={prompt.name} value={prompt.name}>
-                      {prompt.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                placeholder="Select a text prompt"
+                options={
+                  promptOptions?.map((prompt) => ({
+                    value: prompt.name,
+                    label: prompt.name,
+                  })) ?? []
+                }
+              />
               <p className="text-muted-foreground text-xs">
                 Only text prompts can be referenced inline.
               </p>
@@ -141,21 +132,19 @@ export function PromptSelectionDialog({
             {selectedPromptName && (
               <div className="flex flex-col gap-2">
                 <Label htmlFor="selection-type">Reference by</Label>
-                <Select
+                <SelectInput
+                  id="selection-type"
                   value={selectionType}
                   onValueChange={(value: "version" | "label") => {
                     setSelectionType(value);
                     setSelectedVersionOrLabel("");
                   }}
-                >
-                  <SelectTrigger id="selection-type">
-                    <SelectValue placeholder="Select link type" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="label">Label</SelectItem>
-                    <SelectItem value="version">Version</SelectItem>
-                  </SelectContent>
-                </Select>
+                  placeholder="Select link type"
+                  options={[
+                    { value: "label", label: "Label" },
+                    { value: "version", label: "Version" },
+                  ]}
+                />
               </div>
             )}
 
@@ -165,36 +154,27 @@ export function PromptSelectionDialog({
                   {selectionType === "version" ? "Version" : "Label"}
                 </Label>
                 <div className="flex gap-2">
-                  <Select
+                  <SelectInput
+                    id="version-or-label"
                     value={selectedVersionOrLabel}
                     onValueChange={setSelectedVersionOrLabel}
-                  >
-                    <SelectTrigger id="version-or-label">
-                      <SelectValue
-                        placeholder={
-                          selectionType === "version"
-                            ? "Select a version"
-                            : "Select a label"
-                        }
-                      />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {selectionType === "version"
-                        ? selectedPrompt?.versions.map((version) => (
-                            <SelectItem
-                              key={version.toString()}
-                              value={version.toString()}
-                            >
-                              {version}
-                            </SelectItem>
-                          ))
-                        : selectedPrompt?.labels.map((label) => (
-                            <SelectItem key={label} value={label}>
-                              {label}
-                            </SelectItem>
-                          ))}
-                    </SelectContent>
-                  </Select>
+                    placeholder={
+                      selectionType === "version"
+                        ? "Select a version"
+                        : "Select a label"
+                    }
+                    options={
+                      selectionType === "version"
+                        ? (selectedPrompt?.versions.map((version) => ({
+                            value: version.toString(),
+                            label: version.toString(),
+                          })) ?? [])
+                        : (selectedPrompt?.labels.map((label) => ({
+                            value: label,
+                            label,
+                          })) ?? [])
+                    }
+                  />
                   {selectedVersionOrLabel && (
                     <Link
                       href={`${getPromptDetailHref(projectId, selectedPromptName)}?${selectionType}=${encodeURIComponent(selectedVersionOrLabel)}`}

--- a/web/src/features/score-configs/components/UpsertScoreConfigDialogContent.tsx
+++ b/web/src/features/score-configs/components/UpsertScoreConfigDialogContent.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { type UseFormReturn, useFieldArray, useForm } from "react-hook-form";
 
 import { Button } from "@/src/components/ui/button";
+import { SelectInput } from "@/src/components/design-system/SelectInput/SelectInput";
 import {
   DialogBody,
   DialogFooter,
@@ -19,13 +20,6 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/src/components/ui/select";
 import { Textarea } from "@/src/components/ui/textarea";
 import DocPopup from "@/src/components/layouts/doc-popup";
 import {
@@ -131,48 +125,39 @@ export function UpsertScoreConfigDialogContent({
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Data type</FormLabel>
-                  <Select
-                    disabled={mode === "edit"}
-                    defaultValue={field.value}
-                    onValueChange={(value) => {
-                      const nextDataType = value as ScoreConfigDataType;
-                      field.onChange(nextDataType);
-                      form.clearErrors();
-                      if (isNumericDataType(nextDataType)) {
-                        form.setValue("categories", undefined);
-                      } else if (isTextDataType(nextDataType)) {
-                        form.setValue("categories", undefined);
-                        form.setValue("minValue", undefined);
-                        form.setValue("maxValue", undefined);
-                      } else {
-                        form.setValue("minValue", undefined);
-                        form.setValue("maxValue", undefined);
-                        if (isBooleanDataType(nextDataType)) {
-                          replace([
-                            { label: "True", value: 1 },
-                            { label: "False", value: 0 },
-                          ]);
+                  <FormControl>
+                    <SelectInput
+                      disabled={mode === "edit"}
+                      value={field.value}
+                      onValueChange={(value) => {
+                        const nextDataType = value as ScoreConfigDataType;
+                        field.onChange(nextDataType);
+                        form.clearErrors();
+                        if (isNumericDataType(nextDataType)) {
+                          form.setValue("categories", undefined);
+                        } else if (isTextDataType(nextDataType)) {
+                          form.setValue("categories", undefined);
+                          form.setValue("minValue", undefined);
+                          form.setValue("maxValue", undefined);
                         } else {
-                          replace([{ label: "", value: 0 }]);
+                          form.setValue("minValue", undefined);
+                          form.setValue("maxValue", undefined);
+                          if (isBooleanDataType(nextDataType)) {
+                            replace([
+                              { label: "True", value: 1 },
+                              { label: "False", value: 0 },
+                            ]);
+                          } else {
+                            replace([{ label: "", value: 0 }]);
+                          }
                         }
-                      }
-                    }}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select a data type" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {Object.values(ScoreDataTypeEnum)
+                      }}
+                      placeholder="Select a data type"
+                      options={Object.values(ScoreDataTypeEnum)
                         .filter((value) => value !== "CORRECTION")
-                        .map((value) => (
-                          <SelectItem value={value} key={value}>
-                            {value}
-                          </SelectItem>
-                        ))}
-                    </SelectContent>
-                  </Select>
+                        .map((value) => ({ value, label: value }))}
+                    />
+                  </FormControl>
                   <FormMessage />
                 </FormItem>
               )}

--- a/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
@@ -13,14 +13,8 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { PasswordInput } from "@/src/components/design-system/PasswordInput/PasswordInput";
+import { SelectInput } from "@/src/components/design-system/SelectInput/SelectInput";
 import { Switch } from "@/src/components/design-system/Switch/Switch";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/src/components/ui/select";
 import {
   Tooltip,
   TooltipTrigger,
@@ -267,20 +261,17 @@ const MixpanelIntegrationSettingsForm = ({
           render={({ field }) => (
             <FormItem>
               <FormLabel>Mixpanel Region</FormLabel>
-              <Select onValueChange={field.onChange} value={field.value}>
-                <FormControl>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select a region" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  {MIXPANEL_REGIONS.map((region) => (
-                    <SelectItem key={region.subdomain} value={region.subdomain}>
-                      {region.description}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <FormControl>
+                <SelectInput
+                  onValueChange={field.onChange}
+                  value={field.value}
+                  placeholder="Select a region"
+                  options={MIXPANEL_REGIONS.map((region) => ({
+                    value: region.subdomain,
+                    label: region.description,
+                  }))}
+                />
+              </FormControl>
               <FormDescription>
                 Select the Mixpanel region where your project is hosted
               </FormDescription>
@@ -347,26 +338,25 @@ const MixpanelIntegrationSettingsForm = ({
                     </TooltipContent>
                   </Tooltip>
                 </FormLabel>
-                <Select onValueChange={field.onChange} value={field.value}>
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select data to export" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {exportSourceOptions.map((option) => (
-                      <SelectItem
-                        key={option.value}
-                        value={option.value}
-                        disabled={option.unavailable}
-                      >
-                        {option.unavailable
-                          ? `${option.label} (not available on this deployment)`
-                          : option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <FormControl>
+                  <SelectInput
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    placeholder="Select data to export"
+                    options={exportSourceOptions.map((option) => {
+                      if (option.unavailable) {
+                        return {
+                          value: option.value,
+                          label: `${option.label} (not available on this deployment)`,
+                          disabled: true as const,
+                          disabledReason: "Not available on this deployment.",
+                        };
+                      }
+
+                      return { value: option.value, label: option.label };
+                    })}
+                  />
+                </FormControl>
                 <FormDescription>
                   Choose which data sources to export to Mixpanel. Scores are
                   always included.

--- a/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
@@ -14,14 +14,8 @@ import {
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
 import { PasswordInput } from "@/src/components/design-system/PasswordInput/PasswordInput";
+import { SelectInput } from "@/src/components/design-system/SelectInput/SelectInput";
 import { Switch } from "@/src/components/design-system/Switch/Switch";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/src/components/ui/select";
 import {
   Tooltip,
   TooltipTrigger,
@@ -326,26 +320,25 @@ const PostHogIntegrationSettings = ({
                     </TooltipContent>
                   </Tooltip>
                 </FormLabel>
-                <Select onValueChange={field.onChange} value={field.value}>
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select data to export" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {exportSourceOptions.map((option) => (
-                      <SelectItem
-                        key={option.value}
-                        value={option.value}
-                        disabled={option.unavailable}
-                      >
-                        {option.unavailable
-                          ? `${option.label} (not available on this deployment)`
-                          : option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <FormControl>
+                  <SelectInput
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    placeholder="Select data to export"
+                    options={exportSourceOptions.map((option) => {
+                      if (option.unavailable) {
+                        return {
+                          value: option.value,
+                          label: `${option.label} (not available on this deployment)`,
+                          disabled: true as const,
+                          disabledReason: "Not available on this deployment.",
+                        };
+                      }
+
+                      return { value: option.value, label: option.label };
+                    })}
+                  />
+                </FormControl>
                 <FormDescription>
                   Choose which data sources to export to PostHog. Scores are
                   always included.


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17372 app preview](https://pr-17372.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63110548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no concrete behavioral, security, or repository-rule violations identified.

<details open><summary><h3>Summary</h3></summary>

- Extends `SelectInput` trigger props to support disabled and accessible-label states.
- Migrates SSO, annotation queue, blob-storage, project-transfer, prompt, score-config, Mixpanel, and PostHog selectors.
- Preserves controlled values, option restrictions, form validation wiring, and overlay behavior.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Refactor select: PromptSelectionDialog.t..."](https://github.com/langfuse/langfuse/commit/2415d8e10930de7a463055ef72daf722281ee03d)</sub>

<!-- /greptile_comment -->