### PR TITLE
fix(analytics): prevent dropping data points for multi-unit intervals

### DIFF
--- a/web/src/utils/fill-time-series-gaps.clienttest.ts
+++ b/web/src/utils/fill-time-series-gaps.clienttest.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import {
+  fillCategoricalTimeSeriesGaps,
+  fillTimeSeriesGaps,
+} from "@/src/utils/fill-time-series-gaps";
+
+describe("fillTimeSeriesGaps", () => {
+  it("does not drop data points for multi-unit intervals (Issue #17157 regression)", () => {
+    // 5 daily midnight-aligned points with counts 10, 20, 30, 40, 50
+    const data = [
+      { timestamp: new Date(2026, 0, 1), count: 10 },
+      { timestamp: new Date(2026, 0, 2), count: 20 },
+      { timestamp: new Date(2026, 0, 3), count: 30 },
+      { timestamp: new Date(2026, 0, 4), count: 40 },
+      { timestamp: new Date(2026, 0, 5), count: 50 },
+    ];
+
+    const fromDate = new Date(2026, 0, 1);
+    const toDate = new Date(2026, 0, 5, 14, 30);
+    const interval = { count: 2, unit: "day" as const };
+
+    const result = fillTimeSeriesGaps(data, fromDate, toDate, interval);
+
+    // Buckets tiling back from Jan 5 14:30:
+    // Bucket 0: Dec 30 14:30 - Jan 1 14:30 -> contains Jan 1 (10) -> avg 10
+    // Bucket 1: Jan 1 14:30 - Jan 3 14:30 -> contains Jan 2 (20), Jan 3 (30) -> avg 25
+    // Bucket 2: Jan 3 14:30 - Jan 5 14:30 -> contains Jan 4 (40), Jan 5 (50) -> avg 45
+    expect(result).toHaveLength(3);
+    expect(result.map((r) => r.count)).toEqual([10, 25, 45]);
+  });
+
+  it("assigns boundary points to the later bucket and includes toDate", () => {
+    // Points exactly at boundary timestamps
+    const fromDate = new Date(2026, 0, 1);
+    const toDate = new Date(2026, 0, 5);
+    const interval = { count: 2, unit: "day" as const };
+
+    // With toDate = Jan 05 00:00:
+    // Bucket 2: [Jan 03 00:00, Jan 05 00:00]
+    // Bucket 1: [Jan 01 00:00, Jan 03 00:00]
+    // Bucket 0: [Dec 30 00:00, Jan 01 00:00]
+    const data = [
+      { timestamp: new Date(2026, 0, 3), count: 100 },
+      { timestamp: new Date(2026, 0, 5), count: 200 },
+    ];
+
+    const result = fillTimeSeriesGaps(data, fromDate, toDate, interval);
+
+    // Jan 03 00:00 is on the boundary between Bucket 1 ([Jan 1, Jan 3]) and Bucket 2 ([Jan 3, Jan 5]).
+    // Checked newest-first: Bucket 2 receives Jan 03 00:00.
+    // Bucket 2 also receives Jan 05 00:00 (toDate).
+    // So Bucket 2 has both points: avg = (100 + 200) / 2 = 150.
+    // Bucket 1 has no points -> placeholder null count.
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    const lastBucket = result[result.length - 1];
+    expect(lastBucket?.count).toBe(150);
+  });
+
+  it("handles single-unit intervals correctly without alteration", () => {
+    const data = [
+      { timestamp: new Date(2026, 0, 1), count: 10 },
+      { timestamp: new Date(2026, 0, 3), count: 30 },
+    ];
+    const fromDate = new Date(2026, 0, 1);
+    const toDate = new Date(2026, 0, 3);
+    const interval = { count: 1, unit: "day" as const };
+
+    const result = fillTimeSeriesGaps(data, fromDate, toDate, interval);
+
+    expect(result).toHaveLength(3);
+    expect(result.map((r) => r.count)).toEqual([10, null, 30]);
+  });
+});
+
+describe("fillCategoricalTimeSeriesGaps", () => {
+  it("does not drop categorical data points for multi-unit intervals (Issue #17157 regression)", () => {
+    const data = [
+      {
+        timestamp: new Date(2026, 0, 1),
+        category: "ok",
+        count: 10,
+      },
+      {
+        timestamp: new Date(2026, 0, 2),
+        category: "ok",
+        count: 20,
+      },
+      {
+        timestamp: new Date(2026, 0, 3),
+        category: "ok",
+        count: 30,
+      },
+      {
+        timestamp: new Date(2026, 0, 4),
+        category: "ok",
+        count: 40,
+      },
+      {
+        timestamp: new Date(2026, 0, 5),
+        category: "ok",
+        count: 50,
+      },
+    ];
+
+    const fromDate = new Date(2026, 0, 1);
+    const toDate = new Date(2026, 0, 5, 14, 30);
+    const interval = { count: 2, unit: "day" as const };
+
+    const result = fillCategoricalTimeSeriesGaps(
+      data,
+      fromDate,
+      toDate,
+      interval,
+    );
+
+    // Categorical sums points in each bucket:
+    // Bucket 0: contains Jan 1 -> sum = 10
+    // Bucket 1: contains Jan 2, Jan 3 -> sum = 20 + 30 = 50
+    // Bucket 2: contains Jan 4, Jan 5 -> sum = 40 + 50 = 90
+    expect(result).toHaveLength(3);
+    expect(result.map((r) => r.count)).toEqual([10, 50, 90]);
+  });
+});

--- a/web/src/utils/fill-time-series-gaps.ts
+++ b/web/src/utils/fill-time-series-gaps.ts
@@ -228,7 +228,7 @@ function aggregateIntoMultiUnitBuckets<
     let bucketStart = bucketEnd;
 
     // Go back `count` units
-    for (let i = 0; i < count - 1; i++) {
+    for (let i = 0; i < count; i++) {
       bucketStart = subtractSingleUnit(bucketStart);
     }
 
@@ -247,12 +247,13 @@ function aggregateIntoMultiUnitBuckets<
     }
   }
 
-  // Assign data points to buckets
+  // Assign data points to buckets (newest-first so boundary points fall into later bucket)
   for (const dataPoint of data) {
     const ts = toStartOfSingleUnit(dataPoint.timestamp);
 
-    for (const bucket of buckets) {
-      if (ts >= bucket.start && ts <= bucket.end) {
+    for (let i = buckets.length - 1; i >= 0; i--) {
+      const bucket = buckets[i];
+      if (bucket && ts >= bucket.start && ts <= bucket.end) {
         bucket.dataPoints.push(dataPoint);
         break;
       }
@@ -536,7 +537,7 @@ function aggregateCategoricalIntoMultiUnitBuckets<
     let bucketStart = bucketEnd;
 
     // Go back `count` units
-    for (let i = 0; i < count - 1; i++) {
+    for (let i = 0; i < count; i++) {
       bucketStart = subtractSingleUnit(bucketStart);
     }
 
@@ -555,12 +556,13 @@ function aggregateCategoricalIntoMultiUnitBuckets<
     }
   }
 
-  // Assign data points to buckets
+  // Assign data points to buckets (newest-first so boundary points fall into later bucket)
   for (const dataPoint of data) {
     const ts = toStartOfSingleUnit(dataPoint.timestamp);
 
-    for (const bucket of buckets) {
-      if (ts >= bucket.start && ts <= bucket.end) {
+    for (let i = buckets.length - 1; i >= 0; i--) {
+      const bucket = buckets[i];
+      if (bucket && ts >= bucket.start && ts <= bucket.end) {
         bucket.dataPoints.push(dataPoint);
         break;
       }


### PR DESCRIPTION
## What does this PR do?

Resolves #17157: "Score analytics charts silently drop data points for multi-unit time intervals".

### Problem
When the selected time range in score analytics resolves to a multi-unit interval (e.g. `{ count: 2, unit: "day" }`), single-unit points from ClickHouse are aggregated into buckets in `fillTimeSeriesGaps` (and `fillCategoricalTimeSeriesGaps`).
Previously, `bucketStart` was computed by stepping back `count - 1` units from `bucketEnd`, but the subsequent bucket's end was stepped back by a full `count` units:
```ts
for (let i = 0; i < count - 1; i++) {
  bucketStart = subtractSingleUnit(bucketStart);
}
// ...
for (let i = 0; i < count; i++) {
  bucketEnd = subtractSingleUnit(bucketEnd);
}
```
This introduced a 1-unit gap between consecutive buckets. Any single-unit point falling within these gaps had no matching bucket and was silently dropped from charts.

### Solution
1. **Contiguous Buckets**: Stepped `bucketStart` back by `count` units in both `aggregateIntoMultiUnitBuckets` and `aggregateCategoricalIntoMultiUnitBuckets` so buckets tile seamlessly without gaps.
2. **Newest-First Point Assignment**: Assigned data points to buckets newest-first (`for (let i = buckets.length - 1; i >= 0; i--)`) so data points falling exactly on a shared bucket boundary are attributed to the later bucket while `toDate` remains captured by the rightmost bucket.
3. **Regression Tests**: Added `web/src/utils/fill-time-series-gaps.clienttest.ts` covering:
   - 5 daily points across 2-day intervals asserting all points are retained and aggregated to `[10, 25, 45]` (numeric).
   - Categorical multi-unit aggregation asserting all points are retained and summed to `[10, 50, 90]`.
   - Shared boundary assignment to later buckets.
   - Single-unit intervals verifying no regression for `count: 1`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63447111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with only a non-blocking gap in categorical boundary regression coverage.

<details open><summary><h3>Summary</h3></summary>

- Expands each bucket to the full configured interval so consecutive buckets are contiguous.
- Assigns shared-boundary points to the newer bucket while retaining the rightmost endpoint.
- Adds regression coverage for retained points, aggregation results, numeric boundary ownership, and single-unit behavior.
- One non-blocking categorical boundary-test gap remains.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Single-unit analytics points] --> B[Normalize timestamps]
  B --> C[Build contiguous multi-unit buckets backward from toDate]
  C --> D[Check buckets newest-first]
  D --> E[Assign shared-boundary point to newer bucket]
  E --> F[Average numeric values or sum categorical counts]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(analytics): prevent dropping data po..."](https://github.com/langfuse/langfuse/commit/9bb71f7f89a46bfb2047b4a7c4960eceebda85d0)</sub>

<!-- /greptile_comment -->