### PR TITLE
chore(clickhouse): tag query outcomes by input/output content filter

### DIFF
--- a/packages/shared/src/server/clickhouse/queryOutcome.test.ts
+++ b/packages/shared/src/server/clickhouse/queryOutcome.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CLICKHOUSE_QUERY_OUTCOME_METRIC,
   CLICKHOUSE_RESOURCE_ERROR_OUTCOMES,
+  clickHouseQueryHasIoContentFilter,
   clickHouseQueryOutcomeRouteLabel,
   clickHouseQueryTableLabel,
   recordClickHouseQueryOutcome,
@@ -133,6 +134,30 @@ describe("ClickHouse query outcome metric", () => {
     });
   });
 
+  describe("io content filter classification", () => {
+    // The two shapes the filter compiler emits for a substring/token search on
+    // input/output, plus a bare (I)LIKE fallback. See fts.ts.
+    it.each([
+      "SELECT id FROM events_full e WHERE position(lower(e.output), lower({p: String})) > 0",
+      "SELECT id FROM events_full e WHERE hasAllTokens(lower(e.input), arraySlice(arrayDistinct(tokens(lower({p: String}))), 1, 64))",
+      "SELECT id FROM observations o WHERE o.input ILIKE {p: String}",
+      "SELECT id FROM events_full e WHERE output LIKE {p: String}",
+    ])("flags a content scan over input/output: %s", (query) => {
+      expect(clickHouseQueryHasIoContentFilter(query)).toBe(true);
+    });
+
+    // A metadata token search uses the same functions on a different column and
+    // must not be counted, nor must an exact equality or an unrelated query.
+    it.each([
+      "SELECT id FROM events_full e WHERE hasAllTokens(e.metadata_values, arraySlice({p: Array(String)}, 1, 64))",
+      "SELECT id FROM events_full e WHERE e.input = {p: String}",
+      "SELECT id FROM events_full e WHERE e.project_id = {p: String}",
+      "SELECT count() FROM traces",
+    ])("does not flag %s", (query) => {
+      expect(clickHouseQueryHasIoContentFilter(query)).toBe(false);
+    });
+  });
+
   it("maps every ClickHouse resource error type to an outcome", () => {
     expect(CLICKHOUSE_RESOURCE_ERROR_OUTCOMES).toEqual({
       TIMEOUT: "timeout",
@@ -154,6 +179,7 @@ describe("ClickHouse query outcome metric", () => {
         userAgent: "python-httpx/0.28.1",
       },
       "events_full",
+      true,
     );
 
     expect(recordIncrement).toHaveBeenCalledTimes(1);
@@ -165,6 +191,7 @@ describe("ClickHouse query outcome metric", () => {
         surface: "publicapi",
         route: "get_/api/public/v2/observations",
         table: "events_full",
+        io_content_filter: "true",
       },
     );
   });
@@ -177,6 +204,7 @@ describe("ClickHouse query outcome metric", () => {
         surface: "unknown",
       },
       "other",
+      false,
     );
 
     expect(recordIncrement).toHaveBeenCalledWith(
@@ -187,6 +215,7 @@ describe("ClickHouse query outcome metric", () => {
         surface: "unknown",
         route: "other",
         table: "other",
+        io_content_filter: "false",
       },
     );
   });

--- a/packages/shared/src/server/clickhouse/queryOutcome.ts
+++ b/packages/shared/src/server/clickhouse/queryOutcome.ts
@@ -132,15 +132,46 @@ export function clickHouseQueryTableLabel(query: string): ClickHouseQueryTable {
   return OTHER_TABLE_LABEL;
 }
 
+/**
+ * Substring/token search over the `input`/`output` columns — the largest
+ * `events_full` columns, whose token index prunes weakly for common terms — is
+ * the confirmed full-scan / timeout class. The outcome counter is otherwise
+ * blind to filter shape: a timeout on `events_full` cannot be told apart from
+ * any other. This tag lets an operator isolate that class directly on the
+ * unsampled metric, instead of estimating it from sampled APM query text.
+ *
+ * Derived from the query text (like the table label) because threading the
+ * filter shape through every call site is impractical. Matches the two shapes
+ * the filter compiler emits — `position(lower(e.input|output), …) > 0` and the
+ * `hasAllTokens(lower(e.input|output), …)` index prefilter — plus a bare
+ * `input|output (I)LIKE` fallback, across any table alias. Anchored to the
+ * `input`/`output` columns so a metadata token search (`hasAllTokens(
+ * e.metadata_values, …)`) never counts.
+ */
+const IO_CONTENT_FILTER_FUNCTION_PATTERN =
+  /\b(?:position(?:caseinsensitive)?|hasalltokens|hasanytokens|hastoken)\s*\(\s*(?:lower\s*\(\s*)?(?:\w+\.)?(?:input|output)\b/i;
+
+const IO_CONTENT_FILTER_LIKE_PATTERN =
+  /\b(?:\w+\.)?(?:input|output)\s+(?:not\s+)?i?like\b/i;
+
+export function clickHouseQueryHasIoContentFilter(query: string): boolean {
+  return (
+    IO_CONTENT_FILTER_FUNCTION_PATTERN.test(query) ||
+    IO_CONTENT_FILTER_LIKE_PATTERN.test(query)
+  );
+}
+
 export function recordClickHouseQueryOutcome(
   outcome: ClickHouseQueryOutcome,
   tags: NormalizedClickHouseQueryTags,
   table: ClickHouseQueryTable,
+  ioContentFilter: boolean,
 ): void {
   recordIncrement(CLICKHOUSE_QUERY_OUTCOME_METRIC, 1, {
     outcome,
     surface: tags.surface,
     route: clickHouseQueryOutcomeRouteLabel(tags.route),
     table,
+    io_content_filter: String(ioContentFilter),
   });
 }

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -33,6 +33,7 @@ import {
 } from "../clickhouse/queryTags";
 import {
   CLICKHOUSE_RESOURCE_ERROR_OUTCOMES,
+  clickHouseQueryHasIoContentFilter,
   clickHouseQueryTableLabel,
   recordClickHouseQueryOutcome,
 } from "../clickhouse/queryOutcome";
@@ -702,6 +703,7 @@ export async function queryClickhouse<T>(
   if (!opts.allowLegacyEventsRead) assertNoLegacyEventsRead(opts.query);
   const normalizedTags = normalizeClickHouseQueryTags(opts.tags);
   const table = clickHouseQueryTableLabel(opts.query);
+  const ioContentFilter = clickHouseQueryHasIoContentFilter(opts.query);
   return await instrumentAsync(
     { name: "clickhouse-query", spanKind: SpanKind.CLIENT },
     async (span) => {
@@ -764,11 +766,17 @@ export async function queryClickhouse<T>(
             : "error",
           normalizedTags,
           table,
+          ioContentFilter,
         );
         throw wrapped;
       });
 
-      recordClickHouseQueryOutcome("success", normalizedTags, table);
+      recordClickHouseQueryOutcome(
+        "success",
+        normalizedTags,
+        table,
+        ioContentFilter,
+      );
       return rows;
     },
   );


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-17375 app preview](https://pr-17375.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

`langfuse.clickhouse.query.outcome` already tags `surface`, `route`, and `table`, but it is blind to *filter shape*: a timeout on `events_full` looks identical to any other. Substring/token search over the `input`/`output` columns is the confirmed full-table-scan / timeout class, yet the only way to attribute a timeout to it today is sampled APM query text (`@ch.query.text`), which APM retains for only ~2–5% of outcomes — enough to see the shape dominates, not enough to count it.

This adds an `io_content_filter` tag (`true`/`false`) to the counter, derived from the query text the same way the `table` label is (threading filter shape through every call site is impractical). It matches the two shapes the filter compiler emits — `position(lower(input|output), …) > 0` and the `hasAllTokens(lower(input|output), …)` index prefilter — plus a bare `input|output (I)LIKE` fallback, anchored to the `input`/`output` columns so a metadata token search (`hasAllTokens(e.metadata_values, …)`) never counts.

Operators can now isolate the io-content-search timeout class directly on the unsampled metric, e.g. `sum:langfuse.clickhouse.query.outcome{table:events_full,io_content_filter:true,outcome:timeout} by {surface}`.

Cardinality: adds one bounded boolean dimension (×2 series).

## Type of change

- [x] Chore (observability / instrumentation, no user-facing behavior change)

## Checklist

- Classifier unit tests cover both compiled shapes, the `(I)LIKE` fallback, and negatives (metadata token search, exact equality, unrelated query); emit tests assert the new tag.
- `lint`, `typecheck` (shared + web + worker, forced), the shared unit suite, and `knip` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63168386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until generated exact-equality predicates are kept out of the new content-search metric category or the intended category and tests are aligned.

<details open><summary><h3>Summary</h3></summary>

- Adds regex classification for input/output token, substring, and LIKE predicates.
- Records the Boolean tag for successful and failed queries.
- Adds classifier and metric-emission tests.
- The current classifier also tags compiler-generated exact-equality filters despite the intended negative classification.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Q[Generated ClickHouse SQL] --> C[Classify input/output filter]
  C --> E[Execute query]
  E --> O{Terminal outcome}
  O -->|Success| M[Increment query outcome metric]
  O -->|Resource or generic error| M
  C --> M
  M --> T[Tags: surface, route, table, io_content_filter]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["chore(clickhouse): tag query outcomes by..."](https://github.com/langfuse/langfuse/commit/09ab4050f32e409b963759ec734766bc25272270)</sub>

<!-- /greptile_comment -->