### PR TITLE
feat(shared): add opt-in verifiable execution receipt export

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -68,6 +68,7 @@ export * from "./utils/DatabaseReadStream";
 export * from "./utils/transforms";
 export * from "./utils/billingCycleHelpers";
 export * from "./utils/compareVersions";
+export * from "./utils/executionReceipt";
 export * from "./otel/utils";
 export * from "./clickhouse/client";
 export {

--- a/packages/shared/src/server/utils/executionReceipt.test.ts
+++ b/packages/shared/src/server/utils/executionReceipt.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildExecutionReceipt,
+  canonicalJsonString,
+  sha256HexOfCanonical,
+  toSableSubmission,
+  verifyExecutionReceipt,
+  verifySableSubmission,
+  type ExecutionReceiptInput,
+} from "./executionReceipt";
+
+const baseInput: ExecutionReceiptInput = {
+  executionId: "exec-2026-09-11-langfuse-001",
+  traceId: "trace-abc123",
+  projectId: "project-xyz",
+  goal: "Look up the order status and summarize it",
+  claimedStatus: "success",
+  finalReport: "Order 42 is shipped",
+  environment: { region: "eu", sandbox: "public-example" },
+  executor: {
+    name: "langfuse-example-agent",
+    version: "0.1.0",
+    framework: "langfuse",
+    frameworkVersion: "3.x",
+    provider: "example-provider",
+    model: "example-model-snapshot",
+    revision: "git:abc1234",
+  },
+  toolCalls: [
+    {
+      tool: "get_order_status",
+      args: { orderId: "42" },
+      observedResult: { orderId: "42", status: "shipped" },
+      observationId: "obs-001",
+    },
+  ],
+  langfuseTraceUrl:
+    "https://cloud.langfuse.com/project/project-xyz/traces/trace-abc123",
+  capturedAt: "2026-09-11T12:00:00.000Z",
+};
+
+describe("executionReceipt canonicalization", () => {
+  it("is stable regardless of key order", () => {
+    expect(canonicalJsonString({ b: 1, a: { d: 4, c: 3 } })).toBe(
+      canonicalJsonString({ a: { c: 3, d: 4 }, b: 1 }),
+    );
+  });
+
+  it("matches sha256 over canonical utf8 bytes", () => {
+    expect(sha256HexOfCanonical({ b: 1, a: 2 })).toMatch(/^[0-9a-f]{64}$/);
+    expect(sha256HexOfCanonical({ a: 2, b: 1 })).toBe(
+      sha256HexOfCanonical({ b: 1, a: 2 }),
+    );
+  });
+});
+
+describe("buildExecutionReceipt", () => {
+  it("builds a receipt that verifies", () => {
+    const receipt = buildExecutionReceipt(baseInput);
+
+    expect(receipt.protocolVersion).toBe("langfuse.execution-receipt.v1");
+    expect(receipt.contentAddress).toBe(`sha256:${receipt.receiptHash}`);
+    expect(verifyExecutionReceipt(receipt)).toEqual({ ok: true, reasons: [] });
+  });
+
+  it("detects tampering with the observed result", () => {
+    const receipt = buildExecutionReceipt(baseInput);
+    const tampered = {
+      ...receipt,
+      toolCalls: [
+        {
+          ...receipt.toolCalls[0],
+          observedResult: { orderId: "42", status: "refunded" },
+        },
+      ],
+    };
+
+    const result = verifyExecutionReceipt(tampered);
+    expect(result.ok).toBe(false);
+    expect(result.reasons).toContain(
+      "observed_result_hash_mismatch:get_order_status",
+    );
+  });
+
+  it("requires at least one real tool call", () => {
+    expect(() =>
+      buildExecutionReceipt({ ...baseInput, toolCalls: [] }),
+    ).toThrow();
+  });
+});
+
+describe("sable submission mapping", () => {
+  it("emits a structurally valid envelope that verifies", () => {
+    const receipt = buildExecutionReceipt(baseInput);
+    const submission = toSableSubmission(receipt);
+
+    expect(submission.protocol_version).toBe("sable.submission.v0.9");
+    expect(submission.submission_id).toBe(receipt.executionId);
+    expect(verifySableSubmission(submission)).toEqual({
+      ok: true,
+      reasons: [],
+    });
+  });
+
+  it("detects a tampered sable trace", () => {
+    const receipt = buildExecutionReceipt(baseInput);
+    const submission = toSableSubmission(receipt);
+    const tampered = {
+      ...submission,
+      trace: { ...submission.trace, goal: "altered goal" },
+    };
+
+    expect(verifySableSubmission(tampered)).toEqual({
+      ok: false,
+      reasons: ["source_trace_hash_mismatch"],
+    });
+  });
+});

--- a/packages/shared/src/server/utils/executionReceipt.ts
+++ b/packages/shared/src/server/utils/executionReceipt.ts
@@ -1,0 +1,410 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+/**
+ * Cross-runtime execution receipt for optional independent verification.
+ *
+ * Context: https://github.com/langfuse/langfuse/issues/17377
+ *
+ * Langfuse already captures agent/tool traces. This module provides a tiny,
+ * opt-in helper that exports one real tool execution as a compact,
+ * provider-neutral JSON receipt containing:
+ *
+ * - the real tool call (`tool`, `args`)
+ * - the observed result (`observedResult`)
+ * - runtime/provider identity (`executor`)
+ * - provenance links (Langfuse trace/observation URL, capture timestamp)
+ * - SHA-256 hashes sufficient for independent recomputation
+ *
+ * No secrets, API keys, or proprietary trace exports are included. The caller
+ * owns redaction: only pass values that are safe to publish.
+ *
+ * The native receipt (`langfuse.execution-receipt.v1`) can be converted to a
+ * `sable.submission.v0.9` envelope for external verification without
+ * re-collecting evidence. A PASS only means the published evidence is
+ * internally consistent and independently recomputable; it does not imply the
+ * agent is generally reliable or production-safe.
+ */
+
+export const EXECUTION_RECEIPT_PROTOCOL_VERSION =
+  "langfuse.execution-receipt.v1" as const;
+export const SABLE_SUBMISSION_PROTOCOL_VERSION =
+  "sable.submission.v0.9" as const;
+export const EXECUTION_RECEIPT_HASH_ALGORITHM = "sha256" as const;
+export const EXECUTION_RECEIPT_CANONICALIZATION =
+  "json-sort-keys-utf8" as const;
+export const EXECUTION_RECEIPT_COLLECTOR =
+  "langfuse-execution-receipt/0.1" as const;
+
+const hex64 = z.string().regex(/^[0-9a-f]{64}$/);
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonValue);
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, nested]) => nested !== undefined)
+        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+        .map(([key, nested]) => [key, sortJsonValue(nested)]),
+    );
+  }
+  return value;
+}
+
+/**
+ * Canonical JSON: sorted keys, compact separators, UTF-8. Matches
+ * `json.dumps(..., sort_keys=True, separators=(",", ":"), ensure_ascii=False)`.
+ */
+export function canonicalJsonString(value: unknown): string {
+  return JSON.stringify(sortJsonValue(value)) ?? "null";
+}
+
+export function sha256HexOfCanonical(value: unknown): string {
+  return createHash("sha256")
+    .update(canonicalJsonString(value), "utf8")
+    .digest("hex");
+}
+
+export const executionReceiptToolCallSchema = z.object({
+  tool: z.string().min(1),
+  args: z.unknown(),
+  observedResult: z.unknown(),
+  observationId: z.string().min(1).optional(),
+  stateBeforeHash: hex64.optional(),
+  stateAfterHash: hex64.optional(),
+});
+
+export const executionReceiptExecutorSchema = z.object({
+  name: z.string().min(1),
+  version: z.string().min(1).optional(),
+  framework: z.string().min(1).optional(),
+  frameworkVersion: z.string().min(1).optional(),
+  provider: z.string().min(1).optional(),
+  model: z.string().min(1).optional(),
+  revision: z.string().min(1).optional(),
+});
+
+export const executionReceiptInputSchema = z.object({
+  executionId: z.string().min(1),
+  traceId: z.string().min(1),
+  projectId: z.string().min(1),
+  goal: z.string().min(1).optional(),
+  claimedStatus: z.enum(["success", "failure", "uncertain"]).default("success"),
+  finalReport: z.string().optional(),
+  environment: z.unknown().optional(),
+  executor: executionReceiptExecutorSchema,
+  toolCalls: z.array(executionReceiptToolCallSchema).min(1),
+  langfuseTraceUrl: z.string().url().optional(),
+  capturedAt: z.string().min(1).optional(),
+});
+
+export type ExecutionReceiptInput = z.infer<typeof executionReceiptInputSchema>;
+export type ExecutionReceiptToolCall = z.infer<
+  typeof executionReceiptToolCallSchema
+>;
+
+export const executionReceiptSchema = z.object({
+  protocolVersion: z.literal(EXECUTION_RECEIPT_PROTOCOL_VERSION),
+  executionId: z.string().min(1),
+  traceId: z.string().min(1),
+  projectId: z.string().min(1),
+  goal: z.string().optional(),
+  claimedStatus: z.enum(["success", "failure", "uncertain"]),
+  finalReport: z.string().optional(),
+  environment: z.unknown().optional(),
+  executor: executionReceiptExecutorSchema,
+  toolCalls: z
+    .array(
+      executionReceiptToolCallSchema.extend({
+        argsHash: hex64,
+        observedResultHash: hex64,
+      }),
+    )
+    .min(1),
+  provenance: z.object({
+    capturedAt: z.string().min(1),
+    collector: z.string().min(1),
+    langfuseTraceUrl: z.string().url().optional(),
+    redactionPolicy: z.string().min(1),
+  }),
+  commitmentId: z.string().min(1),
+  commitmentHash: hex64,
+  receiptHash: hex64,
+  contentAddress: z.string().min(1),
+  hashAlgorithm: z.literal(EXECUTION_RECEIPT_HASH_ALGORITHM),
+  canonicalization: z.literal(EXECUTION_RECEIPT_CANONICALIZATION),
+});
+
+export type ExecutionReceipt = z.infer<typeof executionReceiptSchema>;
+
+function toIsoTimestamp(value?: string): string {
+  if (value) {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+  }
+  return new Date().toISOString();
+}
+
+/**
+ * Build a verifiable execution receipt from one real Langfuse-traced tool
+ * execution. Pass only publishable values (no secrets or API keys).
+ */
+export function buildExecutionReceipt(
+  rawInput: ExecutionReceiptInput,
+): ExecutionReceipt {
+  const input = executionReceiptInputSchema.parse(rawInput);
+  const capturedAt = toIsoTimestamp(input.capturedAt);
+
+  const toolCalls = input.toolCalls.map((call) => ({
+    ...call,
+    argsHash: sha256HexOfCanonical(call.args ?? null),
+    observedResultHash: sha256HexOfCanonical(call.observedResult ?? null),
+  }));
+
+  const commitmentPayload = {
+    executionId: input.executionId,
+    traceId: input.traceId,
+    projectId: input.projectId,
+    executor: input.executor,
+    toolCalls: toolCalls.map((call) => ({
+      tool: call.tool,
+      argsHash: call.argsHash,
+      observedResultHash: call.observedResultHash,
+      stateBeforeHash: call.stateBeforeHash ?? null,
+      stateAfterHash: call.stateAfterHash ?? null,
+    })),
+  };
+  const commitmentHash = sha256HexOfCanonical(commitmentPayload);
+  const commitmentId = `commitment:${commitmentHash.slice(0, 16)}`;
+
+  const body = {
+    protocolVersion: EXECUTION_RECEIPT_PROTOCOL_VERSION,
+    executionId: input.executionId,
+    traceId: input.traceId,
+    projectId: input.projectId,
+    ...(input.goal !== undefined ? { goal: input.goal } : {}),
+    claimedStatus: input.claimedStatus,
+    ...(input.finalReport !== undefined
+      ? { finalReport: input.finalReport }
+      : {}),
+    ...(input.environment !== undefined
+      ? { environment: input.environment }
+      : {}),
+    executor: input.executor,
+    toolCalls,
+    provenance: {
+      capturedAt,
+      collector: EXECUTION_RECEIPT_COLLECTOR,
+      ...(input.langfuseTraceUrl !== undefined
+        ? { langfuseTraceUrl: input.langfuseTraceUrl }
+        : {}),
+      redactionPolicy: "caller-controlled; no secrets; public receipt only",
+    },
+    commitmentId,
+    commitmentHash,
+    hashAlgorithm: EXECUTION_RECEIPT_HASH_ALGORITHM,
+    canonicalization: EXECUTION_RECEIPT_CANONICALIZATION,
+  };
+
+  const receiptHash = sha256HexOfCanonical(body);
+
+  return executionReceiptSchema.parse({
+    ...body,
+    receiptHash,
+    contentAddress: `sha256:${receiptHash}`,
+  });
+}
+
+export type ReceiptVerification = {
+  ok: boolean;
+  reasons: string[];
+};
+
+/**
+ * Independently verify a receipt by recomputing every hash. Returns
+ * `{ ok: true }` only when the evidence is internally consistent.
+ */
+export function verifyExecutionReceipt(
+  receipt: ExecutionReceipt,
+): ReceiptVerification {
+  const reasons: string[] = [];
+  const parsed = executionReceiptSchema.safeParse(receipt);
+
+  if (!parsed.success) {
+    return { ok: false, reasons: ["schema_mismatch"] };
+  }
+
+  const value = parsed.data;
+
+  for (const call of value.toolCalls) {
+    if (sha256HexOfCanonical(call.args ?? null) !== call.argsHash) {
+      reasons.push(`args_hash_mismatch:${call.tool}`);
+    }
+    if (
+      sha256HexOfCanonical(call.observedResult ?? null) !==
+      call.observedResultHash
+    ) {
+      reasons.push(`observed_result_hash_mismatch:${call.tool}`);
+    }
+  }
+
+  const commitmentPayload = {
+    executionId: value.executionId,
+    traceId: value.traceId,
+    projectId: value.projectId,
+    executor: value.executor,
+    toolCalls: value.toolCalls.map((call) => ({
+      tool: call.tool,
+      argsHash: call.argsHash,
+      observedResultHash: call.observedResultHash,
+      stateBeforeHash: call.stateBeforeHash ?? null,
+      stateAfterHash: call.stateAfterHash ?? null,
+    })),
+  };
+
+  if (sha256HexOfCanonical(commitmentPayload) !== value.commitmentHash) {
+    reasons.push("commitment_hash_mismatch");
+  }
+
+  if (
+    value.commitmentId !== `commitment:${value.commitmentHash.slice(0, 16)}`
+  ) {
+    reasons.push("commitment_id_mismatch");
+  }
+
+  const { receiptHash, contentAddress, ...body } = value;
+  if (sha256HexOfCanonical(body) !== receiptHash) {
+    reasons.push("receipt_hash_mismatch");
+  }
+  if (contentAddress !== `sha256:${receiptHash}`) {
+    reasons.push("content_address_mismatch");
+  }
+
+  return { ok: reasons.length === 0, reasons };
+}
+
+export const sableSubmissionSchema = z.object({
+  protocol_version: z.literal(SABLE_SUBMISSION_PROTOCOL_VERSION),
+  submission_id: z.string().min(1),
+  source: z.object({
+    agent_name: z.string().min(1),
+    agent_version: z.string().min(1),
+    framework: z.string().min(1),
+    framework_version: z.string().min(1),
+    adapter: z.string().min(1),
+  }),
+  trace: z.object({
+    task_id: z.string(),
+    goal: z.string(),
+    agent: z.unknown(),
+    steps: z.array(
+      z.object({
+        tool: z.string(),
+        args: z.unknown(),
+        observed_result: z.unknown(),
+        before_state_hash: hex64,
+        after_state_hash: hex64,
+        state_after: z.unknown(),
+      }),
+    ),
+    claimed_status: z.enum(["success", "failure", "uncertain"]),
+    final_report: z.string(),
+    environment: z.unknown(),
+    integrity: z.object({
+      state_hash_algorithm: z.literal("sha256"),
+    }),
+  }),
+  provenance: z.object({
+    captured_at: z.string().min(1),
+    collector: z.string().min(1),
+    redaction_policy: z.string().min(1),
+  }),
+  integrity: z.object({
+    source_trace_hash: hex64,
+    hash_algorithm: z.literal("sha256"),
+    canonicalization: z.literal("json-sort-keys-utf8"),
+  }),
+});
+
+export type SableSubmission = z.infer<typeof sableSubmissionSchema>;
+
+/**
+ * Map a Langfuse execution receipt to a `sable.submission.v0.9` envelope so
+ * the same real execution can be checked by an external verifier without
+ * re-collecting evidence.
+ */
+export function toSableSubmission(receipt: ExecutionReceipt): SableSubmission {
+  const value = executionReceiptSchema.parse(receipt);
+
+  const trace = {
+    task_id: value.traceId,
+    goal: value.goal ?? value.executionId,
+    agent: {
+      name: value.executor.name,
+      version: value.executor.version ?? "unknown",
+    },
+    steps: value.toolCalls.map((call) => ({
+      tool: call.tool,
+      args: call.args,
+      observed_result: call.observedResult,
+      before_state_hash:
+        call.stateBeforeHash ??
+        sha256HexOfCanonical({ traceId: value.traceId, kind: "before" }),
+      after_state_hash:
+        call.stateAfterHash ??
+        sha256HexOfCanonical(call.observedResult ?? null),
+      state_after: call.observedResult,
+    })),
+    claimed_status: value.claimedStatus,
+    final_report: value.finalReport ?? "",
+    environment: value.environment ?? {},
+    integrity: { state_hash_algorithm: "sha256" as const },
+  };
+
+  return sableSubmissionSchema.parse({
+    protocol_version: SABLE_SUBMISSION_PROTOCOL_VERSION,
+    submission_id: value.executionId,
+    source: {
+      agent_name: value.executor.name,
+      agent_version: value.executor.version ?? "unknown",
+      framework: value.executor.framework ?? "langfuse",
+      framework_version: value.executor.frameworkVersion ?? "unknown",
+      adapter: EXECUTION_RECEIPT_COLLECTOR,
+    },
+    trace,
+    provenance: {
+      captured_at: value.provenance.capturedAt,
+      collector: value.provenance.collector,
+      redaction_policy: value.provenance.redactionPolicy,
+    },
+    integrity: {
+      source_trace_hash: sha256HexOfCanonical(trace),
+      hash_algorithm: "sha256" as const,
+      canonicalization: "json-sort-keys-utf8" as const,
+    },
+  });
+}
+
+/**
+ * Verify a SABLE envelope structurally by recomputing its trace hash.
+ * This checks internal consistency, not general agent reliability.
+ */
+export function verifySableSubmission(
+  submission: SableSubmission,
+): ReceiptVerification {
+  const parsed = sableSubmissionSchema.safeParse(submission);
+  if (!parsed.success) {
+    return { ok: false, reasons: ["schema_mismatch"] };
+  }
+
+  const value = parsed.data;
+  if (sha256HexOfCanonical(value.trace) !== value.integrity.source_trace_hash) {
+    return { ok: false, reasons: ["source_trace_hash_mismatch"] };
+  }
+
+  return { ok: true, reasons: [] };
+}


### PR DESCRIPTION
Closes #17377.

## What
Adds a tiny, opt-in server-side helper (`@langfuse/shared/src/server`) that exports one real Langfuse-traced tool execution as a compact, provider-neutral JSON receipt for independent verification:

- `buildExecutionReceipt(input)` — builds `langfuse.execution-receipt.v1` with the real tool call (`tool`/`args`), observed result, executor/runtime identity (+ revision), provenance (capture timestamp, Langfuse trace URL, caller-controlled redaction policy), and SHA-256 hashes (`argsHash`, `observedResultHash`, `commitmentId`/`commitmentHash`, `receiptHash`, `contentAddress`).
- `verifyExecutionReceipt(receipt)` — recomputes every hash; `ok: true` only when internally consistent.
- `toSableSubmission(receipt)` / `verifySableSubmission(envelope)` — maps the same execution to a `sable.submission.v0.9` envelope (canonical `json-sort-keys-utf8`, `sha256`) so it can be checked by an external verifier without re-collecting evidence.
- No secrets, API keys, or full trace exports are included. The caller owns redaction: only publishable values go in.

A PASS means the published evidence is internally consistent and independently recomputable — not that the agent is generally reliable (same scope as the SABLE intake).

## Verification
- New `executionReceipt.test.ts`: 7 tests pass (deterministic hashes, tamper detection for both receipt and SABLE envelope, key-order-stable canonicalization, rejects empty tool calls).
- `tsc --strict --noEmit` clean on the new module.
- Prettier clean (`--experimental-cli`) on new files.
- Canonical JSON / SHA-256 output cross-checked byte-for-byte against Python `json.dumps(sort_keys=True, separators=(',',':'), ensure_ascii=False)` + `hashlib.sha256`.
- Full monorepo `lint`/`typecheck`/`test` could not run here (requires `pnpm install` + dockerized DBs); CI will cover it.

## Example receipt (fixture-shaped, non-sensitive)
```json
{
  "protocolVersion": "langfuse.execution-receipt.v1",
  "executionId": "exec-2026-09-11-langfuse-001",
  "traceId": "trace-abc123",
  "projectId": "project-xyz",
  "executor": { "name": "langfuse-example-agent", "version": "0.1.0", "framework": "langfuse" },
  "toolCalls": [{ "tool": "get_order_status", "args": { "orderId": "42" }, "observedResult": { "orderId": "42", "status": "shipped" } }],
  "provenance": { "collector": "langfuse-execution-receipt/0.1", "redactionPolicy": "caller-controlled; no secrets; public receipt only" }
}
```
Hashes (`argsHash`, `observedResultHash`, `commitmentHash`, `receiptHash`, `contentAddress: sha256:<receiptHash>`) are computed at build time and recomputable by anyone from the published JSON.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63430103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 0/5</h2>

The PR is not safe to merge because several reachable inputs and transformations undermine the integrity and cross-runtime verification guarantees of the new receipt format.

<details open><summary><h3>Summary</h3></summary>

- Introduces canonical JSON hashing and receipt-level commitments.
- Adds native receipt and SABLE envelope verification.
- Exports the helper through the shared server entry point.
- Adds focused tests for deterministic hashing, basic tampering, and empty tool-call rejection.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  I[Execution input] --> C[Canonicalize values]
  C --> H[Compute tool and commitment hashes]
  H --> R[Execution receipt]
  R --> V[Verify native receipt]
  R --> S[Convert to SABLE envelope]
  S --> SH[Compute source trace hash]
  SH --> SV[Verify SABLE envelope]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat(shared): add opt-in verifiable exec..."](https://github.com/langfuse/langfuse/commit/0bec5623a4bbb1469b3dd0d8cf36c7e951741176)</sub>

<!-- /greptile_comment -->