### PR TITLE
fix(datasets): encode dataset item ID in UI navigation URL paths (#17259)

### DIFF
--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -144,7 +144,7 @@ function DatasetCompareRunsTableInternal(props: {
         return {
           type: "link",
           props: {
-            path: `/project/${props.projectId}/datasets/${props.datasetId}/items/${id}`,
+            path: `/project/${props.projectId}/datasets/${props.datasetId}/items/${encodeURIComponent(id)}`,
             value: id,
           },
         };

--- a/web/src/features/datasets/components/DatasetItemDetailPage.tsx
+++ b/web/src/features/datasets/components/DatasetItemDetailPage.tsx
@@ -226,7 +226,7 @@ export const DatasetItemDetailPage = ({
             <DetailPageNav
               currentId={itemId}
               path={(entry) =>
-                `/project/${projectId}/datasets/${datasetId}/items/${entry.id}`
+                `/project/${projectId}/datasets/${datasetId}/items/${encodeURIComponent(entry.id)}`
               }
               listKey="datasetItems"
             />

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -163,7 +163,7 @@ export function DatasetItemsTable({
         return {
           type: "link",
           props: {
-            path: `/project/${projectId}/datasets/${datasetId}/items/${id}${versionParam}`,
+            path: `/project/${projectId}/datasets/${datasetId}/items/${encodeURIComponent(id)}${versionParam}`,
             value: id,
           },
         };

--- a/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
@@ -115,7 +115,7 @@ export function DatasetRunItemsByRunTable(props: {
         return {
           type: "link",
           props: {
-            path: `/project/${projectId}/datasets/${datasetId}/items/${datasetItemId}${versionParam}`,
+            path: `/project/${projectId}/datasets/${datasetId}/items/${encodeURIComponent(datasetItemId)}${versionParam}`,
             value: datasetItemId,
           },
         };

--- a/web/src/features/navigation/utils/dataset-item-tabs.ts
+++ b/web/src/features/navigation/utils/dataset-item-tabs.ts
@@ -18,11 +18,11 @@ export const getDatasetItemTabs = ({
   {
     value: DATASET_ITEM_TABS.ITEM,
     label: "Item",
-    href: `/project/${projectId}/datasets/${datasetId}/items/${itemId}`,
+    href: `/project/${projectId}/datasets/${datasetId}/items/${encodeURIComponent(itemId)}`,
   },
   {
     value: DATASET_ITEM_TABS.RUNS,
     label: "Experiments",
-    href: `/project/${projectId}/datasets/${datasetId}/items/${itemId}/runs`,
+    href: `/project/${projectId}/datasets/${datasetId}/items/${encodeURIComponent(itemId)}/runs`,
   },
 ];


### PR DESCRIPTION
<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63442041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

This PR is not yet safe to merge because previous/next navigation double-encodes dataset item IDs containing reserved characters.

<details open><summary><h3>Summary</h3></summary>

- Correctly applies single-segment encoding to links produced from raw table and route data.
- The adjacent-item path callback encodes an ID that its shared navigation component has already encoded, breaking previous/next navigation for IDs containing reserved characters.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Raw adjacent item ID] --> B[DetailPageNav encodeURIComponent]
  B --> C[DatasetItemDetailPage encodeURIComponent again]
  C --> D[Double-encoded URL segment]
  D --> E[Decoded to the wrong dataset item ID]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(datasets): encode dataset item ID in..."](https://github.com/langfuse/langfuse/commit/7cf3d35b62f873debabb1d6e6d781da58fb62ff6)</sub>

<!-- /greptile_comment -->