### PR TITLE
fix(experiments): avoid categorical comparison collisions

### DIFF
--- a/web/src/features/experiments/fns/scoreComparisonFilter.clienttest.ts
+++ b/web/src/features/experiments/fns/scoreComparisonFilter.clienttest.ts
@@ -84,6 +84,31 @@ describe("matchesScoreComparisonFilter", () => {
       }),
     ).toBe(false);
   });
+
+  it("detects categorical values that collide when joined", () => {
+    expect(
+      matchesScoreComparisonFilter({
+        operator: "differs",
+        dataType: "CATEGORICAL",
+        baseline: {
+          type: "CATEGORICAL",
+          values: ["a|b", "c"],
+          valueCounts: [
+            { value: "a|b", count: 1 },
+            { value: "c", count: 1 },
+          ],
+        },
+        comparison: {
+          type: "CATEGORICAL",
+          values: ["a", "b|c"],
+          valueCounts: [
+            { value: "a", count: 1 },
+            { value: "b|c", count: 1 },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("score comparison filter URL state", () => {

--- a/web/src/features/experiments/fns/scoreComparisonFilter.ts
+++ b/web/src/features/experiments/fns/scoreComparisonFilter.ts
@@ -100,9 +100,11 @@ export const matchesScoreComparisonFilter = ({
     if (operator !== "differs") return false;
     if (baseline.type !== "CATEGORICAL" || comparison.type !== "CATEGORICAL")
       return false;
+    const baselineValues = [...baseline.values].sort();
+    const comparisonValues = [...comparison.values].sort();
     return (
-      [...baseline.values].sort().join("|") !==
-      [...comparison.values].sort().join("|")
+      baselineValues.length !== comparisonValues.length ||
+      baselineValues.some((value, index) => value !== comparisonValues[index])
     );
   }
 


### PR DESCRIPTION
**What changed**

- Compare sorted categorical values item by item.
- Avoid using `|` as a separator.

**Why**

Categorical values can contain `|`. Different value lists could produce the same joined string and be treated as equal.

Example: `["a|b", "c"]` and `["a", "b|c"]` both became `a|b|c`.

**Tests**

- `pnpm --filter web exec vitest run --project client src/features/experiments/fns/scoreComparisonFilter.clienttest.ts`
- `pnpm exec prettier --check web/src/features/experiments/fns/scoreComparisonFilter.ts web/src/features/experiments/fns/scoreComparisonFilter.clienttest.ts`
- `pnpm --filter web exec eslint src/features/experiments/fns/scoreComparisonFilter.ts src/features/experiments/fns/scoreComparisonFilter.clienttest.ts`

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63272460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the new comparison removes the reported collision without changing the intended order-independent categorical semantics.

<details open><summary><h3>Summary</h3></summary>

- Copies and sorts both categorical value arrays without mutating the inputs.
- Compares array lengths and individual values.
- Adds a regression test for categorical values that previously produced identical joined strings.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(experiments): avoid categorical comp..."](https://github.com/langfuse/langfuse/commit/91a254a4cb9f78c69e5ad8f232eb0b07fd706d97)</sub>

<!-- /greptile_comment -->